### PR TITLE
Add networkScanner helper tests

### DIFF
--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { NetworkScanner } from '../networkScanner';
+
+// Access private methods via casting to any
+const scanner = new NetworkScanner() as any;
+
+describe('NetworkScanner helper methods', () => {
+  it('generateIPRange("192.168.0.0/30") returns two host IPs', () => {
+    const ips = scanner.generateIPRange('192.168.0.0/30');
+    expect(ips).toEqual(['192.168.0.1', '192.168.0.2']);
+  });
+
+  it('compareIPs sorts numerically', () => {
+    const result = scanner.compareIPs('192.168.0.2', '192.168.0.10');
+    expect(result).toBeLessThan(0);
+  });
+
+  it('extractVersion parses banners', () => {
+    const version = scanner.extractVersion('OpenSSH_8.6p1');
+    expect(version).toBe('8.6');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `generateIPRange`, `compareIPs` and `extractVersion`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68612038defc83258fac43b34c30a1a1