### PR TITLE
Add SSH private key option

### DIFF
--- a/src/components/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor.tsx
@@ -31,6 +31,8 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     parentId: undefined,
     sshLibrary: 'websocket',
     authType: 'password',
+    privateKey: '',
+    passphrase: '',
     basicAuthUsername: '',
     basicAuthPassword: '',
     basicAuthRealm: '',
@@ -73,6 +75,8 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
       setFormData({
         ...connection,
         sshLibrary,
+        privateKey: connection.privateKey || '',
+        passphrase: connection.passphrase || '',
         basicAuthUsername: connection.basicAuthUsername || '',
         basicAuthPassword: connection.basicAuthPassword || '',
         basicAuthRealm: connection.basicAuthRealm || '',
@@ -86,6 +90,8 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
         port: 3389,
         username: '',
         password: '',
+        privateKey: '',
+        passphrase: '',
         domain: '',
         description: '',
         isGroup: false,
@@ -125,6 +131,8 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
       port: formData.port || protocolPorts[formData.protocol as string] || 22,
       username: formData.username,
       password: formData.password,
+      privateKey: formData.privateKey,
+      passphrase: formData.passphrase,
       domain: formData.domain,
       description,
       isGroup: formData.isGroup || false,
@@ -402,18 +410,65 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
                       />
                     </div>
 
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Password
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.password || ''}
-                        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Password"
-                      />
-                    </div>
+                    {formData.protocol === 'ssh' && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-300 mb-2">
+                          Authentication Type
+                        </label>
+                        <select
+                          value={formData.authType}
+                          onChange={(e) => setFormData({ ...formData, authType: e.target.value as any })}
+                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        >
+                          <option value="password">Password</option>
+                          <option value="key">Private Key</option>
+                        </select>
+                      </div>
+                    )}
+
+                    {formData.authType === 'password' && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-300 mb-2">
+                          Password
+                        </label>
+                        <input
+                          type="password"
+                          value={formData.password || ''}
+                          onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          placeholder="Password"
+                        />
+                      </div>
+                    )}
+
+                    {formData.protocol === 'ssh' && formData.authType === 'key' && (
+                      <>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-300 mb-2">
+                            Private Key
+                          </label>
+                          <textarea
+                            value={formData.privateKey || ''}
+                            onChange={(e) => setFormData({ ...formData, privateKey: e.target.value })}
+                            rows={4}
+                            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                            placeholder="-----BEGIN PRIVATE KEY-----"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-300 mb-2">
+                            Passphrase (optional)
+                          </label>
+                          <input
+                            type="password"
+                            value={formData.passphrase || ''}
+                            onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
+                            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                            placeholder="Passphrase"
+                          />
+                        </div>
+                      </>
+                    )}
                   </>
                 )}
 

--- a/src/components/WebTerminal.tsx
+++ b/src/components/WebTerminal.tsx
@@ -247,6 +247,8 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
         port: connection?.port || 22,
         username: connection?.username || 'user',
         password: connection?.password || 'password',
+        privateKey: connection?.privateKey,
+        passphrase: connection?.passphrase,
         library: sshLibrary,
       });
 


### PR DESCRIPTION
## Summary
- allow specifying `privateKey` and `passphrase` in connection editor
- pass these fields to `SSHClient` when opening a terminal

## Testing
- `npm test` *(fails: needs vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_6867fae299908325a82759882e7168cb