### PR TITLE
Add grey color scheme

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -252,6 +252,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                         <option value="red">Red</option>
                         <option value="orange">Orange</option>
                         <option value="teal">Teal</option>
+                        <option value="grey">Grey</option>
                       </select>
                     </div>
 

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -24,6 +24,7 @@ export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
     { name: 'red', colors: ['#ef4444', '#dc2626', '#b91c1c'] },
     { name: 'orange', colors: ['#f97316', '#ea580c', '#c2410c'] },
     { name: 'teal', colors: ['#14b8a6', '#0d9488', '#0f766e'] },
+    { name: 'grey', colors: ['#9ca3af', '#6b7280', '#4b5563'] },
   ];
 
   return (

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -2,7 +2,7 @@ export interface GlobalSettings {
   // General Settings
   language: string;
   theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled';
-  colorScheme: 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'teal';
+  colorScheme: 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'teal' | 'grey';
   singleWindowMode: boolean;
   singleConnectionMode: boolean;
   reconnectOnReload: boolean;

--- a/src/utils/__tests__/settingsManager.test.ts
+++ b/src/utils/__tests__/settingsManager.test.ts
@@ -29,4 +29,15 @@ describe('SettingsManager colorScheme', () => {
     const loaded = await again.loadSettings();
     expect(loaded.colorScheme).toBe('green');
   });
+
+  it('accepts grey colorScheme', async () => {
+    const manager = SettingsManager.getInstance();
+    await manager.loadSettings();
+    await manager.saveSettings({ colorScheme: 'grey' });
+
+    (SettingsManager as any).instance = undefined;
+    const again = SettingsManager.getInstance();
+    const loaded = await again.loadSettings();
+    expect(loaded.colorScheme).toBe('grey');
+  });
 });

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -111,6 +111,11 @@ export class ThemeManager {
       secondary: '#0d9488',
       accent: '#0f766e',
     },
+    grey: {
+      primary: '#9ca3af',
+      secondary: '#6b7280',
+      accent: '#4b5563',
+    },
   };
 
   private applyResolvedTheme(themeName: string, colorScheme: string): void {


### PR DESCRIPTION
## Summary
- add new grey color scheme in ThemeManager
- expose grey option in ThemeSelector and SettingsDialog
- extend color scheme types
- test persistence of grey scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f866a1c08325b7982cc626f423e8