### PR TITLE
Replace mRemoteNG references

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Modern mRemoteNG Web Application</title>
+    <title>Modern sortOfRemoteNG Web Application</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ const AppContent: React.FC = () => {
     // Single window mode check
     const checkSingleWindow = () => {
       if (!settingsManager.checkSingleWindow()) {
-        alert('Another mRemoteNG window is already open. Only one instance is allowed.');
+        alert('Another sortOfRemoteNG window is already open. Only one instance is allowed.');
         window.close();
       }
     };
@@ -115,7 +115,7 @@ const AppContent: React.FC = () => {
       }
       
       setIsInitialized(true);
-      settingsManager.logAction('info', 'Application initialized', undefined, 'mRemoteNG started successfully');
+      settingsManager.logAction('info', 'Application initialized', undefined, 'sortOfRemoteNG started successfully');
     } catch (error) {
       console.error('Failed to initialize application:', error);
       settingsManager.logAction('error', 'Application initialization failed', undefined, error instanceof Error ? error.message : 'Unknown error');

--- a/src/components/ImportExport.tsx
+++ b/src/components/ImportExport.tsx
@@ -86,7 +86,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
 
   const exportToXML = (): string => {
     const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>\n';
-    const xmlRoot = '<mRemoteNG>\n';
+    const xmlRoot = '<sortOfRemoteNG>\n';
     const xmlConnections = state.connections.map(conn => {
       const attributes = [
         `Id="${conn.id}"`,
@@ -106,7 +106,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
       
       return `  <Connection ${attributes} />`;
     }).join('\n');
-    const xmlFooter = '\n</mRemoteNG>';
+    const xmlFooter = '\n</sortOfRemoteNG>';
     
     return xmlHeader + xmlRoot + xmlConnections + xmlFooter;
   };
@@ -429,7 +429,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
                 <div className="grid grid-cols-3 gap-3">
                   {[
                     { value: 'json', label: 'JSON', icon: FileText, desc: 'Structured data format' },
-                    { value: 'xml', label: 'XML', icon: Database, desc: 'mRemoteNG compatible' },
+                    { value: 'xml', label: 'XML', icon: Database, desc: 'sortOfRemoteNG compatible' },
                     { value: 'csv', label: 'CSV', icon: Settings, desc: 'Spreadsheet format' }
                   ].map(format => (
                     <button
@@ -475,7 +475,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
               <div>
                 <h3 className="text-lg font-medium text-white mb-4">Import Connections</h3>
                 <p className="text-gray-400 mb-4">
-                  Import connections from JSON, XML, or CSV files. Supported formats include mRemoteNG exports.
+                  Import connections from JSON, XML, or CSV files. Supported formats include sortOfRemoteNG exports.
                 </p>
               </div>
 

--- a/src/components/TOTPManager.tsx
+++ b/src/components/TOTPManager.tsx
@@ -16,7 +16,7 @@ export const TOTPManager: React.FC<TOTPManagerProps> = ({ isOpen, onClose, conne
   const [totpConfigs, setTotpConfigs] = useState<TOTPConfig[]>([]);
   const [showAddForm, setShowAddForm] = useState(false);
   const [newConfig, setNewConfig] = useState<Partial<TOTPConfig>>({
-    issuer: 'mRemoteNG',
+    issuer: 'sortOfRemoteNG',
     account: '',
     digits: 6,
     period: 30,
@@ -57,7 +57,7 @@ export const TOTPManager: React.FC<TOTPManagerProps> = ({ isOpen, onClose, conne
     const secret = totpService.generateSecret();
     const config: TOTPConfig = {
       secret,
-      issuer: newConfig.issuer || 'mRemoteNG',
+      issuer: newConfig.issuer || 'sortOfRemoteNG',
       account: newConfig.account,
       digits: newConfig.digits || 6,
       period: newConfig.period || 30,
@@ -76,7 +76,7 @@ export const TOTPManager: React.FC<TOTPManagerProps> = ({ isOpen, onClose, conne
     totpService.saveConfig(config);
     setTotpConfigs([...totpConfigs, config]);
     setNewConfig({
-      issuer: 'mRemoteNG',
+      issuer: 'sortOfRemoteNG',
       account: '',
       digits: 6,
       period: 30,
@@ -155,7 +155,7 @@ export const TOTPManager: React.FC<TOTPManagerProps> = ({ isOpen, onClose, conne
                     value={newConfig.issuer || ''}
                     onChange={(e) => setNewConfig({ ...newConfig, issuer: e.target.value })}
                     className="w-full px-3 py-2 bg-gray-600 border border-gray-500 rounded-md text-white"
-                    placeholder="mRemoteNG"
+                    placeholder="sortOfRemoteNG"
                   />
                 </div>
                 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "mRemoteNG",
+    "title": "sortOfRemoteNG",
     "subtitle": "Remote Connection Manager"
   },
   "connections": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "mRemoteNG",
+    "title": "sortOfRemoteNG",
     "subtitle": "Gestor de Conexiones Remotas"
   },
   "connections": {


### PR DESCRIPTION
## Summary
- rename `mRemoteNG` mentions to `sortOfRemoteNG` across UI and i18n files

## Testing
- `npm run lint` *(fails: 141 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686039c5a2648325b156931fb99f6877