### PR TITLE
Implement collection editing

### DIFF
--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -42,4 +42,12 @@ describe('CollectionManager', () => {
     expect(stored[0].name).toBe('Updated');
     expect(stored[0].description).toBe('changed');
   });
+
+  it('updates currentCollection when editing selected collection', async () => {
+    const col = await manager.createCollection('A');
+    await manager.selectCollection(col.id);
+    const updated = { ...col, name: 'B' };
+    manager.updateCollection(updated);
+    expect(manager.getCurrentCollection()?.name).toBe('B');
+  });
 });

--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -103,6 +103,9 @@ export class CollectionManager {
     if (index >= 0) {
       collections[index] = { ...collection, updatedAt: new Date() };
       this.saveCollections(collections);
+      if (this.currentCollection?.id === collection.id) {
+        this.currentCollection = { ...collections[index] };
+      }
     }
   }
 

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { CollectionSelector } from '../src/components/CollectionSelector';
+import { CollectionManager } from '../src/utils/collectionManager';
+
+// simple i18n mock for components using react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+describe('CollectionSelector editing', () => {
+  let manager: CollectionManager;
+  let collectionId: string;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    (CollectionManager as any).instance = undefined;
+    manager = CollectionManager.getInstance();
+    const col = await manager.createCollection('First', 'desc');
+    collectionId = col.id;
+  });
+
+  it('persists edited name and description', () => {
+    render(
+      <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
+    );
+
+    fireEvent.click(screen.getByTitle('Edit'));
+
+    const [nameInput, descInput] = screen.getAllByRole('textbox');
+    fireEvent.change(nameInput, { target: { value: 'Renamed' } });
+    fireEvent.change(descInput, { target: { value: 'updated' } });
+
+    fireEvent.click(screen.getByText('Update'));
+
+    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
+    expect(stored[0].name).toBe('Renamed');
+    expect(stored[0].description).toBe('updated');
+  });
+});


### PR DESCRIPTION
## Summary
- update `CollectionManager.updateCollection` to refresh `currentCollection`
- test collection editing persistence at manager level
- add UI test for editing collections through `CollectionSelector`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68615c0f58848325b61ff4b1e4bc4cd3