### PR TITLE
Refactor app lifecycle and session management into hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import { Monitor, Zap, Menu, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionProvider, useConnections } from './contexts/ConnectionContext';
@@ -9,13 +9,13 @@ import { SessionViewer } from './components/SessionViewer';
 import { QuickConnect } from './components/QuickConnect';
 import { PasswordDialog } from './components/PasswordDialog';
 import { CollectionSelector } from './components/CollectionSelector';
-import { Connection, ConnectionSession } from './types/connection';
+import { Connection } from './types/connection';
 import { SecureStorage } from './utils/storage';
 import { SettingsManager } from './utils/settingsManager';
 import { StatusChecker } from './utils/statusChecker';
-import { ScriptEngine } from './utils/scriptEngine';
 import { CollectionManager } from './utils/collectionManager';
-import { ThemeManager } from './utils/themeManager';
+import { useSessionManager } from './hooks/useSessionManager';
+import { useAppLifecycle } from './hooks/useAppLifecycle';
 
 const AppContent: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -27,138 +27,38 @@ const AppContent: React.FC = () => {
   const [showCollectionSelector, setShowCollectionSelector] = useState(false);
   const [passwordDialogMode, setPasswordDialogMode] = useState<'setup' | 'unlock'>('setup');
   const [passwordError, setPasswordError] = useState<string>('');
-  const [activeSessionId, setActiveSessionId] = useState<string | undefined>();
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [reconnectingSessions, setReconnectingSessions] = useState<Set<string>>(new Set());
-  const hasReconnected = useRef<boolean>(false);
 
   const settingsManager = SettingsManager.getInstance();
   const statusChecker = StatusChecker.getInstance();
-  const scriptEngine = ScriptEngine.getInstance();
   const collectionManager = CollectionManager.getInstance();
-  const themeManager = ThemeManager.getInstance();
 
-  // Initialize application
-  useEffect(() => {
-    initializeApp();
-    
-    // Handle page unload
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      const settings = settingsManager.getSettings();
-      if (settings.warnOnExit && state.sessions.length > 0) {
-        e.preventDefault();
-        e.returnValue = t('dialogs.confirmExit');
-        return t('dialogs.confirmExit');
-      }
-    };
+  const {
+    activeSessionId,
+    setActiveSessionId,
+    activeSession,
+    handleConnect,
+    handleQuickConnect,
+    handleSessionClose,
+  } = useSessionManager();
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    
-    // Single window mode check
-    const checkSingleWindow = () => {
-      if (!settingsManager.checkSingleWindow()) {
-        alert('Another sortOfRemoteNG window is already open. Only one instance is allowed.');
-        window.close();
-      }
-    };
-
-    const singleWindowInterval = setInterval(checkSingleWindow, 5000);
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      clearInterval(singleWindowInterval);
-      statusChecker.cleanup();
-    };
-  }, []);
-
-  // Check if we need to show collection selector or password dialog on startup
-  useEffect(() => {
-    if (isInitialized) {
-      const currentCollection = collectionManager.getCurrentCollection();
-      if (!currentCollection) {
-        setShowCollectionSelector(true);
-      } else if (currentCollection.isEncrypted && !SecureStorage.isStorageUnlocked()) {
-        setPasswordDialogMode('unlock');
-        setShowPasswordDialog(true);
-      }
-    }
-  }, [isInitialized]);
-
-  // Reconnect sessions on reload if enabled (fixed to prevent loop)
-  useEffect(() => {
-    const settings = settingsManager.getSettings();
-    if (settings.reconnectOnReload && isInitialized && state.connections.length > 0) {
-      const savedSessions = sessionStorage.getItem('mremote-active-sessions');
-      if (savedSessions && !hasReconnected.current) {
-        try {
-          const sessions = JSON.parse(savedSessions);
-          // Clear the saved sessions to prevent reconnection loop
-          sessionStorage.removeItem('mremote-active-sessions');
-
-          sessions.forEach((sessionData: any) => {
-            const connection = state.connections.find(c => c.id === sessionData.connectionId);
-            if (connection && !reconnectingSessions.has(connection.id)) {
-              setReconnectingSessions(prev => new Set(prev).add(connection.id));
-              setTimeout(() => {
-                handleConnect(connection);
-                setReconnectingSessions(prev => {
-                  const newSet = new Set(prev);
-                  newSet.delete(connection.id);
-                  return newSet;
-                });
-              }, 1000);
-            }
-          });
-        } catch (error) {
-          console.error('Failed to restore sessions:', error);
-        }
-        hasReconnected.current = true;
-      }
-    }
-  }, [isInitialized, state.connections]);
-
-  // Save active sessions for reconnection (only save when sessions change, not on reload)
-  useEffect(() => {
-    const settings = settingsManager.getSettings();
-    if (settings.reconnectOnReload && state.sessions.length > 0) {
-      const sessionData = state.sessions.map(session => ({
-        connectionId: session.connectionId,
-        name: session.name,
-      }));
-      sessionStorage.setItem('mremote-active-sessions', JSON.stringify(sessionData));
-    } else if (state.sessions.length === 0) {
-      sessionStorage.removeItem('mremote-active-sessions');
-    }
-  }, [state.sessions]);
-
-  const initializeApp = async () => {
-    try {
-      await settingsManager.initialize();
-      
-      // Apply theme
-      themeManager.loadSavedTheme();
-      themeManager.injectThemeCSS();
-      
-      // Apply language setting
-      const settings = settingsManager.getSettings();
-      if (settings.language !== i18n.language) {
-        i18n.changeLanguage(settings.language);
-      }
-      
-      setIsInitialized(true);
-      settingsManager.logAction('info', 'Application initialized', undefined, 'sortOfRemoteNG started successfully');
-    } catch (error) {
-      console.error('Failed to initialize application:', error);
-      settingsManager.logAction('error', 'Application initialization failed', undefined, error instanceof Error ? error.message : 'Unknown error');
-    }
-  };
+  const { isInitialized } = useAppLifecycle({
+    handleConnect,
+    setShowCollectionSelector,
+    setShowPasswordDialog,
+    setPasswordDialogMode,
+  });
 
   const handleCollectionSelect = async (collectionId: string, password?: string) => {
     try {
       await collectionManager.selectCollection(collectionId, password);
       await loadData();
       setShowCollectionSelector(false);
-      settingsManager.logAction('info', 'Collection selected', undefined, `Collection: ${collectionManager.getCurrentCollection()?.name}`);
+      settingsManager.logAction(
+        'info',
+        'Collection selected',
+        undefined,
+        `Collection: ${collectionManager.getCurrentCollection()?.name}`,
+      );
     } catch (error) {
       console.error('Failed to select collection:', error);
       alert('Failed to access collection. Please check your password.');
@@ -177,193 +77,20 @@ const AppContent: React.FC = () => {
 
   const handleDeleteConnection = (connection: Connection) => {
     const settings = settingsManager.getSettings();
-    const confirmMessage = connection.warnOnClose || settings.warnOnClose 
-      ? t('dialogs.confirmDelete') 
+    const confirmMessage = connection.warnOnClose || settings.warnOnClose
+      ? t('dialogs.confirmDelete')
       : null;
-    
+
     if (!confirmMessage || confirm(confirmMessage)) {
       dispatch({ type: 'DELETE_CONNECTION', payload: connection.id });
       statusChecker.stopChecking(connection.id);
-      settingsManager.logAction('info', 'Connection deleted', connection.id, `Connection "${connection.name}" deleted`);
+      settingsManager.logAction(
+        'info',
+        'Connection deleted',
+        connection.id,
+        `Connection "${connection.name}" deleted`,
+      );
     }
-  };
-
-  const connectSession = async (session: ConnectionSession, connection: Connection) => {
-    const settings = settingsManager.getSettings();
-    const startTime = Date.now();
-
-    settingsManager.logAction('info', 'Connection initiated', connection.id, `Connecting to ${connection.hostname}:${connection.port}`);
-
-    try {
-      await scriptEngine.executeScriptsForTrigger('onConnect', { connection, session });
-    } catch (error) {
-      console.error('Script execution failed:', error);
-    }
-
-    if (connection.statusCheck?.enabled) {
-      statusChecker.startChecking(connection);
-    }
-
-    const timeout = (connection.timeout || settings.connectionTimeout) * 1000;
-    const connectionPromise = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        const connectionTime = Date.now() - startTime;
-
-        settingsManager.recordPerformanceMetric({
-          connectionTime,
-          dataTransferred: 0,
-          latency: Math.random() * 50 + 10,
-          throughput: Math.random() * 1000 + 500,
-          cpuUsage: Math.random() * 30 + 10,
-          memoryUsage: Math.random() * 50 + 20,
-          timestamp: Date.now(),
-        });
-
-        dispatch({
-          type: 'UPDATE_SESSION',
-          payload: {
-            ...session,
-            status: 'connected',
-            metrics: {
-              connectionTime,
-              dataTransferred: 0,
-              latency: Math.random() * 50 + 10,
-              throughput: Math.random() * 1000 + 500,
-            },
-          },
-        });
-
-        dispatch({
-          type: 'UPDATE_CONNECTION',
-          payload: {
-            ...connection,
-            lastConnected: new Date(),
-            connectionCount: (connection.connectionCount || 0) + 1,
-          },
-        });
-
-        settingsManager.logAction('info', 'Connection established', connection.id, `Connected successfully in ${connectionTime}ms`, connectionTime);
-        resolve();
-      }, 2000);
-    });
-
-    const timeoutPromise = new Promise<void>((_, reject) => {
-      setTimeout(() => {
-        reject(new Error('Connection timeout'));
-      }, timeout);
-    });
-
-    try {
-      await Promise.race([connectionPromise, timeoutPromise]);
-    } catch (error) {
-      dispatch({
-        type: 'UPDATE_SESSION',
-        payload: { ...session, status: 'error' },
-      });
-
-      settingsManager.logAction('error', 'Connection failed', connection.id, error instanceof Error ? error.message : 'Unknown error');
-
-      if ((session.reconnectAttempts || 0) < (session.maxReconnectAttempts || 0)) {
-        setTimeout(() => {
-          handleReconnect(session);
-        }, connection.retryDelay || settings.retryDelay);
-      }
-    }
-  };
-
-  const handleConnect = async (connection: Connection) => {
-    const settings = settingsManager.getSettings();
-    
-    // Check single connection mode
-    if (settings.singleConnectionMode && state.sessions.length > 0) {
-      if (!confirm('Close existing connection and open new one?')) {
-        return;
-      }
-      // Close all existing sessions
-      state.sessions.forEach(session => {
-        dispatch({ type: 'REMOVE_SESSION', payload: session.id });
-      });
-    }
-
-    // Check max concurrent connections
-    if (state.sessions.length >= settings.maxConcurrentConnections) {
-      alert(`Maximum concurrent connections (${settings.maxConcurrentConnections}) reached.`);
-      return;
-    }
-
-    // Create a new session
-    const session: ConnectionSession = {
-      id: crypto.randomUUID(),
-      connectionId: connection.id,
-      name: settings.hostnameOverride && connection.hostname ? connection.hostname : connection.name,
-      status: 'connecting',
-      startTime: new Date(),
-      protocol: connection.protocol,
-      hostname: connection.hostname,
-      reconnectAttempts: 0,
-      maxReconnectAttempts: connection.retryAttempts || settings.retryAttempts,
-    };
-
-    dispatch({ type: 'ADD_SESSION', payload: session });
-    setActiveSessionId(session.id);
-
-    await connectSession(session, connection);
-  };
-
-  const reconnectSession = async (session: ConnectionSession, connection: Connection) => {
-    const updatedSession: ConnectionSession = {
-      ...session,
-      status: 'reconnecting',
-      reconnectAttempts: (session.reconnectAttempts || 0) + 1,
-      startTime: new Date(),
-    };
-
-    dispatch({ type: 'UPDATE_SESSION', payload: updatedSession });
-    settingsManager.logAction(
-      'info',
-      'Reconnection attempt',
-      connection.id,
-      `Attempt ${updatedSession.reconnectAttempts}/${updatedSession.maxReconnectAttempts}`
-    );
-
-    await connectSession(updatedSession, connection);
-  };
-
-  const handleReconnect = async (session: ConnectionSession) => {
-    const connection = state.connections.find(c => c.id === session.connectionId);
-    if (!connection) return;
-
-    setTimeout(() => {
-      reconnectSession(session, connection);
-    }, 2000);
-  };
-
-  const handleQuickConnect = (hostname: string, protocol: string) => {
-    const tempConnection: Connection = {
-      id: crypto.randomUUID(),
-      name: `${t('connections.quickConnect')} - ${hostname}`,
-      protocol: protocol as Connection['protocol'],
-      hostname,
-      port: getDefaultPort(protocol),
-      isGroup: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    handleConnect(tempConnection);
-  };
-
-  const getDefaultPort = (protocol: string): number => {
-    const ports: Record<string, number> = {
-      rdp: 3389,
-      ssh: 22,
-      vnc: 5900,
-      http: 80,
-      https: 443,
-      telnet: 23,
-      rlogin: 513,
-    };
-    return ports[protocol] || 22;
   };
 
   const handlePasswordSubmit = async (password: string) => {
@@ -374,7 +101,6 @@ const AppContent: React.FC = () => {
       if (passwordDialogMode === 'unlock') {
         await loadData();
       } else {
-        // Setup mode - save current data with password
         await saveData();
       }
 
@@ -389,7 +115,6 @@ const AppContent: React.FC = () => {
 
   const handlePasswordCancel = () => {
     if (passwordDialogMode === 'setup') {
-      // Save without password
       saveData().catch(console.error);
     }
     setShowPasswordDialog(false);
@@ -399,62 +124,19 @@ const AppContent: React.FC = () => {
   const handleShowPasswordDialog = () => {
     if (SecureStorage.isStorageEncrypted()) {
       if (SecureStorage.isStorageUnlocked()) {
-        // Already unlocked, show setup to change password
         setPasswordDialogMode('setup');
       } else {
-        // Locked, show unlock
         setPasswordDialogMode('unlock');
       }
     } else {
-      // Not encrypted, show setup
       setPasswordDialogMode('setup');
     }
     setShowPasswordDialog(true);
   };
 
-  const handleSessionClose = async (sessionId: string) => {
-    const session = state.sessions.find(s => s.id === sessionId);
-    if (!session) return;
-
-    const connection = state.connections.find(c => c.id === session.connectionId);
-    const settings = settingsManager.getSettings();
-    
-    const shouldWarn = connection?.warnOnClose || settings.warnOnClose;
-    if (shouldWarn && !confirm(t('dialogs.confirmClose'))) {
-      return;
-    }
-
-    // Execute onDisconnect scripts
-    if (connection) {
-      try {
-        await scriptEngine.executeScriptsForTrigger('onDisconnect', { connection, session });
-      } catch (error) {
-        console.error('Script execution failed:', error);
-      }
-    }
-
-    dispatch({ type: 'REMOVE_SESSION', payload: sessionId });
-    
-    if (connection) {
-      statusChecker.stopChecking(connection.id);
-      settingsManager.logAction('info', 'Session closed', connection.id, `Session "${session.name}" closed`);
-    }
-
-    // If this was the active session, switch to another or clear
-    if (activeSessionId === sessionId) {
-      const remainingSessions = state.sessions.filter(s => s.id !== sessionId);
-      setActiveSessionId(remainingSessions.length > 0 ? remainingSessions[0].id : undefined);
-    }
-  };
-
-  const activeSession = state.sessions.find(s => s.id === activeSessionId);
-
   return (
     <div className="h-screen bg-gray-900 text-white flex flex-col">
-      {!isInitialized && (
-        <div className="fixed inset-0 bg-black z-50" />
-      )}
-      {/* Title Bar */}
+      {!isInitialized && <div className="fixed inset-0 bg-black z-50" />}
       <div className="h-12 bg-gray-800 border-b border-gray-700 flex items-center justify-between px-4">
         <div className="flex items-center space-x-3">
           <Monitor size={20} className="text-blue-400" />
@@ -466,7 +148,7 @@ const AppContent: React.FC = () => {
             </span>
           )}
         </div>
-        
+
         <div className="flex items-center space-x-2">
           <button
             onClick={() => setShowQuickConnect(true)}
@@ -475,7 +157,7 @@ const AppContent: React.FC = () => {
             <Zap size={14} />
             <span>{t('connections.quickConnect')}</span>
           </button>
-          
+
           <div className="flex items-center space-x-1 text-xs text-gray-400">
             <Globe size={12} />
             <select
@@ -487,8 +169,8 @@ const AppContent: React.FC = () => {
               <option value="es">ES</option>
             </select>
           </div>
-          
-          <button 
+
+          <button
             onClick={() => setShowCollectionSelector(true)}
             className="p-2 hover:bg-gray-700 rounded transition-colors"
             title="Switch Collection"
@@ -499,7 +181,6 @@ const AppContent: React.FC = () => {
       </div>
 
       <div className="flex flex-1 overflow-hidden">
-        {/* Sidebar */}
         <Sidebar
           onNewConnection={handleNewConnection}
           onEditConnection={handleEditConnection}
@@ -508,16 +189,13 @@ const AppContent: React.FC = () => {
           onShowPasswordDialog={handleShowPasswordDialog}
         />
 
-        {/* Main Content */}
         <div className="flex-1 flex flex-col">
-          {/* Session Tabs */}
           <SessionTabs
             activeSessionId={activeSessionId}
             onSessionSelect={setActiveSessionId}
             onSessionClose={handleSessionClose}
           />
 
-          {/* Content Area */}
           <div className="flex-1 overflow-hidden">
             {activeSession ? (
               <SessionViewer session={activeSession} />
@@ -526,7 +204,7 @@ const AppContent: React.FC = () => {
                 <Monitor size={64} className="mb-4" />
                 <h2 className="text-xl font-medium mb-2">Welcome to {t('app.title')}</h2>
                 <p className="text-center max-w-md mb-6">
-                  Manage your remote connections efficiently. Create new connections or select 
+                  Manage your remote connections efficiently. Create new connections or select
                   an existing one from the sidebar to get started.
                 </p>
                 <div className="flex space-x-4">
@@ -549,7 +227,6 @@ const AppContent: React.FC = () => {
         </div>
       </div>
 
-      {/* Modals */}
       <CollectionSelector
         isOpen={showCollectionSelector}
         onCollectionSelect={handleCollectionSelect}
@@ -579,12 +256,10 @@ const AppContent: React.FC = () => {
   );
 };
 
-const App: React.FC = () => {
-  return (
-    <ConnectionProvider>
-      <AppContent />
-    </ConnectionProvider>
-  );
-};
+const App: React.FC = () => (
+  <ConnectionProvider>
+    <AppContent />
+  </ConnectionProvider>
+);
 
 export default App;

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -1,0 +1,151 @@
+import { useEffect, useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useConnections } from '../contexts/ConnectionContext';
+import { SettingsManager } from '../utils/settingsManager';
+import { StatusChecker } from '../utils/statusChecker';
+import { CollectionManager } from '../utils/collectionManager';
+import { ThemeManager } from '../utils/themeManager';
+import { SecureStorage } from '../utils/storage';
+import { Connection, ConnectionSession } from '../types/connection';
+
+interface Options {
+  handleConnect: (connection: Connection) => void;
+  setShowCollectionSelector: (value: boolean) => void;
+  setShowPasswordDialog: (value: boolean) => void;
+  setPasswordDialogMode: (mode: 'setup' | 'unlock') => void;
+}
+
+export const useAppLifecycle = ({
+  handleConnect,
+  setShowCollectionSelector,
+  setShowPasswordDialog,
+  setPasswordDialogMode,
+}: Options) => {
+  const { t, i18n } = useTranslation();
+  const { state } = useConnections();
+
+  const settingsManager = SettingsManager.getInstance();
+  const statusChecker = StatusChecker.getInstance();
+  const collectionManager = CollectionManager.getInstance();
+  const themeManager = ThemeManager.getInstance();
+
+  const [isInitialized, setIsInitialized] = useState(false);
+  const hasReconnected = useRef(false);
+  const reconnectingSessions = useRef<Set<string>>(new Set());
+
+  const initializeApp = async () => {
+    try {
+      await settingsManager.initialize();
+
+      themeManager.loadSavedTheme();
+      themeManager.injectThemeCSS();
+
+      const settings = settingsManager.getSettings();
+      if (settings.language !== i18n.language) {
+        i18n.changeLanguage(settings.language);
+      }
+
+      setIsInitialized(true);
+      settingsManager.logAction(
+        'info',
+        'Application initialized',
+        undefined,
+        'sortOfRemoteNG started successfully',
+      );
+    } catch (error) {
+      console.error('Failed to initialize application:', error);
+      settingsManager.logAction(
+        'error',
+        'Application initialization failed',
+        undefined,
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  };
+
+  useEffect(() => {
+    initializeApp();
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      const settings = settingsManager.getSettings();
+      if (settings.warnOnExit && state.sessions.length > 0) {
+        e.preventDefault();
+        e.returnValue = t('dialogs.confirmExit');
+        return t('dialogs.confirmExit');
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    const checkSingleWindow = () => {
+      if (!settingsManager.checkSingleWindow()) {
+        alert('Another sortOfRemoteNG window is already open. Only one instance is allowed.');
+        window.close();
+      }
+    };
+
+    const singleWindowInterval = setInterval(checkSingleWindow, 5000);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      clearInterval(singleWindowInterval);
+      statusChecker.cleanup();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (isInitialized) {
+      const currentCollection = collectionManager.getCurrentCollection();
+      if (!currentCollection) {
+        setShowCollectionSelector(true);
+      } else if (currentCollection.isEncrypted && !SecureStorage.isStorageUnlocked()) {
+        setPasswordDialogMode('unlock');
+        setShowPasswordDialog(true);
+      }
+    }
+  }, [isInitialized]);
+
+  useEffect(() => {
+    const settings = settingsManager.getSettings();
+    if (settings.reconnectOnReload && isInitialized && state.connections.length > 0) {
+      const savedSessions = sessionStorage.getItem('mremote-active-sessions');
+      if (savedSessions && !hasReconnected.current) {
+        try {
+          const sessions: ConnectionSession[] = JSON.parse(savedSessions);
+          sessionStorage.removeItem('mremote-active-sessions');
+
+          sessions.forEach(sessionData => {
+            const connection = state.connections.find(c => c.id === sessionData.connectionId);
+            if (connection && !reconnectingSessions.current.has(connection.id)) {
+              reconnectingSessions.current.add(connection.id);
+              setTimeout(() => {
+                handleConnect(connection);
+                reconnectingSessions.current.delete(connection.id);
+              }, 1000);
+            }
+          });
+        } catch (error) {
+          console.error('Failed to restore sessions:', error);
+        }
+        hasReconnected.current = true;
+      }
+    }
+  }, [isInitialized, state.connections, handleConnect]);
+
+  useEffect(() => {
+    const settings = settingsManager.getSettings();
+    if (settings.reconnectOnReload && state.sessions.length > 0) {
+      const sessionData = state.sessions.map(session => ({
+        connectionId: session.connectionId,
+        name: session.name,
+      }));
+      sessionStorage.setItem('mremote-active-sessions', JSON.stringify(sessionData));
+    } else if (state.sessions.length === 0) {
+      sessionStorage.removeItem('mremote-active-sessions');
+    }
+  }, [state.sessions]);
+
+  return { isInitialized };
+};
+


### PR DESCRIPTION
## Summary
- add `useAppLifecycle` hook to manage initialization and reconnection
- add `useSessionManager` hook to encapsulate session handling
- simplify `App.tsx` by consuming the new hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ade70c67883258ed72829d6c1070e