### PR TITLE
Fix timed operations cleanup

### DIFF
--- a/src/utils/raceWithTimeout.ts
+++ b/src/utils/raceWithTimeout.ts
@@ -1,0 +1,17 @@
+export function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): { promise: Promise<T>; timer: ReturnType<typeof setTimeout> } {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      onTimeout?.();
+      reject(new Error('Operation timed out'));
+    }, timeoutMs);
+  });
+
+  const raced = Promise.race([promise, timeoutPromise]) as Promise<T>;
+  raced.finally(() => clearTimeout(timer));
+  return { promise: raced, timer };
+}


### PR DESCRIPTION
## Summary
- manage connection race timers safely
- add `raceWithTimeout` utility

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686ffe9e25688325ac273677ae98671d