### PR TITLE
Add ConnectionTree tests

### DIFF
--- a/src/contexts/ConnectionContext.tsx
+++ b/src/contexts/ConnectionContext.tsx
@@ -86,7 +86,7 @@ const connectionReducer = (state: ConnectionState, action: ConnectionAction): Co
   }
 };
 
-const ConnectionContext = createContext<{
+export const ConnectionContext = createContext<{
   state: ConnectionState;
   dispatch: React.Dispatch<ConnectionAction>;
   saveData: (usePassword?: boolean) => Promise<void>;

--- a/tests/ConnectionTree.test.tsx
+++ b/tests/ConnectionTree.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import { ConnectionTree } from '../src/components/ConnectionTree';
+import { ConnectionProvider, useConnections } from '../src/contexts/ConnectionContext';
+import { Connection } from '../src/types/connection';
+
+const mockConnections: Connection[] = [
+  {
+    id: 'group1',
+    name: 'Group 1',
+    protocol: 'rdp',
+    hostname: '',
+    port: 0,
+    isGroup: true,
+    expanded: false,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    id: 'item1',
+    name: 'Item 1',
+    protocol: 'rdp',
+    hostname: 'host',
+    port: 3389,
+    parentId: 'group1',
+    isGroup: false,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+];
+
+function InitConnections({ connections }: { connections: Connection[] }) {
+  const { dispatch } = useConnections();
+  React.useEffect(() => {
+    dispatch({ type: 'SET_CONNECTIONS', payload: connections });
+  }, [connections, dispatch]);
+  return <ConnectionTree onConnect={() => {}} onEdit={() => {}} onDelete={() => {}} />;
+}
+
+describe('ConnectionTree', () => {
+  it('toggles group expansion when clicking the toggle button', async () => {
+    render(
+      <ConnectionProvider>
+        <InitConnections connections={mockConnections} />
+      </ConnectionProvider>
+    );
+
+    expect(screen.queryByText('Item 1')).toBeNull();
+
+    const groupRow = screen.getByText('Group 1').closest('.group') as HTMLElement;
+    const toggleButton = within(groupRow).getAllByRole('button')[0];
+
+    fireEvent.click(toggleButton);
+
+    expect(await screen.findByText('Item 1')).toBeInTheDocument();
+  });
+
+  it('selects an item when clicked', async () => {
+    let selectedId: string | null = null;
+    const Observer = () => {
+      const { state } = useConnections();
+      React.useEffect(() => {
+        selectedId = state.selectedConnection?.id ?? null;
+      }, [state.selectedConnection]);
+      return null;
+    };
+
+    render(
+      <ConnectionProvider>
+        <Observer />
+        <InitConnections connections={mockConnections} />
+      </ConnectionProvider>
+    );
+
+    const groupRow = screen.getByText('Group 1').closest('.group') as HTMLElement;
+    const toggleButton = within(groupRow).getAllByRole('button')[0];
+    fireEvent.click(toggleButton);
+
+    const itemRow = screen.getByText('Item 1');
+    fireEvent.click(itemRow);
+
+    expect(selectedId).toBe('item1');
+  });
+});


### PR DESCRIPTION
## Summary
- export `ConnectionContext` for tests
- add unit tests for `ConnectionTree` to verify expansion and selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686112db82848325bdd041505fa1a14e