### PR TITLE
Fix light theme text color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,10 @@ body {
   color: var(--color-textSecondary) !important;
 }
 
+.text-white {
+  color: var(--color-text) !important;
+}
+
 .text-blue-200,
 .text-blue-300,
 .text-blue-400,

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -38,7 +38,7 @@ export class ThemeManager {
         accent: '#10b981',
         background: '#ffffff',
         surface: '#f9fafb',
-        text: '#111827',
+        text: '#000000',
         textSecondary: '#6b7280',
         border: '#e5e7eb',
         success: '#10b981',


### PR DESCRIPTION
## Summary
- ensure `.text-white` uses theme variable
- update light theme text color to black

## Testing
- `npm test` *(fails: vitest runs in watch mode, but all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68613582bf748325b9318807e6fe959e