### PR TITLE
Add default port utility

### DIFF
--- a/src/components/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor.tsx
@@ -4,6 +4,7 @@ import { Connection } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 import { TagManager } from './TagManager';
 import { SSHLibraryType } from '../utils/sshLibraries';
+import { getDefaultPort } from '../utils/defaultPorts';
 
 interface ConnectionEditorProps {
   connection?: Connection;
@@ -47,15 +48,6 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     }
   };
 
-  const protocolPorts: Record<string, number> = {
-    rdp: 3389,
-    ssh: 22,
-    vnc: 5900,
-    http: 80,
-    https: 443,
-    telnet: 23,
-    rlogin: 513,
-  };
 
   // Get all available tags from existing connections
   const allTags = Array.from(
@@ -136,7 +128,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
       name: formData.name || 'New Connection',
       protocol: formData.protocol as Connection['protocol'],
       hostname: formData.hostname || '',
-      port: formData.port || protocolPorts[formData.protocol as string] || 22,
+      port: formData.port || getDefaultPort(formData.protocol as string),
       username: formData.username,
       password: formData.password,
       privateKey: formData.privateKey,
@@ -168,7 +160,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     setFormData({
       ...formData,
       protocol: protocol as Connection['protocol'],
-      port: protocolPorts[protocol] || 22,
+      port: getDefaultPort(protocol),
       authType: ['http', 'https'].includes(protocol) ? 'basic' : 'password',
     });
   };

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -5,6 +5,7 @@ import { Connection, ConnectionSession } from '../types/connection';
 import { SettingsManager } from '../utils/settingsManager';
 import { StatusChecker } from '../utils/statusChecker';
 import { ScriptEngine } from '../utils/scriptEngine';
+import { getDefaultPort } from '../utils/defaultPorts';
 
 export const useSessionManager = () => {
   const { t } = useTranslation();
@@ -175,19 +176,6 @@ export const useSessionManager = () => {
     };
 
     handleConnect(tempConnection);
-  };
-
-  const getDefaultPort = (protocol: string): number => {
-    const ports: Record<string, number> = {
-      rdp: 3389,
-      ssh: 22,
-      vnc: 5900,
-      http: 80,
-      https: 443,
-      telnet: 23,
-      rlogin: 513,
-    };
-    return ports[protocol] || 22;
   };
 
   const handleSessionClose = async (sessionId: string) => {

--- a/src/utils/defaultPorts.ts
+++ b/src/utils/defaultPorts.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_PORTS: Record<string, number> = {
+  rdp: 3389,
+  ssh: 22,
+  vnc: 5900,
+  http: 80,
+  https: 443,
+  telnet: 23,
+  rlogin: 513,
+};
+
+export const getDefaultPort = (protocol: string): number => {
+  return DEFAULT_PORTS[protocol] ?? 22;
+};
+
+export default getDefaultPort;


### PR DESCRIPTION
## Summary
- centralize mapping of default ports
- use the new `getDefaultPort` helper in connection editor and session manager

## Testing
- `npx -y vitest --run` *(fails: Cannot find package 'vitest')*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686ae17a53948325a89d5fab5daa36ac