### PR TITLE
Wrap debug console statements

### DIFF
--- a/src/components/RDPClient.tsx
+++ b/src/components/RDPClient.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { debugLog } from '../utils/debugLogger';
 import { ConnectionSession } from '../types/connection';
 import { 
   Monitor, 
@@ -186,7 +187,7 @@ export const RDPClient: React.FC<RDPClientProps> = ({ session }) => {
     const canvasX = x * scaleX;
     const canvasY = y * scaleY;
     
-    console.log(`RDP Click at: ${canvasX}, ${canvasY}`);
+    debugLog(`RDP Click at: ${canvasX}, ${canvasY}`);
     
     // Simulate click response
     const ctx = canvas.getContext('2d');
@@ -206,11 +207,11 @@ export const RDPClient: React.FC<RDPClientProps> = ({ session }) => {
     if (!isConnected) return;
     
     event.preventDefault();
-    console.log(`RDP Key: ${event.key}`);
+    debugLog(`RDP Key: ${event.key}`);
     
     // Handle special key combinations
     if (event.ctrlKey && event.altKey && event.key === 'Delete') {
-      console.log('Ctrl+Alt+Del sent to remote session');
+      debugLog('Ctrl+Alt+Del sent to remote session');
     }
   };
 

--- a/src/components/VNCClient.tsx
+++ b/src/components/VNCClient.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { debugLog } from '../utils/debugLogger';
 import { ConnectionSession } from '../types/connection';
 import { 
   Monitor, 
@@ -262,7 +263,7 @@ export const VNCClient: React.FC<VNCClientProps> = ({ session }) => {
     const canvasX = x * scaleX;
     const canvasY = y * scaleY;
     
-    console.log(`VNC Click at: ${canvasX}, ${canvasY}`);
+    debugLog(`VNC Click at: ${canvasX}, ${canvasY}`);
     
     // Send mouse click to VNC server
     if (rfb) {
@@ -295,7 +296,7 @@ export const VNCClient: React.FC<VNCClientProps> = ({ session }) => {
       rfb.sendKey(event.keyCode, 'KeyDown');
     }
     
-    console.log(`VNC Key: ${event.key}`);
+    debugLog(`VNC Key: ${event.key}`);
   };
 
   const handleKeyUp = (event: React.KeyboardEvent) => {

--- a/src/components/WebBrowser.tsx
+++ b/src/components/WebBrowser.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { debugLog } from '../utils/debugLogger';
 import { 
   ArrowLeft, 
   ArrowRight, 
@@ -95,7 +96,7 @@ export const WebBrowser: React.FC<WebBrowserProps> = ({ session }) => {
         if (iframe && iframe.contentWindow) {
           // Note: Due to CORS restrictions, we can't directly inject auth headers
           // This would need to be handled by a proxy server or browser extension
-          console.log('Basic auth configured for:', connection.basicAuthUsername);
+          debugLog('Basic auth configured for:', connection.basicAuthUsername);
         }
       } catch (error) {
         console.warn('Cannot access iframe content due to CORS restrictions');

--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -1,0 +1,9 @@
+import { SettingsManager } from './settingsManager';
+
+export function debugLog(...args: unknown[]): void {
+  const settings = SettingsManager.getInstance().getSettings();
+  if (settings.logLevel === 'debug') {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+}

--- a/src/utils/fileTransferService.ts
+++ b/src/utils/fileTransferService.ts
@@ -1,4 +1,5 @@
 import { FileTransferSession } from '../types/connection';
+import { debugLog } from './debugLogger';
 
 interface FileItem {
   name: string;
@@ -181,7 +182,7 @@ export class FileTransferService {
   async deleteFile(connectionId: string, remotePath: string): Promise<void> {
     // Simulate file deletion
     await new Promise(resolve => setTimeout(resolve, 500));
-    console.log(`Deleted file: ${remotePath}`);
+    debugLog(`Deleted file: ${remotePath}`);
   }
 
   getActiveTransfers(connectionId: string): FileTransferSession[] {
@@ -204,17 +205,17 @@ export class FileTransferService {
   // SFTP specific methods
   async createDirectory(connectionId: string, path: string): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 300));
-    console.log(`Created directory: ${path}`);
+    debugLog(`Created directory: ${path}`);
   }
 
   async renameFile(connectionId: string, oldPath: string, newPath: string): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 300));
-    console.log(`Renamed ${oldPath} to ${newPath}`);
+    debugLog(`Renamed ${oldPath} to ${newPath}`);
   }
 
   async changePermissions(connectionId: string, path: string, permissions: string): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 300));
-    console.log(`Changed permissions of ${path} to ${permissions}`);
+    debugLog(`Changed permissions of ${path} to ${permissions}`);
   }
 
   // SCP specific methods

--- a/src/utils/restApiServer.ts
+++ b/src/utils/restApiServer.ts
@@ -5,6 +5,7 @@ import { RateLimiterMemory } from 'rate-limiter-flexible';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { Connection, ConnectionSession } from '../types/connection';
+import { debugLog } from './debugLogger';
 
 interface ApiConfig {
   port: number;
@@ -320,7 +321,7 @@ export class RestApiServer {
     return new Promise((resolve, reject) => {
       try {
         this.server = this.app.listen(this.config.port, () => {
-          console.log(`REST API server started on port ${this.config.port}`);
+          debugLog(`REST API server started on port ${this.config.port}`);
           resolve();
         });
       } catch (error) {
@@ -333,7 +334,7 @@ export class RestApiServer {
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {
-          console.log('REST API server stopped');
+          debugLog('REST API server stopped');
           resolve();
         });
       } else {

--- a/src/utils/sshLibraries.ts
+++ b/src/utils/sshLibraries.ts
@@ -1,3 +1,4 @@
+import { debugLog } from './debugLogger';
 // SSH Library Abstraction Layer
 export interface SSHLibraryConfig {
   host: string;
@@ -280,12 +281,12 @@ export class SimpleSSHClient extends BaseSSHClient {
     if (this.ssh && this.isConnected) {
       // Simple-SSH doesn't support interactive shell input in the same way
       // This is a limitation of the library
-      console.log('Simple-SSH: Sending data:', data);
+      debugLog('Simple-SSH: Sending data:', data);
     }
   }
 
   resize(cols: number, rows: number): void {
-    console.log(`Simple-SSH: Terminal resized to ${cols}x${rows}`);
+    debugLog(`Simple-SSH: Terminal resized to ${cols}x${rows}`);
   }
 
   disconnect(): void {

--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -1,3 +1,5 @@
+import { debugLog } from './debugLogger';
+
 export class WakeOnLanService {
   async sendWakePacket(macAddress: string, broadcastAddress: string = '255.255.255.255', port: number = 9): Promise<void> {
     try {
@@ -13,7 +15,7 @@ export class WakeOnLanService {
       // Send via WebSocket to a WOL service (would need backend implementation)
       await this.sendPacketViaWebSocket(magicPacket, broadcastAddress, port);
       
-      console.log(`Wake-on-LAN packet sent to ${macAddress} via ${broadcastAddress}:${port}`);
+      debugLog(`Wake-on-LAN packet sent to ${macAddress} via ${broadcastAddress}:${port}`);
     } catch (error) {
       console.error('Failed to send Wake-on-LAN packet:', error);
       throw error;
@@ -91,7 +93,7 @@ export class WakeOnLanService {
       this.sendWakePacket(macAddress, broadcastAddress);
     }, delay);
     
-    console.log(`Wake-on-LAN scheduled for ${wakeTime.toLocaleString()}`);
+    debugLog(`Wake-on-LAN scheduled for ${wakeTime.toLocaleString()}`);
   }
 
   // Test if device is awake


### PR DESCRIPTION
## Summary
- add `debugLog` helper that only logs when log level is `debug`
- wrap browser, RDP, and VNC component console statements
- wrap file transfer, wake-on-LAN, SSH, and REST API logs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68615131e0148325ae28aa06cc2e965d