### PR TITLE
Ensure scriptEngine persists settings

### DIFF
--- a/src/utils/__tests__/scriptEngine.test.ts
+++ b/src/utils/__tests__/scriptEngine.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { ScriptEngine } from '../scriptEngine';
+import { SettingsManager } from '../settingsManager';
+import { CustomScript } from '../../types/settings';
+
+let dom: JSDOM;
+
+beforeEach(() => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>');
+  (global as any).window = dom.window;
+  (global as any).document = dom.window.document;
+  localStorage.clear();
+  (SettingsManager as any).instance = undefined;
+  (ScriptEngine as any).instance = undefined;
+});
+
+describe('ScriptEngine.setSetting', () => {
+  it('persists setting changes via scripts', async () => {
+    const settingsManager = SettingsManager.getInstance();
+    await settingsManager.loadSettings();
+    const engine = ScriptEngine.getInstance();
+
+    const script: CustomScript = {
+      id: 's1',
+      name: 'update setting',
+      type: 'javascript',
+      content: "await setSetting('colorScheme', 'purple');",
+      trigger: 'manual',
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    await engine.executeScript(script, { trigger: 'manual' });
+
+    (SettingsManager as any).instance = undefined;
+    const again = SettingsManager.getInstance();
+    const loaded = await again.loadSettings();
+    expect(loaded.colorScheme).toBe('purple');
+  });
+});

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -96,7 +96,7 @@ export class ScriptEngine {
       
       // Settings access
       getSetting: (key: string) => this.getSetting(key),
-      setSetting: (key: string, value: any) => this.setSetting(key, value),
+      setSetting: async (key: string, value: any) => this.setSetting(key, value),
     };
 
     // Execute the script
@@ -180,8 +180,8 @@ export class ScriptEngine {
     return (settings as any)[key];
   }
 
-  private setSetting(key: string, value: any): void {
-    this.settingsManager.saveSettings({ [key]: value });
+  private async setSetting(key: string, value: any): Promise<void> {
+    await this.settingsManager.saveSettings({ [key]: value });
   }
 
   // Get scripts for a specific trigger and protocol


### PR DESCRIPTION
## Summary
- update `ScriptEngine.setSetting` to be async and await saving
- expose async `setSetting` in script context
- add unit test that verifies settings persist when modified from a script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a6f14b2fc8325bb829446118d3e36