### PR TITLE
Implement connection duplication

### DIFF
--- a/src/components/ConnectionTree.tsx
+++ b/src/components/ConnectionTree.tsx
@@ -167,7 +167,12 @@ const ConnectionTreeItem: React.FC<ConnectionTreeItemProps> = ({
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                // TODO: Implement duplicate functionality
+                const now = new Date();
+                const newConnection = structuredClone(connection);
+                newConnection.id = crypto.randomUUID();
+                newConnection.createdAt = now;
+                newConnection.updatedAt = now;
+                dispatch({ type: 'ADD_CONNECTION', payload: newConnection });
                 setShowMenu(false);
               }}
               className="flex items-center w-full px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 transition-colors"

--- a/tests/ConnectionTree.test.tsx
+++ b/tests/ConnectionTree.test.tsx
@@ -82,4 +82,25 @@ describe('ConnectionTree', () => {
 
     expect(selectedId).toBe('item1');
   });
+
+  it('duplicates a connection when Duplicate is clicked', async () => {
+    render(
+      <ConnectionProvider>
+        <InitConnections connections={mockConnections} />
+      </ConnectionProvider>
+    );
+
+    const groupRow = screen.getByText('Group 1').closest('.group') as HTMLElement;
+    const toggleButton = within(groupRow).getAllByRole('button')[0];
+    fireEvent.click(toggleButton);
+
+    const itemGroup = screen.getByText('Item 1').closest('.group') as HTMLElement;
+    const menuButton = within(itemGroup).getAllByRole('button')[1];
+    fireEvent.click(menuButton);
+
+    const duplicateButton = screen.getByText('Duplicate');
+    fireEvent.click(duplicateButton);
+
+    expect(await screen.findAllByText('Item 1')).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary
- enable duplicating a connection from ConnectionTree
- verify duplicate entry creation in ConnectionTree tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68614eda37e083259d49dbf74337a662