### PR TITLE
Fix WebTerminal cleanup and dependencies

### DIFF
--- a/src/components/WebTerminal.tsx
+++ b/src/components/WebTerminal.tsx
@@ -119,13 +119,19 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
       window.removeEventListener('resize', handleResize);
       if (sshClient.current) {
         sshClient.current.disconnect();
+        sshClient.current = null;
       }
       if (terminal.current) {
         terminal.current.dispose();
       }
-      terminalRef.current!.innerHTML = '';
+      if (terminalRef.current) {
+        terminalRef.current.innerHTML = '';
+      }
       terminal.current = null;
       fitAddon.current = null;
+      setIsConnected(false);
+      setConnectionError('');
+      setCurrentLine('');
     };
   }, [session.id]);
 


### PR DESCRIPTION
## Summary
- restrict WebTerminal's main effect to session id changes
- reset connection state when the component unmounts

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68611c047edc8325a39f0caa2fdd5931