### PR TITLE
Improve CIDR validation in network scanner

### DIFF
--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -19,4 +19,14 @@ describe('NetworkScanner helper methods', () => {
     const version = scanner.extractVersion('OpenSSH_8.6p1');
     expect(version).toBe('8.6');
   });
+
+  it('throws on malformed CIDR strings', () => {
+    expect(() => scanner.generateIPRange('192.168.0.0')).toThrow();
+    expect(() => scanner.generateIPRange('192.168.0.0/abc')).toThrow();
+  });
+
+  it('throws when prefix is outside supported range', () => {
+    expect(() => scanner.generateIPRange('192.168.0.0/23')).toThrow();
+    expect(() => scanner.generateIPRange('192.168.0.0/31')).toThrow();
+  });
 });

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -35,9 +35,19 @@ export class NetworkScanner {
   }
 
   private generateIPRange(cidr: string): string[] {
-    const [network, prefixLength] = cidr.split('/');
-    const prefix = parseInt(prefixLength);
-    
+    const parts = cidr.split('/');
+    if (parts.length !== 2) {
+      throw new Error(`Malformed CIDR string: ${cidr}`);
+    }
+
+    const [network, prefixLength] = parts;
+
+    if (!prefixLength || isNaN(Number(prefixLength))) {
+      throw new Error(`Invalid prefix length in CIDR: ${cidr}`);
+    }
+
+    const prefix = parseInt(prefixLength, 10);
+
     if (prefix < 24 || prefix > 30) {
       throw new Error('Only /24 to /30 networks are supported');
     }


### PR DESCRIPTION
## Summary
- validate prefix when generating IP ranges
- throw errors for malformed CIDR strings
- test invalid CIDR inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6cfb79d48325b574b0d95b05b0d0