### PR TITLE
Avoid side effects when generating TOTP

### DIFF
--- a/src/utils/totpService.ts
+++ b/src/utils/totpService.ts
@@ -1,4 +1,5 @@
 import { authenticator } from 'otplib';
+import { Authenticator } from '@otplib/core';
 import { TOTPConfig } from '../types/settings';
 
 export class TOTPService {
@@ -17,36 +18,36 @@ export class TOTPService {
   }
 
   generateSecret(): string {
-    return authenticator.generateSecret();
+    const instance = new Authenticator(authenticator.options);
+    return instance.generateSecret();
   }
 
   generateToken(secret: string, config?: Partial<TOTPConfig>): string {
-    const options = {
+    const instance = new Authenticator(authenticator.options);
+    instance.options = {
+      ...instance.options,
       digits: config?.digits ?? 6,
       step: config?.period ?? 30,
       algorithm: (config?.algorithm ?? 'SHA1').toLowerCase(),
     };
-
-    return authenticator.clone(options).generate(secret);
+    return instance.generate(secret);
   }
 
   verifyToken(token: string, secret: string, config?: Partial<TOTPConfig>): boolean {
-    const options = {
+    const instance = new Authenticator(authenticator.options);
+    instance.options = {
+      ...instance.options,
       digits: config?.digits ?? 6,
       step: config?.period ?? 30,
       algorithm: (config?.algorithm ?? 'SHA1').toLowerCase(),
       window: 1, // Allow 1 step tolerance
     };
-
-    return authenticator.clone(options).verify({ token, secret });
+    return instance.verify({ token, secret });
   }
 
   generateOTPAuthURL(config: TOTPConfig): string {
-    return authenticator.keyuri(
-      config.account,
-      config.issuer,
-      config.secret
-    );
+    const instance = new Authenticator(authenticator.options);
+    return instance.keyuri(config.account, config.issuer, config.secret);
   }
 
   saveConfig(config: TOTPConfig): void {

--- a/tests/totpService.test.ts
+++ b/tests/totpService.test.ts
@@ -51,6 +51,13 @@ describe('TOTPService', () => {
     expect(service.verifyToken(oldToken, secret)).toBe(true);
   });
 
+  it('does not mutate global authenticator when using custom options', () => {
+    const original = { ...authenticator.options };
+    const secret = service.generateSecret();
+    service.generateToken(secret, { digits: 8 });
+    expect(authenticator.options).toEqual(original);
+  });
+
   it('loads qrcode module only once when generating multiple QR codes', async () => {
     const spy = vi.spyOn(service as any, 'importQRCode');
     const config = {


### PR DESCRIPTION
## Summary
- instantiate `Authenticator` inside `TOTPService` methods instead of using the shared export
- ensure global `authenticator` instance stays unchanged in tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686186d728c4832588e415c16ba0cc3d