### PR TITLE
Fix totp options usage with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "crypto-js": "^4.2.0",
@@ -76,6 +77,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/utils/totpService.ts
+++ b/src/utils/totpService.ts
@@ -11,21 +11,23 @@ export class TOTPService {
   generateToken(secret: string, config?: Partial<TOTPConfig>): string {
     const options = {
       digits: config?.digits || 6,
-      period: config?.period || 30,
-      algorithm: config?.algorithm || 'SHA1',
+      step: config?.period || 30,
+      algorithm: (config?.algorithm || 'SHA1').toLowerCase(),
     };
 
+    authenticator.options = options;
     return authenticator.generate(secret);
   }
 
   verifyToken(token: string, secret: string, config?: Partial<TOTPConfig>): boolean {
     const options = {
       digits: config?.digits || 6,
-      period: config?.period || 30,
-      algorithm: config?.algorithm || 'SHA1',
+      step: config?.period || 30,
+      algorithm: (config?.algorithm || 'SHA1').toLowerCase(),
       window: 1, // Allow 1 step tolerance
     };
 
+    authenticator.options = options;
     return authenticator.verify({ token, secret });
   }
 

--- a/tests/totpService.test.ts
+++ b/tests/totpService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { authenticator } from 'otplib';
+import { TOTPService } from '../src/utils/totpService';
+
+describe('TOTPService', () => {
+  let service: TOTPService;
+
+  beforeEach(() => {
+    service = new TOTPService();
+  });
+
+  it('generates and verifies tokens with default options', () => {
+    const secret = service.generateSecret();
+    const token = service.generateToken(secret);
+
+    // authenticator uses same default options after generateToken
+    const expected = authenticator.generate(secret);
+    expect(token).toBe(expected);
+    expect(service.verifyToken(token, secret)).toBe(true);
+  });
+
+  it('generates and verifies tokens with custom options', () => {
+    const secret = service.generateSecret();
+    const options = { digits: 8, period: 60, algorithm: 'SHA256' as const };
+
+    const token = service.generateToken(secret, options);
+
+    authenticator.options = {
+      digits: options.digits,
+      step: options.period,
+      algorithm: options.algorithm.toLowerCase(),
+      window: 1,
+    };
+    const expected = authenticator.generate(secret);
+    expect(token).toBe(expected);
+    expect(service.verifyToken(token, secret, options)).toBe(true);
+  });
+
+  it('verifies tokens from previous time step using window option', () => {
+    const secret = service.generateSecret();
+    const step = 30;
+
+    authenticator.options = { digits: 6, step, algorithm: 'sha1', epoch: Date.now() - step * 1000 };
+    const oldToken = authenticator.generate(secret);
+
+    expect(service.verifyToken(oldToken, secret)).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- set `authenticator.options` when generating or verifying tokens
- normalize algorithm casing
- add vitest and configuration
- test TOTPService with default and custom options

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68610904ddac8325a025aab3698eba0c