### PR TITLE
Add rainbow and semi-light themes

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -233,6 +233,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                         <option value="light">Light</option>
                         <option value="darkest">Darkest</option>
                         <option value="oled">OLED Black</option>
+                        <option value="semilight">Semi Light</option>
+                        <option value="rainbow">Rainbow</option>
                         <option value="auto">Auto</option>
                       </select>
                     </div>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,7 +1,7 @@
 export interface GlobalSettings {
   // General Settings
   language: string;
-  theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled';
+  theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled' | 'semilight' | 'rainbow';
   colorScheme: 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'teal' | 'grey';
   singleWindowMode: boolean;
   singleConnectionMode: boolean;

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -78,6 +78,38 @@ export class ThemeManager {
         error: '#ef4444',
       },
     },
+    semilight: {
+      name: 'Semi Light',
+      colors: {
+        primary: '#3b82f6',
+        secondary: '#6b7280',
+        accent: '#10b981',
+        background: '#f3f4f6',
+        surface: '#e5e7eb',
+        text: '#000000',
+        textSecondary: '#374151',
+        border: '#d1d5db',
+        success: '#10b981',
+        warning: '#f59e0b',
+        error: '#ef4444',
+      },
+    },
+    rainbow: {
+      name: 'Rainbow',
+      colors: {
+        primary: '#ff0000',
+        secondary: '#ff7f00',
+        accent: '#ffff00',
+        background: '#ffffff',
+        surface: '#f9fafb',
+        text: '#000000',
+        textSecondary: '#555555',
+        border: '#cccccc',
+        success: '#00ff00',
+        warning: '#ff7f00',
+        error: '#ff0000',
+      },
+    },
   };
 
   private colorSchemes: Record<string, Record<string, string>> = {


### PR DESCRIPTION
## Summary
- add `semilight` and `rainbow` themes to ThemeManager
- expose new themes via settings type and dialog

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867fc3165d48325a084beeb56e34a19