### PR TITLE
Fix bundler error from ssh2 dependency

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,17 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    exclude: ['lucide-react'],
+    exclude: [
+      'lucide-react',
+      'ssh2',
+      'node-ssh',
+      'simple-ssh',
+      'cpu-features',
+    ],
+  },
+  build: {
+    rollupOptions: {
+      external: ['ssh2', 'node-ssh', 'simple-ssh', 'cpu-features'],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- exclude ssh-related libraries from dependency optimization
- mark these packages as external during Vite build

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686705e2a6ec832581a322132b434a61