### PR TITLE
Extract service map

### DIFF
--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -29,4 +29,16 @@ describe('NetworkScanner helper methods', () => {
     expect(() => scanner.generateIPRange('192.168.0.0/23')).toThrow();
     expect(() => scanner.generateIPRange('192.168.0.0/31')).toThrow();
   });
+
+  it('identifyService returns mapped values', () => {
+    const result = scanner.identifyService(22);
+    expect(result.service).toBe('ssh');
+    expect(result.protocol).toBe('ssh');
+  });
+
+  it('identifyService handles unknown ports', () => {
+    const result = scanner.identifyService(9999);
+    expect(result.service).toBe('unknown');
+    expect(result.protocol).toBe('unknown');
+  });
 });

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -1,6 +1,7 @@
 import { DiscoveredHost, DiscoveredService } from '../types/connection';
 import { NetworkDiscoveryConfig } from '../types/settings';
 import { Semaphore } from './semaphore';
+import serviceMap from './serviceMap';
 
 export class NetworkScanner {
   async scanNetwork(
@@ -178,27 +179,7 @@ export class NetworkScanner {
   }
 
   private identifyService(port: number, banner?: string): DiscoveredService | null {
-    const commonServices: Record<number, { service: string; protocol: string }> = {
-      21: { service: 'ftp', protocol: 'ftp' },
-      22: { service: 'ssh', protocol: 'ssh' },
-      23: { service: 'telnet', protocol: 'telnet' },
-      25: { service: 'smtp', protocol: 'smtp' },
-      53: { service: 'dns', protocol: 'dns' },
-      80: { service: 'http', protocol: 'http' },
-      110: { service: 'pop3', protocol: 'pop3' },
-      143: { service: 'imap', protocol: 'imap' },
-      443: { service: 'https', protocol: 'https' },
-      993: { service: 'imaps', protocol: 'imaps' },
-      995: { service: 'pop3s', protocol: 'pop3s' },
-      3306: { service: 'mysql', protocol: 'mysql' },
-      3389: { service: 'rdp', protocol: 'rdp' },
-      5432: { service: 'postgresql', protocol: 'postgresql' },
-      5900: { service: 'vnc', protocol: 'vnc' },
-      5901: { service: 'vnc', protocol: 'vnc' },
-      5902: { service: 'vnc', protocol: 'vnc' },
-    };
-
-    const serviceInfo = commonServices[port];
+    const serviceInfo = serviceMap[port];
     if (!serviceInfo) {
       return {
         port,

--- a/src/utils/serviceMap.ts
+++ b/src/utils/serviceMap.ts
@@ -1,0 +1,21 @@
+export const serviceMap: Record<number, { service: string; protocol: string }> = {
+  21: { service: 'ftp', protocol: 'ftp' },
+  22: { service: 'ssh', protocol: 'ssh' },
+  23: { service: 'telnet', protocol: 'telnet' },
+  25: { service: 'smtp', protocol: 'smtp' },
+  53: { service: 'dns', protocol: 'dns' },
+  80: { service: 'http', protocol: 'http' },
+  110: { service: 'pop3', protocol: 'pop3' },
+  143: { service: 'imap', protocol: 'imap' },
+  443: { service: 'https', protocol: 'https' },
+  993: { service: 'imaps', protocol: 'imaps' },
+  995: { service: 'pop3s', protocol: 'pop3s' },
+  3306: { service: 'mysql', protocol: 'mysql' },
+  3389: { service: 'rdp', protocol: 'rdp' },
+  5432: { service: 'postgresql', protocol: 'postgresql' },
+  5900: { service: 'vnc', protocol: 'vnc' },
+  5901: { service: 'vnc', protocol: 'vnc' },
+  5902: { service: 'vnc', protocol: 'vnc' },
+};
+
+export default serviceMap;


### PR DESCRIPTION
## Summary
- centralize service mapping in `serviceMap.ts`
- use the map inside `NetworkScanner`
- test `identifyService` using the new mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719dc304088325ace1e1275eaba7f3