### PR TITLE
Implement auto-save for settings

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,5 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { X, Save, RotateCcw, Globe, Shield, Zap, Monitor, Code, Wifi } from 'lucide-react';
+import {
+  X,
+  Save,
+  RotateCcw,
+  Globe,
+  Shield,
+  Zap,
+  Monitor,
+  Code,
+  Wifi,
+  CheckCircle,
+  AlertCircle,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { GlobalSettings, ProxyConfig } from '../types/settings';
 import { SettingsManager } from '../utils/settingsManager';
@@ -15,6 +27,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
   const [activeTab, setActiveTab] = useState('general');
   const [settings, setSettings] = useState<GlobalSettings | null>(null);
   const [isBenchmarking, setIsBenchmarking] = useState(false);
+  const [autoSaveStatus, setAutoSaveStatus] = useState<'success' | 'error' | null>(null);
   const settingsManager = SettingsManager.getInstance();
   const themeManager = ThemeManager.getInstance();
 
@@ -73,18 +86,50 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
     }
   };
 
-  const updateSettings = (updates: Partial<GlobalSettings>) => {
-    if (settings) {
-      setSettings({ ...settings, ...updates });
+  const showAutoSave = (status: 'success' | 'error') => {
+    setAutoSaveStatus(status);
+    setTimeout(() => setAutoSaveStatus(null), 2000);
+  };
+
+  const updateSettings = async (updates: Partial<GlobalSettings>) => {
+    if (!settings) return;
+
+    const newSettings = { ...settings, ...updates };
+    setSettings(newSettings);
+
+    try {
+      await settingsManager.saveSettings(newSettings);
+
+      if (updates.language && updates.language !== i18n.language) {
+        i18n.changeLanguage(updates.language);
+      }
+
+      if (updates.theme || updates.colorScheme) {
+        themeManager.applyTheme(newSettings.theme, newSettings.colorScheme);
+      }
+
+      showAutoSave('success');
+    } catch (error) {
+      console.error('Failed to auto save settings:', error);
+      showAutoSave('error');
     }
   };
 
-  const updateProxy = (updates: Partial<ProxyConfig>) => {
-    if (settings) {
-      setSettings({
-        ...settings,
-        globalProxy: { ...settings.globalProxy, ...updates } as ProxyConfig,
-      });
+  const updateProxy = async (updates: Partial<ProxyConfig>) => {
+    if (!settings) return;
+
+    const newSettings = {
+      ...settings,
+      globalProxy: { ...settings.globalProxy, ...updates } as ProxyConfig,
+    };
+    setSettings(newSettings);
+
+    try {
+      await settingsManager.saveSettings(newSettings);
+      showAutoSave('success');
+    } catch (error) {
+      console.error('Failed to auto save settings:', error);
+      showAutoSave('error');
     }
   };
 
@@ -100,7 +145,23 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[90vh] overflow-hidden">
+      <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[90vh] overflow-hidden relative">
+        {autoSaveStatus && (
+          <div className={`absolute top-2 right-2 flex items-center space-x-1 text-sm ${
+            autoSaveStatus === 'success' ? 'text-green-400' : 'text-red-400'
+          }`}>
+            {autoSaveStatus === 'success' ? (
+              <CheckCircle size={16} />
+            ) : (
+              <AlertCircle size={16} />
+            )}
+            <span>
+              {autoSaveStatus === 'success'
+                ? t('settings.autoSaveSuccess')
+                : t('settings.autoSaveError')}
+            </span>
+          </div>
+        )}
         <div className="flex items-center justify-between p-6 border-b border-gray-700">
           <h2 className="text-xl font-semibold text-white">{t('settings.title')}</h2>
           <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -103,7 +103,9 @@
     "advanced": "Advanced",
     "save": "Save",
     "cancel": "Cancel",
-    "reset": "Reset to Defaults"
+    "reset": "Reset to Defaults",
+    "autoSaveSuccess": "Options saved",
+    "autoSaveError": "Auto save failed"
   },
   "tabs": {
     "groupBy": "Group By",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -103,7 +103,9 @@
     "advanced": "Avanzado",
     "save": "Guardar",
     "cancel": "Cancelar",
-    "reset": "Restablecer Valores Predeterminados"
+    "reset": "Restablecer Valores Predeterminados",
+    "autoSaveSuccess": "Opciones guardadas",
+    "autoSaveError": "Error al guardar"
   },
   "tabs": {
     "groupBy": "Agrupar Por",


### PR DESCRIPTION
## Summary
- auto-save settings whenever form inputs change
- display a temporary success/failure indicator in Settings dialog
- add i18n strings for auto-save messages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68611b1a26e08325b362b6269c657aed