### PR TITLE
Add enums for settings selections

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,7 +13,13 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings, ProxyConfig } from '../types/settings';
+import {
+  GlobalSettings,
+  ProxyConfig,
+  Theme,
+  ColorScheme,
+  StatusCheckMethod,
+} from '../types/settings';
 import { SettingsManager } from '../utils/settingsManager';
 import { ThemeManager } from '../utils/themeManager';
 
@@ -226,7 +232,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                       </label>
                       <select
                         value={settings.theme}
-                        onChange={(e) => updateSettings({ theme: e.target.value as any })}
+                        onChange={(e) => updateSettings({ theme: e.target.value as Theme })}
                         className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
                       >
                         <option value="dark">Dark</option>
@@ -244,7 +250,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                       </label>
                       <select
                         value={settings.colorScheme}
-                        onChange={(e) => updateSettings({ colorScheme: e.target.value as any })}
+                        onChange={(e) => updateSettings({ colorScheme: e.target.value as ColorScheme })}
                         className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
                       >
                         <option value="blue">Blue</option>
@@ -482,7 +488,9 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                       </label>
                       <select
                         value={settings.statusCheckMethod}
-                        onChange={(e) => updateSettings({ statusCheckMethod: e.target.value as any })}
+                        onChange={(e) =>
+                          updateSettings({ statusCheckMethod: e.target.value as StatusCheckMethod })
+                        }
                         className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
                       >
                         <option value="socket">Socket</option>

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Palette, Sun, Moon, Monitor } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Theme, ColorScheme } from '../types/settings';
 
 interface ThemeSelectorProps {
-  theme: 'dark' | 'light' | 'auto';
-  colorScheme: string;
-  onThemeChange: (theme: 'dark' | 'light' | 'auto') => void;
-  onColorSchemeChange: (scheme: string) => void;
+  theme: Theme;
+  colorScheme: ColorScheme;
+  onThemeChange: (theme: Theme) => void;
+  onColorSchemeChange: (scheme: ColorScheme) => void;
 }
 
 export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
@@ -42,7 +43,7 @@ export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
           ].map(({ value, label, icon: Icon }) => (
             <button
               key={value}
-              onClick={() => onThemeChange(value as any)}
+              onClick={() => onThemeChange(value as Theme)}
               className={`p-4 rounded-lg border-2 transition-colors flex flex-col items-center space-y-2 ${
                 theme === value
                   ? 'border-blue-500 bg-blue-500/20'
@@ -65,7 +66,7 @@ export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
           {colorSchemes.map(scheme => (
             <button
               key={scheme.name}
-              onClick={() => onColorSchemeChange(scheme.name)}
+              onClick={() => onColorSchemeChange(scheme.name as ColorScheme)}
               className={`p-4 rounded-lg border-2 transition-colors ${
                 colorScheme === scheme.name
                   ? 'border-blue-500 bg-blue-500/20'

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,8 +1,32 @@
+export const Themes = [
+  'dark',
+  'light',
+  'auto',
+  'darkest',
+  'oled',
+  'semilight',
+] as const;
+export type Theme = typeof Themes[number];
+
+export const ColorSchemes = [
+  'blue',
+  'green',
+  'purple',
+  'red',
+  'orange',
+  'teal',
+  'grey',
+] as const;
+export type ColorScheme = typeof ColorSchemes[number];
+
+export const StatusCheckMethods = ['ping', 'socket', 'http'] as const;
+export type StatusCheckMethod = typeof StatusCheckMethods[number];
+
 export interface GlobalSettings {
   // General Settings
   language: string;
-  theme: 'dark' | 'light' | 'auto' | 'darkest' | 'oled' | 'semilight';
-  colorScheme: 'blue' | 'green' | 'purple' | 'red' | 'orange' | 'teal' | 'grey';
+  theme: Theme;
+  colorScheme: ColorScheme;
   singleWindowMode: boolean;
   singleConnectionMode: boolean;
   reconnectOnReload: boolean;
@@ -55,7 +79,7 @@ export interface GlobalSettings {
   // Status Checking
   enableStatusChecking: boolean;
   statusCheckInterval: number;
-  statusCheckMethod: 'ping' | 'socket' | 'http';
+  statusCheckMethod: StatusCheckMethod;
   
   // Network Discovery
   networkDiscovery: NetworkDiscoveryConfig;

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -1,9 +1,9 @@
-import { ThemeConfig } from '../types/settings';
+import { ThemeConfig, Theme, ColorScheme } from '../types/settings';
 
 export class ThemeManager {
   private static instance: ThemeManager;
-  private currentTheme: string = 'dark';
-  private currentColorScheme: string = 'blue';
+  private currentTheme: Theme = 'dark';
+  private currentColorScheme: ColorScheme = 'blue';
   private systemThemeStop?: () => void;
 
   static getInstance(): ThemeManager {
@@ -160,7 +160,7 @@ export class ThemeManager {
     document.body.classList.add(`theme-${themeName}`, `scheme-${colorScheme}`);
   }
 
-  applyTheme(themeName: string, colorScheme: string): void {
+  applyTheme(themeName: Theme, colorScheme: ColorScheme): void {
     this.currentTheme = themeName;
     this.currentColorScheme = colorScheme;
 
@@ -184,26 +184,28 @@ export class ThemeManager {
     localStorage.setItem('mremote-color-scheme', colorScheme);
   }
 
-  getCurrentTheme(): string {
+  getCurrentTheme(): Theme {
     return this.currentTheme;
   }
 
-  getCurrentColorScheme(): string {
+  getCurrentColorScheme(): ColorScheme {
     return this.currentColorScheme;
   }
 
-  getAvailableThemes(): string[] {
-    return Object.keys(this.themes);
+  getAvailableThemes(): Theme[] {
+    return Object.keys(this.themes) as Theme[];
   }
 
-  getAvailableColorSchemes(): string[] {
-    return Object.keys(this.colorSchemes);
+  getAvailableColorSchemes(): ColorScheme[] {
+    return Object.keys(this.colorSchemes) as ColorScheme[];
   }
 
   loadSavedTheme(): void {
-    const savedTheme = localStorage.getItem('mremote-theme') || 'dark';
-    const savedColorScheme = localStorage.getItem('mremote-color-scheme') || 'blue';
-    
+    const savedTheme = (localStorage.getItem('mremote-theme') || 'dark') as Theme;
+    const savedColorScheme = (
+      localStorage.getItem('mremote-color-scheme') || 'blue'
+    ) as ColorScheme;
+
     this.applyTheme(savedTheme, savedColorScheme);
   }
 
@@ -216,7 +218,7 @@ export class ThemeManager {
   }
 
   // Listen for system theme changes
-  watchSystemTheme(callback: (theme: string) => void): (() => void) | undefined {
+  watchSystemTheme(callback: (theme: 'dark' | 'light') => void): (() => void) | undefined {
     if (window.matchMedia) {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
       


### PR DESCRIPTION
## Summary
- add `Theme`, `ColorScheme`, and `StatusCheckMethod` helper types
- enforce those enums in `SettingsDialog` select handlers
- update `ThemeSelector` props
- type `ThemeManager` methods with the new enums

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686af1d3db408325a30ea0ecedd02a6a