### PR TITLE
Fix terminal cleanup and focus

### DIFF
--- a/src/components/WebTerminal.tsx
+++ b/src/components/WebTerminal.tsx
@@ -76,6 +76,7 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
     terminal.current.loadAddon(new WebLinksAddon());
 
     terminal.current.open(terminalRef.current);
+    terminal.current.focus();
     fitAddon.current.fit();
 
     // Initialize SSH connection for SSH protocol
@@ -122,8 +123,11 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
       if (terminal.current) {
         terminal.current.dispose();
       }
+      terminalRef.current!.innerHTML = '';
+      terminal.current = null;
+      fitAddon.current = null;
     };
-  }, [session]);
+  }, [session.id]);
 
   const handleNonSSHInput = (data: string) => {
     if (!terminal.current) return;


### PR DESCRIPTION
## Summary
- update terminal cleanup behavior
- change `useEffect` dependency in WebTerminal
- ensure terminal gets focus after mount

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861087721dc8325a449c975ccbe3fd7