### PR TITLE
Introduce localStorage utility service

### DIFF
--- a/src/utils/__tests__/localStorageService.test.ts
+++ b/src/utils/__tests__/localStorageService.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalStorageService } from '../localStorageService';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('LocalStorageService', () => {
+  it('stores and retrieves objects', () => {
+    const value = { a: 1, b: 'two' };
+    LocalStorageService.setItem('obj', value);
+    const result = LocalStorageService.getItem<typeof value>('obj');
+    expect(result).toEqual(value);
+  });
+
+  it('returns null for invalid JSON', () => {
+    localStorage.setItem('bad', 'notjson');
+    const result = LocalStorageService.getItem('bad');
+    expect(result).toBeNull();
+  });
+});

--- a/src/utils/localStorageService.ts
+++ b/src/utils/localStorageService.ts
@@ -1,0 +1,28 @@
+export class LocalStorageService {
+  static getItem<T>(key: string): T | null {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) as T : null;
+    } catch (error) {
+      console.error(`Failed to parse localStorage key "${key}":`, error);
+      return null;
+    }
+  }
+
+  static setItem<T>(key: string, value: T): void {
+    try {
+      const serialized = JSON.stringify(value);
+      localStorage.setItem(key, serialized);
+    } catch (error) {
+      console.error(`Failed to set localStorage key "${key}":`, error);
+    }
+  }
+
+  static removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(`Failed to remove localStorage key "${key}":`, error);
+    }
+  }
+}

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -1,5 +1,6 @@
 import { GlobalSettings, ActionLogEntry, PerformanceMetrics, CustomScript } from '../types/settings';
 import { SecureStorage } from './storage';
