### PR TITLE
Implement theme variables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -21,3 +21,103 @@ body {
   background-color: var(--color-background);
   color: var(--color-text);
 }
+
+/* Map commonly used Tailwind utility classes to theme variables */
+.bg-gray-900,
+.bg-gray-800,
+.bg-gray-750,
+.bg-gray-700 {
+  background-color: var(--color-surface) !important;
+}
+
+.bg-gray-600,
+.bg-gray-500 {
+  background-color: var(--color-border) !important;
+}
+
+.bg-blue-400,
+.bg-blue-500,
+.bg-blue-600,
+.bg-blue-700,
+.bg-blue-900 {
+  background-color: var(--color-primary) !important;
+}
+
+.bg-green-400,
+.bg-green-500,
+.bg-green-600,
+.bg-green-700 {
+  background-color: var(--color-success) !important;
+}
+
+.bg-red-400,
+.bg-red-500,
+.bg-red-600,
+.bg-red-700,
+.bg-red-900 {
+  background-color: var(--color-error) !important;
+}
+
+.bg-yellow-400,
+.bg-yellow-500,
+.bg-orange-900 {
+  background-color: var(--color-warning) !important;
+}
+
+.text-gray-300,
+.text-gray-400,
+.text-gray-500 {
+  color: var(--color-textSecondary) !important;
+}
+
+.text-blue-200,
+.text-blue-300,
+.text-blue-400,
+.text-blue-600 {
+  color: var(--color-primary) !important;
+}
+
+.text-green-400 {
+  color: var(--color-success) !important;
+}
+
+.text-red-300,
+.text-red-400 {
+  color: var(--color-error) !important;
+}
+
+.text-purple-400 {
+  color: var(--color-accent) !important;
+}
+
+.text-orange-300,
+.text-orange-400,
+.text-yellow-400 {
+  color: var(--color-warning) !important;
+}
+
+.border-gray-500,
+.border-gray-600,
+.border-gray-700 {
+  border-color: var(--color-border) !important;
+}
+
+.border-blue-400,
+.border-blue-500,
+.border-blue-700 {
+  border-color: var(--color-primary) !important;
+}
+
+.border-green-500 {
+  border-color: var(--color-success) !important;
+}
+
+.border-red-500,
+.border-red-700 {
+  border-color: var(--color-error) !important;
+}
+
+.border-orange-400,
+.border-orange-700 {
+  border-color: var(--color-warning) !important;
+}


### PR DESCRIPTION
## Summary
- hook common Tailwind classes to CSS variables
- allow ThemeManager to affect background, text and border colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68613129ecdc83259f5f767cde6bfcce