### PR TITLE
fix: share config interfaces

### DIFF
--- a/src/components/NetworkDiscovery.tsx
+++ b/src/components/NetworkDiscovery.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { X, Search, Wifi, Monitor, Database, HardDrive, Globe, Play, Plus, Settings, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { NetworkDiscoveryConfig, DiscoveredHost, DiscoveredService } from '../types/connection';
+import { DiscoveredHost, DiscoveredService } from '../types/connection';
+import { NetworkDiscoveryConfig } from '../types/settings';
 import { NetworkScanner } from '../utils/networkScanner';
 import { useConnections } from '../contexts/ConnectionContext';
 

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -152,13 +152,6 @@ export interface TabLayout {
   }[];
 }
 
-export interface AutoLockConfig {
-  enabled: boolean;
-  timeoutMinutes: number;
-  lockOnIdle: boolean;
-  lockOnSuspend: boolean;
-  requirePassword: boolean;
-}
 
 export interface ConnectionFilter {
   searchTerm: string;
@@ -184,15 +177,6 @@ export interface ConnectionStatus {
   error?: string;
 }
 
-export interface NetworkDiscoveryConfig {
-  enabled: boolean;
-  ipRange: string;
-  portRanges: string[];
-  protocols: string[];
-  timeout: number;
-  maxConcurrent: number;
-  customPorts: Record<string, number[]>;
-}
 
 export interface DiscoveredHost {
   ip: string;

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -1,4 +1,5 @@
-import { NetworkDiscoveryConfig, DiscoveredHost, DiscoveredService } from '../types/connection';
+import { DiscoveredHost, DiscoveredService } from '../types/connection';
+import { NetworkDiscoveryConfig } from '../types/settings';
 
 export class NetworkScanner {
   async scanNetwork(


### PR DESCRIPTION
## Summary
- remove duplicate `AutoLockConfig` and `NetworkDiscoveryConfig` from `connection.ts`
- import canonical types from `settings.ts`
- update network scanner and discovery components to use the shared interfaces

## Testing
- `npx tsc --noEmit`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6861839195f083259976ef7fe0935227