+import { LocalStorageService } from './localStorageService';
 
 const DEFAULT_SETTINGS: GlobalSettings = {
   language: 'en',
@@ -111,9 +112,9 @@ export class SettingsManager {
 
   async loadSettings(): Promise<GlobalSettings> {
     try {
-      const stored = localStorage.getItem('mremote-settings');
+      const stored = LocalStorageService.getItem<GlobalSettings>('mremote-settings');
       if (stored) {
-        this.settings = { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+        this.settings = { ...DEFAULT_SETTINGS, ...stored };
       }
       return this.settings;
     } catch (error) {
@@ -125,7 +126,7 @@ export class SettingsManager {
   async saveSettings(settings: Partial<GlobalSettings>): Promise<void> {
     try {
       this.settings = { ...this.settings, ...settings };
-      localStorage.setItem('mremote-settings', JSON.stringify(this.settings));
+      LocalStorageService.setItem('mremote-settings', this.settings);
       this.logAction('info', 'Settings updated', undefined, 'Settings saved successfully');
     } catch (error) {
       console.error('Failed to save settings:', error);
@@ -180,7 +181,7 @@ export class SettingsManager {
 
   private saveActionLog(): void {
     try {
-      localStorage.setItem('mremote-action-log', JSON.stringify(this.actionLog));
+      LocalStorageService.setItem('mremote-action-log', this.actionLog);
     } catch (error) {
       console.error('Failed to save action log:', error);
     }
@@ -188,9 +189,9 @@ export class SettingsManager {
 
   private loadActionLog(): void {
     try {
-      const stored = localStorage.getItem('mremote-action-log');
+      const stored = LocalStorageService.getItem<any[]>('mremote-action-log');
       if (stored) {
-        this.actionLog = JSON.parse(stored).map((entry: any) => ({
+        this.actionLog = stored.map((entry: any) => ({
           ...entry,
           timestamp: new Date(entry.timestamp),
         }));
@@ -220,7 +221,7 @@ export class SettingsManager {
 
   private savePerformanceMetrics(): void {
     try {
-      localStorage.setItem('mremote-performance-metrics', JSON.stringify(this.performanceMetrics));
+      LocalStorageService.setItem('mremote-performance-metrics', this.performanceMetrics);
     } catch (error) {
       console.error('Failed to save performance metrics:', error);
     }
@@ -228,9 +229,9 @@ export class SettingsManager {
 
   private loadPerformanceMetrics(): void {
     try {
-      const stored = localStorage.getItem('mremote-performance-metrics');
+      const stored = LocalStorageService.getItem<PerformanceMetrics[]>('mremote-performance-metrics');
       if (stored) {
-        this.performanceMetrics = JSON.parse(stored);
+        this.performanceMetrics = stored;
       }
     } catch (error) {
       console.error('Failed to load performance metrics:', error);
@@ -279,7 +280,7 @@ export class SettingsManager {
 
   private saveCustomScripts(): void {
     try {
-      localStorage.setItem('mremote-custom-scripts', JSON.stringify(this.customScripts));
+      LocalStorageService.setItem('mremote-custom-scripts', this.customScripts);
     } catch (error) {
       console.error('Failed to save custom scripts:', error);
     }
@@ -287,9 +288,9 @@ export class SettingsManager {
 
   private loadCustomScripts(): void {
     try {
-      const stored = localStorage.getItem('mremote-custom-scripts');
+      const stored = LocalStorageService.getItem<any[]>('mremote-custom-scripts');
       if (stored) {
-        this.customScripts = JSON.parse(stored).map((script: any) => ({
+        this.customScripts = stored.map((script: any) => ({
           ...script,
           createdAt: new Date(script.createdAt),
           updatedAt: new Date(script.updatedAt),
@@ -348,12 +349,12 @@ export class SettingsManager {
     if (!this.settings.singleWindowMode) return true;
 
     const windowId = sessionStorage.getItem('mremote-window-id');
-    const activeWindowId = localStorage.getItem('mremote-active-window');
+    const activeWindowId = LocalStorageService.getItem<string>('mremote-active-window');
 
     if (!windowId) {
       const newWindowId = crypto.randomUUID();
       sessionStorage.setItem('mremote-window-id', newWindowId);
-      localStorage.setItem('mremote-active-window', newWindowId);
+      LocalStorageService.setItem('mremote-active-window', newWindowId);
       return true;
     }
 
@@ -361,7 +362,7 @@ export class SettingsManager {
       return false; // Another window is active
     }
 
-    localStorage.setItem('mremote-active-window', windowId);
+    LocalStorageService.setItem('mremote-active-window', windowId);
     return true;
   }
 

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -1,4 +1,5 @@
 import { ThemeConfig, Theme, ColorScheme } from '../types/settings';
+import { LocalStorageService } from './localStorageService';
 
 export class ThemeManager {
   private static instance: ThemeManager;
@@ -180,8 +181,8 @@ export class ThemeManager {
     }
 
     // Store in localStorage
-    localStorage.setItem('mremote-theme', themeName);
-    localStorage.setItem('mremote-color-scheme', colorScheme);
+    LocalStorageService.setItem('mremote-theme', themeName);
+    LocalStorageService.setItem('mremote-color-scheme', colorScheme);
   }
 
   getCurrentTheme(): Theme {
@@ -201,9 +202,9 @@ export class ThemeManager {
   }
 
   loadSavedTheme(): void {
-    const savedTheme = (localStorage.getItem('mremote-theme') || 'dark') as Theme;
+    const savedTheme = (LocalStorageService.getItem('mremote-theme') || 'dark') as Theme;
     const savedColorScheme = (
-      localStorage.getItem('mremote-color-scheme') || 'blue'
+      LocalStorageService.getItem('mremote-color-scheme') || 'blue'
     ) as ColorScheme;
 
     this.applyTheme(savedTheme, savedColorScheme);

--- a/src/utils/totpService.ts
+++ b/src/utils/totpService.ts
@@ -1,6 +1,7 @@
 import { authenticator } from 'otplib';
 import { Authenticator } from '@otplib/core';
 import { TOTPConfig } from '../types/settings';
+import { LocalStorageService } from './localStorageService';
 
 export class TOTPService {
   private readonly storageKey = 'mremote-totp-configs';
@@ -60,13 +61,13 @@ export class TOTPService {
       configs.push(config);
     }
     
-    localStorage.setItem(this.storageKey, JSON.stringify(configs));
+    LocalStorageService.setItem(this.storageKey, configs);
   }
 
   getAllConfigs(): TOTPConfig[] {
     try {
-      const stored = localStorage.getItem(this.storageKey);
-      return stored ? JSON.parse(stored) : [];
+      const stored = LocalStorageService.getItem<TOTPConfig[]>(this.storageKey);
+      return stored ? stored : [];
     } catch (error) {
       console.error('Failed to load TOTP configs:', error);
       return [];
@@ -79,7 +80,7 @@ export class TOTPService {
 
   deleteConfig(secret: string): void {
     const configs = this.getAllConfigs().filter(config => config.secret !== secret);
-    localStorage.setItem(this.storageKey, JSON.stringify(configs));
+    LocalStorageService.setItem(this.storageKey, configs);
   }
 
   // Generate QR code data URL
@@ -125,7 +126,7 @@ export class TOTPService {
         }
       });
       
-      localStorage.setItem(this.storageKey, JSON.stringify(configs));
+      LocalStorageService.setItem(this.storageKey, configs);
     } catch (error) {
       throw new Error('Failed to import TOTP configurations: ' + (error instanceof Error ? error.message : 'Unknown error'));
     }


### PR DESCRIPTION
## Summary
- add LocalStorageService utility for JSON storage with error handling
- refactor SettingsManager, ThemeManager and TOTPService to use new service
- test the LocalStorageService

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 148 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b067bb3508325b2d6d54ec3cf8bf6