### PR TITLE
Refactor TOTPService token generation

### DIFF
--- a/src/utils/totpService.ts
+++ b/src/utils/totpService.ts
@@ -10,32 +10,23 @@ export class TOTPService {
 
   generateToken(secret: string, config?: Partial<TOTPConfig>): string {
     const options = {
-      digits: config?.digits || 6,
-      step: config?.period || 30,
-      algorithm: (config?.algorithm || 'SHA1').toLowerCase(),
-    };
-    authenticator.options = {
-      ...options,
-      algorithm: options.algorithm.toLowerCase(),
+      digits: config?.digits ?? 6,
+      step: config?.period ?? 30,
+      algorithm: (config?.algorithm ?? 'SHA1').toLowerCase(),
     };
 
-
-    return authenticator.generate(secret);
+    return authenticator.clone(options).generate(secret);
   }
 
   verifyToken(token: string, secret: string, config?: Partial<TOTPConfig>): boolean {
     const options = {
-      digits: config?.digits || 6,
-      step: config?.period || 30,
-      algorithm: (config?.algorithm || 'SHA1').toLowerCase(),
+      digits: config?.digits ?? 6,
+      step: config?.period ?? 30,
+      algorithm: (config?.algorithm ?? 'SHA1').toLowerCase(),
       window: 1, // Allow 1 step tolerance
     };
-    authenticator.options = {
-      ...options,
-      algorithm: options.algorithm.toLowerCase(),
-    };
 
-    return authenticator.verify({ token, secret });
+    return authenticator.clone(options).verify({ token, secret });
   }
 
   generateOTPAuthURL(config: TOTPConfig): string {

--- a/tests/totpService.test.ts
+++ b/tests/totpService.test.ts
@@ -13,7 +13,7 @@ describe('TOTPService', () => {
     const secret = service.generateSecret();
     const token = service.generateToken(secret);
 
-    // authenticator uses same default options after generateToken
+    // authenticator default options match service defaults
     const expected = authenticator.generate(secret);
     expect(token).toBe(expected);
     expect(service.verifyToken(token, secret)).toBe(true);
@@ -25,13 +25,13 @@ describe('TOTPService', () => {
 
     const token = service.generateToken(secret, options);
 
-    authenticator.options = {
-      digits: options.digits,
-      step: options.period,
-      algorithm: options.algorithm.toLowerCase(),
-      window: 1,
-    };
-    const expected = authenticator.generate(secret);
+    const expected = authenticator
+      .clone({
+        digits: options.digits,
+        step: options.period,
+        algorithm: options.algorithm.toLowerCase(),
+      })
+      .generate(secret);
     expect(token).toBe(expected);
     expect(service.verifyToken(token, secret, options)).toBe(true);
   });
@@ -40,8 +40,9 @@ describe('TOTPService', () => {
     const secret = service.generateSecret();
     const step = 30;
 
-    authenticator.options = { digits: 6, step, algorithm: 'sha1', epoch: Date.now() - step * 1000 };
-    const oldToken = authenticator.generate(secret);
+    const oldToken = authenticator
+      .clone({ digits: 6, step, algorithm: 'sha1', epoch: Date.now() - step * 1000 })
+      .generate(secret);
 
     expect(service.verifyToken(oldToken, secret)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- refactor generateToken/verifyToken to use authenticator.clone with options
- remove duplicate lowercasing of algorithm
- update vitest suite for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68614ee04c08832580af3a16744c2c98