### PR TITLE
Remove rainbow theme and improve SSH terminal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -451,6 +451,9 @@ const AppContent: React.FC = () => {
 
   return (
     <div className="h-screen bg-gray-900 text-white flex flex-col">
+      {!isInitialized && (
+        <div className="fixed inset-0 bg-black z-50" />
+      )}
       {/* Title Bar */}
       <div className="h-12 bg-gray-800 border-b border-gray-700 flex items-center justify-between px-4">
         <div className="flex items-center space-x-3">

--- a/src/components/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor.tsx
@@ -39,6 +39,14 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     httpHeaders: {},
   });
 
+  const handlePrivateKeyFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const text = await file.text();
+      setFormData(prev => ({ ...prev, privateKey: text }));
+    }
+  };
+
   const protocolPorts: Record<string, number> = {
     rdp: 3389,
     ssh: 22,
@@ -447,13 +455,19 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
                           <label className="block text-sm font-medium text-gray-300 mb-2">
                             Private Key
                           </label>
-                          <textarea
-                            value={formData.privateKey || ''}
-                            onChange={(e) => setFormData({ ...formData, privateKey: e.target.value })}
-                            rows={4}
-                            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-                            placeholder="-----BEGIN PRIVATE KEY-----"
-                          />
+                        <textarea
+                          value={formData.privateKey || ''}
+                          onChange={(e) => setFormData({ ...formData, privateKey: e.target.value })}
+                          rows={4}
+                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                          placeholder="-----BEGIN PRIVATE KEY-----"
+                        />
+                        <input
+                          type="file"
+                          accept=".key,.pem,.ppk"
+                          onChange={handlePrivateKeyFileChange}
+                          className="mt-2 text-sm text-gray-300"
+                        />
                         </div>
                         <div>
                           <label className="block text-sm font-medium text-gray-300 mb-2">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -234,7 +234,6 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                         <option value="darkest">Darkest</option>
                         <option value="oled">OLED Black</option>
                         <option value="semilight">Semi Light</option>
-                        <option value="rainbow">Rainbow</option>
                         <option value="auto">Auto</option>
                       </select>
                     </div>

--- a/src/components/WebTerminal.tsx
+++ b/src/components/WebTerminal.tsx
@@ -76,9 +76,13 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
     terminal.current.loadAddon(fitAddon.current);
     terminal.current.loadAddon(new WebLinksAddon());
 
-    terminal.current.open(terminalRef.current);
-    terminal.current.focus();
-    fitAddon.current.fit();
+    if (terminalRef.current?.parentElement) {
+      terminal.current.open(terminalRef.current);
+      terminal.current.focus();
+      fitAddon.current.fit();
+    } else {
+      console.error('Terminal requires parent element');
+    }
 
     // Initialize SSH connection for SSH protocol
     if (session.protocol === 'ssh') {
@@ -94,11 +98,12 @@ export const WebTerminal: React.FC<WebTerminalProps> = ({ session, onResize }) =
 
     // Handle terminal input
     const dataDisposable = terminal.current.onData((data) => {
-      if (sshClient.current && isConnectedRef.current) {
-        // Send data directly to SSH client
-        sshClient.current.sendData(data);
+      if (session.protocol === 'ssh') {
+        if (sshClient.current && isConnectedRef.current) {
+          sshClient.current.sendData(data);
+        }
+        // ignore input while connecting
       } else {
-        // Handle non-SSH protocols with proper line handling
         handleNonSSHInput(data);
       }
     });

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,7 +1,7 @@
 export interface GlobalSettings {
   // General Settings
   language: string;
-  theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled' | 'semilight' | 'rainbow';
+  theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled' | 'semilight';
   colorScheme: 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'teal' | 'grey';
   singleWindowMode: boolean;
   singleConnectionMode: boolean;

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -94,22 +94,6 @@ export class ThemeManager {
         error: '#ef4444',
       },
     },
-    rainbow: {
-      name: 'Rainbow',
-      colors: {
-        primary: '#ff0000',
-        secondary: '#ff7f00',
-        accent: '#ffff00',
-        background: '#ffffff',
-        surface: '#f9fafb',
-        text: '#000000',
-        textSecondary: '#555555',
-        border: '#cccccc',
-        success: '#00ff00',
-        warning: '#ff7f00',
-        error: '#ff0000',
-      },
-    },
   };
 
   private colorSchemes: Record<string, Record<string, string>> = {


### PR DESCRIPTION
## Summary
- drop `rainbow` theme from settings
- show black screen until settings load
- ignore keystrokes until SSH connects
- check terminal parent before opening
- allow SSH private key uploads

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 181 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6868199162dc8325a1203b79d4f73a57