### PR TITLE
Add unit tests for utilities

### DIFF
--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CollectionManager } from '../collectionManager';
+
+const sampleData = { connections: [], settings: {}, timestamp: 1 };
+
+describe('CollectionManager', () => {
+  let manager: CollectionManager;
+
+  beforeEach(() => {
+    localStorage.clear();
+    manager = new CollectionManager();
+  });
+
+  it('creates and persists a collection', async () => {
+    const col = await manager.createCollection('Test');
+    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(col.id);
+    expect(stored[0].name).toBe('Test');
+  });
+
+  it('loads collection data', async () => {
+    localStorage.setItem('mremote-collection-abc', JSON.stringify(sampleData));
+    const loaded = await manager.loadCollectionData('abc');
+    expect(loaded).toEqual(sampleData);
+  });
+
+  it('generates export filenames', () => {
+    const a = manager.generateExportFilename();
+    const b = manager.generateExportFilename();
+    expect(a).toMatch(/sortofremoteng-exports-.*\.json/);
+    expect(b).toMatch(/sortofremoteng-exports-.*\.json/);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/utils/__tests__/dragDropManager.test.ts
+++ b/src/utils/__tests__/dragDropManager.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DragDropManager, DragDropResult } from '../dragDropManager';
+import { Connection } from '../../types/connection';
+
+const baseDate = new Date();
+
+function makeConnection(partial: Partial<Connection>): Connection {
+  return {
+    id: 'id',
+    name: 'name',
+    protocol: 'ssh',
+    hostname: 'host',
+    port: 22,
+    isGroup: false,
+    createdAt: baseDate,
+    updatedAt: baseDate,
+    ...partial,
+  } as Connection;
+}
+
+describe('DragDropManager.processDropResult', () => {
+  let manager: DragDropManager;
+  let connections: Connection[];
+
+  beforeEach(() => {
+    manager = new DragDropManager();
+    connections = [
+      makeConnection({ id: 'group1', name: 'Group1', isGroup: true }),
+      makeConnection({ id: 'item1', name: 'Item1', parentId: 'group1' }),
+      makeConnection({ id: 'group2', name: 'Group2', isGroup: true }),
+    ];
+  });
+
+  it('moves connection inside a group', () => {
+    const result: DragDropResult = { draggedId: 'item1', targetId: 'group2', position: 'inside' };
+    const updated = manager.processDropResult(result, connections);
+    const item = updated.find(c => c.id === 'item1')!;
+    expect(item.parentId).toBe('group2');
+    expect(updated.map(c => c.id)).toEqual(['group1', 'group2', 'item1']);
+  });
+
+  it('moves connection before another', () => {
+    const result: DragDropResult = { draggedId: 'item1', targetId: 'group2', position: 'before' };
+    const updated = manager.processDropResult(result, connections);
+    const item = updated.find(c => c.id === 'item1')!;
+    expect(item.parentId).toBeUndefined();
+    expect(updated.map(c => c.id)).toEqual(['group1', 'item1', 'group2']);
+  });
+});

--- a/src/utils/__tests__/wakeOnLan.test.ts
+++ b/src/utils/__tests__/wakeOnLan.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { WakeOnLanService } from '../wakeOnLan';
+
+describe('WakeOnLanService', () => {
+  it('formats MAC addresses', () => {
+    expect(WakeOnLanService.formatMacAddress('AABBCCDDEEFF')).toBe('aa:bb:cc:dd:ee:ff');
+    expect(WakeOnLanService.formatMacAddress('aa-bb-cc-dd-ee-ff')).toBe('aa:bb:cc:dd:ee:ff');
+  });
+
+  it('validates MAC addresses', () => {
+    expect(WakeOnLanService.validateMacAddress('aa:bb:cc:dd:ee:ff')).toBe(true);
+    expect(WakeOnLanService.validateMacAddress('gg:hh:ii:jj:kk:ll')).toBe(false);
+  });
+
+  it('creates a proper magic packet', () => {
+    const service = new WakeOnLanService();
+    const packet = (service as any).createMagicPacket('aabbccddeeff');
+    expect(packet.length).toBe(102);
+    for (let i = 0; i < 6; i++) {
+      expect(packet[i]).toBe(0xff);
+    }
+    const mac = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    expect(packet.slice(6, 12)).toEqual(mac);
+    expect(packet.slice(packet.length - 6)).toEqual(mac);
+  });
+});


### PR DESCRIPTION
## Summary
- test MAC address helpers and magic packet creation
- cover collection manager logic
- verify drag drop manager handling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68611ada724883258e2b3a1f0006519a