### PR TITLE
Refactor ConnectionEditor into modular sections

### DIFF
--- a/src/components/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { X, Save, Monitor, Terminal, Eye, Globe, Phone, Folder } from 'lucide-react';
+import { X, Save } from 'lucide-react';
 import { Connection } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 import { TagManager } from './TagManager';
 import { SSHLibraryType } from '../utils/sshLibraries';
 import { getDefaultPort } from '../utils/defaultPorts';
+import GeneralSection from './connectionEditor/GeneralSection';
+import SSHOptions from './connectionEditor/SSHOptions';
+import HTTPOptions from './connectionEditor/HTTPOptions';
 
 interface ConnectionEditorProps {
   connection?: Connection;
@@ -39,15 +42,6 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     basicAuthRealm: '',
     httpHeaders: {},
   });
-
-  const handlePrivateKeyFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const text = await file.text();
-      setFormData(prev => ({ ...prev, privateKey: text }));
-    }
-  };
-
 
   // Get all available tags from existing connections
   const allTags = Array.from(
@@ -156,14 +150,6 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     onClose();
   };
 
-  const handleProtocolChange = (protocol: string) => {
-    setFormData({
-      ...formData,
-      protocol: protocol as Connection['protocol'],
-      port: getDefaultPort(protocol),
-      authType: ['http', 'https'].includes(protocol) ? 'basic' : 'password',
-    });
-  };
 
   const handleTagsChange = (tags: string[]) => {
     setFormData({ ...formData, tags });
@@ -173,31 +159,8 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     // Tags are automatically available once created
   };
 
-  const addHttpHeader = () => {
-    const key = prompt('Header name:');
-    if (key) {
-      const value = prompt('Header value:');
-      if (value !== null) {
-        setFormData({
-          ...formData,
-          httpHeaders: {
-            ...formData.httpHeaders,
-            [key]: value,
-          },
-        });
-      }
-    }
-  };
-
-  const removeHttpHeader = (key: string) => {
-    const headers = { ...formData.httpHeaders };
-    delete headers[key];
-    setFormData({ ...formData, httpHeaders: headers });
-  };
 
   if (!isOpen) return null;
