### PR TITLE
Extract rdp drawing helpers

### DIFF
--- a/src/components/RDPClient.tsx
+++ b/src/components/RDPClient.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { debugLog } from '../utils/debugLogger';
 import { ConnectionSession } from '../types/connection';
+import { drawSimulatedDesktop } from './rdpCanvas';
 import { 
   Monitor, 
   Maximize2, 
@@ -73,103 +74,6 @@ export const RDPClient: React.FC<RDPClientProps> = ({ session }) => {
     }
   };
 
-  const drawSimulatedDesktop = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
-    // Draw desktop background
-    const gradient = ctx.createLinearGradient(0, 0, width, height);
-    gradient.addColorStop(0, '#1e40af');
-    gradient.addColorStop(1, '#1e3a8a');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, width, height);
-    
-    // Draw taskbar
-    ctx.fillStyle = '#374151';
-    ctx.fillRect(0, height - 40, width, 40);
-    
-    // Draw start button
-    ctx.fillStyle = '#4f46e5';
-    ctx.fillRect(5, height - 35, 80, 30);
-    ctx.fillStyle = 'white';
-    ctx.font = '14px Arial';
-    ctx.fillText('Start', 15, height - 15);
-    
-    // Draw system tray
-    ctx.fillStyle = '#6b7280';
-    ctx.fillRect(width - 100, height - 35, 95, 30);
-    
-    // Draw time
-    ctx.fillStyle = 'white';
-    ctx.font = '12px Arial';
-    const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    ctx.fillText(time, width - 60, height - 15);
-    
-    // Draw desktop icons
-    drawDesktopIcon(ctx, 50, 50, 'Computer');
-    drawDesktopIcon(ctx, 50, 130, 'Documents');
-    drawDesktopIcon(ctx, 50, 210, 'Network');
-    
-    // Draw window
-    drawWindow(ctx, 200, 100, 400, 300, 'Remote Desktop Session');
-  };
-
-  const drawDesktopIcon = (ctx: CanvasRenderingContext2D, x: number, y: number, label: string) => {
-    // Icon background
-    ctx.fillStyle = '#3b82f6';
-    ctx.fillRect(x, y, 48, 48);
-    
-    // Icon border
-    ctx.strokeStyle = '#1d4ed8';
-    ctx.lineWidth = 2;
-    ctx.strokeRect(x, y, 48, 48);
-    
-    // Icon symbol
-    ctx.fillStyle = 'white';
-    ctx.font = '20px Arial';
-    ctx.textAlign = 'center';
-    ctx.fillText('📁', x + 24, y + 32);
-    
-    // Label
-    ctx.fillStyle = 'white';
-    ctx.font = '11px Arial';
-    ctx.fillText(label, x + 24, y + 65);
-    ctx.textAlign = 'left';
-  };
-
-  const drawWindow = (ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, title: string) => {
-    // Window background
-    ctx.fillStyle = '#f3f4f6';
-    ctx.fillRect(x, y, width, height);
-    
-    // Title bar
-    ctx.fillStyle = '#4f46e5';
-    ctx.fillRect(x, y, width, 30);
-    
-    // Title text
-    ctx.fillStyle = 'white';
-    ctx.font = '14px Arial';
-    ctx.fillText(title, x + 10, y + 20);
-    
-    // Window controls
-    ctx.fillStyle = '#ef4444';
-    ctx.fillRect(x + width - 25, y + 5, 20, 20);
-    ctx.fillStyle = 'white';
-    ctx.font = '12px Arial';
-    ctx.textAlign = 'center';
-    ctx.fillText('×', x + width - 15, y + 17);
-    ctx.textAlign = 'left';
-    
-    // Window content
-    ctx.fillStyle = '#1f2937';
-    ctx.fillRect(x + 10, y + 40, width - 20, height - 50);
-    
-    // Content text
-    ctx.fillStyle = '#10b981';
-    ctx.font = '12px monospace';
-    ctx.fillText('C:\\Users\\Administrator>', x + 20, y + 60);
-    ctx.fillText('Microsoft Windows [Version 10.0.19044]', x + 20, y + 80);
-    ctx.fillText('(c) Microsoft Corporation. All rights reserved.', x + 20, y + 100);
-    ctx.fillText('', x + 20, y + 120);
-    ctx.fillText('C:\\Users\\Administrator>_', x + 20, y + 140);
-  };
 
   const handleCanvasClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
     if (!isConnected) return;

--- a/src/components/rdpCanvas.ts
+++ b/src/components/rdpCanvas.ts
@@ -1,0 +1,116 @@
+export const drawSimulatedDesktop = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number
+): void => {
+  // Draw desktop background
+  const gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, '#1e40af');
+  gradient.addColorStop(1, '#1e3a8a');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  // Draw taskbar
+  ctx.fillStyle = '#374151';
+  ctx.fillRect(0, height - 40, width, 40);
+
+  // Draw start button
+  ctx.fillStyle = '#4f46e5';
+  ctx.fillRect(5, height - 35, 80, 30);
+  ctx.fillStyle = 'white';
+  ctx.font = '14px Arial';
+  ctx.fillText('Start', 15, height - 15);
+
+  // Draw system tray
+  ctx.fillStyle = '#6b7280';
+  ctx.fillRect(width - 100, height - 35, 95, 30);
+
+  // Draw time
+  ctx.fillStyle = 'white';
+  ctx.font = '12px Arial';
+  const time = new Date().toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+  ctx.fillText(time, width - 60, height - 15);
+
+  // Draw desktop icons
+  drawDesktopIcon(ctx, 50, 50, 'Computer');
+  drawDesktopIcon(ctx, 50, 130, 'Documents');
+  drawDesktopIcon(ctx, 50, 210, 'Network');
+
+  // Draw window
+  drawWindow(ctx, 200, 100, 400, 300, 'Remote Desktop Session');
+};
+
+export const drawDesktopIcon = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  label: string
+): void => {
+  // Icon background
+  ctx.fillStyle = '#3b82f6';
+  ctx.fillRect(x, y, 48, 48);
+
+  // Icon border
+  ctx.strokeStyle = '#1d4ed8';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(x, y, 48, 48);
+
+  // Icon symbol
+  ctx.fillStyle = 'white';
+  ctx.font = '20px Arial';
+  ctx.textAlign = 'center';
+  ctx.fillText('📁', x + 24, y + 32);
+
+  // Label
+  ctx.fillStyle = 'white';
+  ctx.font = '11px Arial';
+  ctx.fillText(label, x + 24, y + 65);
+  ctx.textAlign = 'left';
+};
+
+export const drawWindow = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  title: string
+): void => {
+  // Window background
+  ctx.fillStyle = '#f3f4f6';
+  ctx.fillRect(x, y, width, height);
+
+  // Title bar
+  ctx.fillStyle = '#4f46e5';
+  ctx.fillRect(x, y, width, 30);
+
+  // Title text
+  ctx.fillStyle = 'white';
+  ctx.font = '14px Arial';
+  ctx.fillText(title, x + 10, y + 20);
+
+  // Window controls
+  ctx.fillStyle = '#ef4444';
+  ctx.fillRect(x + width - 25, y + 5, 20, 20);
+  ctx.fillStyle = 'white';
+  ctx.font = '12px Arial';
+  ctx.textAlign = 'center';
+  ctx.fillText('×', x + width - 15, y + 17);
+  ctx.textAlign = 'left';
+
+  // Window content
+  ctx.fillStyle = '#1f2937';
+  ctx.fillRect(x + 10, y + 40, width - 20, height - 50);
+
+  // Content text
+  ctx.fillStyle = '#10b981';
+  ctx.font = '12px monospace';
+  ctx.fillText('C:\\Users\\Administrator>', x + 20, y + 60);
+  ctx.fillText('Microsoft Windows [Version 10.0.19044]', x + 20, y + 80);
+  ctx.fillText('(c) Microsoft Corporation. All rights reserved.', x + 20, y + 100);
+  ctx.fillText('', x + 20, y + 120);
+  ctx.fillText('C:\\Users\\Administrator>_', x + 20, y + 140);
+};

--- a/tests/rdpCanvas.test.ts
+++ b/tests/rdpCanvas.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { drawDesktopIcon, drawSimulatedDesktop } from '../src/components/rdpCanvas';
+
+type MockCtx = Pick<CanvasRenderingContext2D,
+  'fillRect' | 'strokeRect' | 'fillText' | 'createLinearGradient'> & {
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  font: string;
+  textAlign: string;
+};
+
+function createMockCtx(): MockCtx {
+  const gradient = { addColorStop: vi.fn() } as unknown as CanvasGradient;
+  return {
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    createLinearGradient: vi.fn(() => gradient),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    font: '',
+    textAlign: ''
+  };
+}
+
+describe('rdpCanvas helpers', () => {
+  it('drawDesktopIcon uses canvas APIs', () => {
+    const ctx = createMockCtx();
+    drawDesktopIcon(ctx as unknown as CanvasRenderingContext2D, 10, 20, 'Label');
+
+    expect(ctx.fillRect).toHaveBeenCalledWith(10, 20, 48, 48);
+    expect(ctx.strokeRect).toHaveBeenCalledWith(10, 20, 48, 48);
+    expect(ctx.fillText).toHaveBeenCalledWith('📁', 34, 52);
+  });
+
+  it('drawSimulatedDesktop does not throw', () => {
+    const ctx = createMockCtx();
+    expect(() => drawSimulatedDesktop(ctx as unknown as CanvasRenderingContext2D, 100, 80)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- move drawing functions to `rdpCanvas.ts`
- use the new helpers in `RDPClient`
- test the helpers with a small unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b37cf826c832588013dc22ba49cdf