-
-  const isHttpProtocol = ['http', 'https'].includes(formData.protocol || '');
 
   return (
     <div
@@ -220,325 +183,9 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          <div className="flex items-center space-x-4">
-            <label className="flex items-center space-x-2">
-              <input
-                type="checkbox"
-                checked={formData.isGroup}
-                onChange={(e) => setFormData({ ...formData, isGroup: e.target.checked })}
-                className="rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500"
-              />
-              <span className="text-gray-300">Create as folder/group</span>
-            </label>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Name *
-              </label>
-              <input
-                type="text"
-                required
-                value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder={formData.isGroup ? "Folder name" : "Connection name"}
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Parent Folder
-              </label>
-              <select
-                value={formData.parentId || ''}
-                onChange={(e) => setFormData({ ...formData, parentId: e.target.value || undefined })}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="">Root (No parent)</option>
-                {availableGroups.map(group => (
-                  <option key={group.id} value={group.id}>
-                    {group.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {!formData.isGroup && (
-              <>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
-                    Protocol
-                  </label>
-                  <select
-                    value={formData.protocol}
-                    onChange={(e) => handleProtocolChange(e.target.value)}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  >
-                    <option value="rdp">RDP (Remote Desktop)</option>
-                    <option value="ssh">SSH (Secure Shell)</option>
-                    <option value="vnc">VNC (Virtual Network Computing)</option>
-                    <option value="http">HTTP</option>
-                    <option value="https">HTTPS</option>
-                    <option value="telnet">Telnet</option>
-                    <option value="rlogin">RLogin</option>
-                  </select>
-                </div>
-
-                {formData.protocol === 'ssh' && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-300 mb-2">
-                      SSH Library
-                    </label>
-                    <select
-                      value={formData.sshLibrary}
-                      onChange={(e) => setFormData({ ...formData, sshLibrary: e.target.value as SSHLibraryType })}
-                      className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    >
-                      <option value="webssh">WebSSH Library (Default)</option>
-                      <option value="ssh2">SSH2 Library</option>
-                      <option value="node-ssh">Node-SSH Library</option>
-                      <option value="simple-ssh">Simple-SSH Library</option>
-                    </select>
-                    <p className="text-xs text-gray-500 mt-1">
-                      Choose the SSH library implementation for this connection
-                    </p>
-                  </div>
-                )}
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
-                    Hostname/IP *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={formData.hostname}
-                    onChange={(e) => setFormData({ ...formData, hostname: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="192.168.1.100 or server.example.com"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
-                    Port
-                  </label>
-                  <input
-                    type="number"
-                    value={formData.port}
-                    onChange={(e) => setFormData({ ...formData, port: parseInt(e.target.value) || 0 })}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    min="1"
-                    max="65535"
-                  />
-                </div>
-
-                {/* Authentication Section */}
-                {isHttpProtocol && (
-                  <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-gray-300 mb-2">
-                      Authentication Type
-                    </label>
-                    <select
-                      value={formData.authType}
-                      onChange={(e) => setFormData({ ...formData, authType: e.target.value as any })}
-                      className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    >
-                      <option value="basic">Basic Authentication</option>
-                      <option value="header">Custom Headers</option>
-                    </select>
-                  </div>
-                )}
-
-                {isHttpProtocol && formData.authType === 'basic' && (
-                  <>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Basic Auth Username
-                      </label>
-                      <input
-                        type="text"
-                        value={formData.basicAuthUsername || ''}
-                        onChange={(e) => setFormData({ ...formData, basicAuthUsername: e.target.value })}
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Username"
-                      />
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Basic Auth Password
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.basicAuthPassword || ''}
-                        onChange={(e) => setFormData({ ...formData, basicAuthPassword: e.target.value })}
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Password"
-                      />
-                    </div>
-
-                    <div className="md:col-span-2">
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Realm (Optional)
-                      </label>
-                      <input
-                        type="text"
-                        value={formData.basicAuthRealm || ''}
-                        onChange={(e) => setFormData({ ...formData, basicAuthRealm: e.target.value })}
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Authentication realm"
-                      />
-                    </div>
-                  </>
-                )}
-
-                {!isHttpProtocol && (
-                  <>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Username
-                      </label>
-                      <input
-                        type="text"
-                        value={formData.username || ''}
-                        onChange={(e) => setFormData({ ...formData, username: e.target.value })}
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Username"
-                      />
-                    </div>
-
-                    {formData.protocol === 'ssh' && (
-                      <div>
-                        <label className="block text-sm font-medium text-gray-300 mb-2">
-                          Authentication Type
-                        </label>
-                        <select
-                          value={formData.authType}
-                          onChange={(e) => setFormData({ ...formData, authType: e.target.value as any })}
-                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        >
-                          <option value="password">Password</option>
-                          <option value="key">Private Key</option>
-                        </select>
-                      </div>
-                    )}
-
-                    {formData.authType === 'password' && (
-                      <div>
-                        <label className="block text-sm font-medium text-gray-300 mb-2">
-                          Password
-                        </label>
-                        <input
-                          type="password"
-                          value={formData.password || ''}
-                          onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                          placeholder="Password"
-                        />
-                      </div>
-                    )}
-
-                    {formData.protocol === 'ssh' && formData.authType === 'key' && (
-                      <>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-300 mb-2">
-                            Private Key
-                          </label>
-                        <textarea
-                          value={formData.privateKey || ''}
-                          onChange={(e) => setFormData({ ...formData, privateKey: e.target.value })}
-                          rows={4}
-                          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-                          placeholder="-----BEGIN PRIVATE KEY-----"
-                        />
-                        <input
-                          type="file"
-                          accept=".key,.pem,.ppk"
-                          onChange={handlePrivateKeyFileChange}
-                          className="mt-2 text-sm text-gray-300"
-                        />
-                        </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-300 mb-2">
-                            Passphrase (optional)
-                          </label>
-                          <input
-                            type="password"
-                            value={formData.passphrase || ''}
-                            onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
-                            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                            placeholder="Passphrase"
-                          />
-                        </div>
-                      </>
-                    )}
-                  </>
-                )}
-
-                {formData.protocol === 'rdp' && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-300 mb-2">
-                      Domain
-                    </label>
-                    <input
-                      type="text"
-                      value={formData.domain || ''}
-                      onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
-                      className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      placeholder="Domain (optional)"
-                    />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* HTTP Headers */}
-          {isHttpProtocol && formData.authType === 'header' && (
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Custom HTTP Headers
-              </label>
-              <div className="space-y-2">
-                {Object.entries(formData.httpHeaders || {}).map(([key, value]) => (
-                  <div key={key} className="flex items-center space-x-2">
-                    <input
-                      type="text"
-                      value={key}
-                      readOnly
-                      className="flex-1 px-3 py-2 bg-gray-600 border border-gray-500 rounded-md text-white"
-                    />
-                    <input
-                      type="text"
-                      value={value}
-                      onChange={(e) => setFormData({
-                        ...formData,
-                        httpHeaders: { ...formData.httpHeaders, [key]: e.target.value }
-                      })}
-                      className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removeHttpHeader(key)}
-                      className="px-3 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md transition-colors"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                ))}
-                <button
-                  type="button"
-                  onClick={addHttpHeader}
-                  className="px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
-                >
-                  Add Header
-                </button>
-              </div>
-            </div>
-          )}
+          <GeneralSection formData={formData} setFormData={setFormData} availableGroups={availableGroups} />
+          <SSHOptions formData={formData} setFormData={setFormData} />
+          <HTTPOptions formData={formData} setFormData={setFormData} />
 
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-2">

--- a/src/components/connectionEditor/GeneralSection.tsx
+++ b/src/components/connectionEditor/GeneralSection.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Connection } from '../../types/connection';
+import { SSHLibraryType } from '../../utils/sshLibraries';
+import { getDefaultPort } from '../../utils/defaultPorts';
+
+interface GeneralSectionProps {
+  formData: Partial<Connection & { sshLibrary?: SSHLibraryType }>;
+  setFormData: React.Dispatch<React.SetStateAction<Partial<Connection & { sshLibrary?: SSHLibraryType }>>>;
+  availableGroups: Connection[];
+}
+
+export const GeneralSection: React.FC<GeneralSectionProps> = ({ formData, setFormData, availableGroups }) => {
+  const handleProtocolChange = (protocol: string) => {
+    setFormData(prev => ({
+      ...prev,
+      protocol: protocol as Connection['protocol'],
+      port: getDefaultPort(protocol),
+      authType: ['http', 'https'].includes(protocol) ? 'basic' : 'password',
+    }));
+  };
+
+  return (
+    <>
+      <div className="flex items-center space-x-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={!!formData.isGroup}
+            onChange={(e) => setFormData({ ...formData, isGroup: e.target.checked })}
+            className="rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500"
+          />
+          <span className="text-gray-300">Create as folder/group</span>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Name *</label>
+          <input
+            type="text"
+            required
+            value={formData.name || ''}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            placeholder={formData.isGroup ? 'Folder name' : 'Connection name'}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Parent Folder</label>
+          <select
+            value={formData.parentId || ''}
+            onChange={(e) => setFormData({ ...formData, parentId: e.target.value || undefined })}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            <option value="">Root (No parent)</option>
+            {availableGroups.map(group => (
+              <option key={group.id} value={group.id}>{group.name}</option>
+            ))}
+          </select>
+        </div>
+
+        {!formData.isGroup && (
+          <>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Protocol</label>
+              <select
+                value={formData.protocol}
+                onChange={(e) => handleProtocolChange(e.target.value)}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="rdp">RDP (Remote Desktop)</option>
+                <option value="ssh">SSH (Secure Shell)</option>
+                <option value="vnc">VNC (Virtual Network Computing)</option>
+                <option value="http">HTTP</option>
+                <option value="https">HTTPS</option>
+                <option value="telnet">Telnet</option>
+                <option value="rlogin">RLogin</option>
+              </select>
+            </div>
+
+            {formData.protocol === 'ssh' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">SSH Library</label>
+                <select
+                  value={formData.sshLibrary}
+                  onChange={(e) => setFormData({ ...formData, sshLibrary: e.target.value as SSHLibraryType })}
+                  className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="webssh">WebSSH Library (Default)</option>
+                  <option value="ssh2">SSH2 Library</option>
+                  <option value="node-ssh">Node-SSH Library</option>
+                  <option value="simple-ssh">Simple-SSH Library</option>
+                </select>
+                <p className="text-xs text-gray-500 mt-1">Choose the SSH library implementation for this connection</p>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Hostname/IP *</label>
+              <input
+                type="text"
+                required
+                value={formData.hostname || ''}
+                onChange={(e) => setFormData({ ...formData, hostname: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="192.168.1.100 or server.example.com"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Port</label>
+              <input
+                type="number"
+                value={formData.port || 0}
+                onChange={(e) => setFormData({ ...formData, port: parseInt(e.target.value) || 0 })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                min={1}
+                max={65535}
+              />
+            </div>
+
+            {formData.protocol === 'rdp' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">Domain</label>
+                <input
+                  type="text"
+                  value={formData.domain || ''}
+                  onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
+                  className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Domain (optional)"
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default GeneralSection;

--- a/src/components/connectionEditor/HTTPOptions.tsx
+++ b/src/components/connectionEditor/HTTPOptions.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Connection } from '../../types/connection';
+import { SSHLibraryType } from '../../utils/sshLibraries';
+
+interface HTTPOptionsProps {
+  formData: Partial<Connection & { sshLibrary?: SSHLibraryType }>;
+  setFormData: React.Dispatch<React.SetStateAction<Partial<Connection & { sshLibrary?: SSHLibraryType }>>>;
+}
+
+export const HTTPOptions: React.FC<HTTPOptionsProps> = ({ formData, setFormData }) => {
+  const isHttpProtocol = ['http', 'https'].includes(formData.protocol || '');
+  if (formData.isGroup || !isHttpProtocol) return null;
+
+  const addHttpHeader = () => {
+    const key = prompt('Header name:');
+    if (key) {
+      const value = prompt('Header value:');
+      if (value !== null) {
+        setFormData(prev => ({
+          ...prev,
+          httpHeaders: {
+            ...(prev.httpHeaders || {}),
+            [key]: value,
+          },
+        }));
+      }
+    }
+  };
+
+  const removeHttpHeader = (key: string) => {
+    const headers = { ...(formData.httpHeaders || {}) } as Record<string, string>;
+    delete headers[key];
+    setFormData({ ...formData, httpHeaders: headers });
+  };
+
+  return (
+    <>
+      <div className="md:col-span-2">
+        <label className="block text-sm font-medium text-gray-300 mb-2">Authentication Type</label>
+        <select
+          value={formData.authType}
+          onChange={(e) => setFormData({ ...formData, authType: e.target.value as any })}
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        >
+          <option value="basic">Basic Authentication</option>
+          <option value="header">Custom Headers</option>
+        </select>
+      </div>
+
+      {formData.authType === 'basic' && (
+        <>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Basic Auth Username</label>
+            <input
+              type="text"
+              value={formData.basicAuthUsername || ''}
+              onChange={(e) => setFormData({ ...formData, basicAuthUsername: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Username"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Basic Auth Password</label>
+            <input
+              type="password"
+              value={formData.basicAuthPassword || ''}
+              onChange={(e) => setFormData({ ...formData, basicAuthPassword: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Password"
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-300 mb-2">Realm (Optional)</label>
+            <input
+              type="text"
+              value={formData.basicAuthRealm || ''}
+              onChange={(e) => setFormData({ ...formData, basicAuthRealm: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Authentication realm"
+            />
+          </div>
+        </>
+      )}
+
+      {formData.authType === 'header' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Custom HTTP Headers</label>
+          <div className="space-y-2">
+            {Object.entries(formData.httpHeaders || {}).map(([key, value]) => (
+              <div key={key} className="flex items-center space-x-2">
+                <input
+                  type="text"
+                  value={key}
+                  readOnly
+                  className="flex-1 px-3 py-2 bg-gray-600 border border-gray-500 rounded-md text-white"
+                />
+                <input
+                  type="text"
+                  value={value}
+                  onChange={(e) => setFormData({ ...formData, httpHeaders: { ...(formData.httpHeaders || {}), [key]: e.target.value } })}
+                  className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeHttpHeader(key)}
+                  className="px-3 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addHttpHeader}
+              className="px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+            >
+              Add Header
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default HTTPOptions;

--- a/src/components/connectionEditor/SSHOptions.tsx
+++ b/src/components/connectionEditor/SSHOptions.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Connection } from '../../types/connection';
+import { SSHLibraryType } from '../../utils/sshLibraries';
+
+interface SSHOptionsProps {
+  formData: Partial<Connection & { sshLibrary?: SSHLibraryType }>;
+  setFormData: React.Dispatch<React.SetStateAction<Partial<Connection & { sshLibrary?: SSHLibraryType }>>>;
+}
+
+export const SSHOptions: React.FC<SSHOptionsProps> = ({ formData, setFormData }) => {
+  const isHttpProtocol = ['http', 'https'].includes(formData.protocol || '');
+  if (formData.isGroup || isHttpProtocol) return null;
+
+  const handlePrivateKeyFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const text = await file.text();
+      setFormData(prev => ({ ...prev, privateKey: text }));
+    }
+  };
+
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">Username</label>
+        <input
+          type="text"
+          value={formData.username || ''}
+          onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="Username"
+        />
+      </div>
+
+      {formData.protocol === 'ssh' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Authentication Type</label>
+          <select
+            value={formData.authType}
+            onChange={(e) => setFormData({ ...formData, authType: e.target.value as any })}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            <option value="password">Password</option>
+            <option value="key">Private Key</option>
+          </select>
+        </div>
+      )}
+
+      {formData.authType === 'password' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Password</label>
+          <input
+            type="password"
+            value={formData.password || ''}
+            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            placeholder="Password"
+          />
+        </div>
+      )}
+
+      {formData.protocol === 'ssh' && formData.authType === 'key' && (
+        <>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Private Key</label>
+            <textarea
+              value={formData.privateKey || ''}
+              onChange={(e) => setFormData({ ...formData, privateKey: e.target.value })}
+              rows={4}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              placeholder="-----BEGIN PRIVATE KEY-----"
+            />
+            <input
+              type="file"
+              accept=".key,.pem,.ppk"
+              onChange={handlePrivateKeyFileChange}
+              className="mt-2 text-sm text-gray-300"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Passphrase (optional)</label>
+            <input
+              type="password"
+              value={formData.passphrase || ''}
+              onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder="Passphrase"
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+export default SSHOptions;

--- a/tests/ConnectionEditorSections.test.tsx
+++ b/tests/ConnectionEditorSections.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GeneralSection from '../src/components/connectionEditor/GeneralSection';
+import SSHOptions from '../src/components/connectionEditor/SSHOptions';
+import HTTPOptions from '../src/components/connectionEditor/HTTPOptions';
+import { Connection } from '../src/types/connection';
+
+describe('ConnectionEditor subcomponents', () => {
+  const baseData: Partial<Connection> = {
+    name: 'test',
+    protocol: 'ssh',
+    hostname: 'host',
+    port: 22,
+    isGroup: false,
+  };
+
+  it('shows SSH library selector in GeneralSection when protocol is ssh', () => {
+    render(
+      <GeneralSection
+        formData={{ ...baseData, protocol: 'ssh' }}
+        setFormData={() => {}}
+        availableGroups={[]}
+      />
+    );
+    expect(screen.getAllByText(/SSH Library/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows private key textarea in SSHOptions when authType is key', () => {
+    render(
+      <SSHOptions
+        formData={{ ...baseData, authType: 'key', protocol: 'ssh' }}
+        setFormData={() => {}}
+      />
+    );
+    expect(screen.getByPlaceholderText(/BEGIN PRIVATE KEY/)).toBeInTheDocument();
+  });
+
+  it('shows basic auth fields in HTTPOptions', () => {
+    render(
+      <HTTPOptions
+        formData={{ ...baseData, protocol: 'http', authType: 'basic' }}
+        setFormData={() => {}}
+      />
+    );
+    expect(screen.getByText(/Basic Auth Username/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- split `ConnectionEditor` into `GeneralSection`, `SSHOptions` and `HTTPOptions`
- compose new components from `ConnectionEditor`
- add unit tests for new connection editor sections

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686af1d2bab08325ae3197325ac59c3a