### PR TITLE
Refactor Settings and ImportExport components

### DIFF
--- a/src/components/ImportExport/ExportTab.tsx
+++ b/src/components/ImportExport/ExportTab.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Download, FileText, Database, Settings, Lock } from 'lucide-react';
+import { Connection } from '../../types/connection';
+
+interface ExportTabProps {
+  connections: Connection[];
+  exportFormat: 'json' | 'xml' | 'csv';
+  setExportFormat: (format: 'json' | 'xml' | 'csv') => void;
+  includePasswords: boolean;
+  setIncludePasswords: (val: boolean) => void;
+  exportEncrypted: boolean;
+  setExportEncrypted: (val: boolean) => void;
+  exportPassword: string;
+  setExportPassword: (val: string) => void;
+  isProcessing: boolean;
+  handleExport: () => void;
+}
+
+const ExportTab: React.FC<ExportTabProps> = ({
+  connections,
+  exportFormat,
+  setExportFormat,
+  includePasswords,
+  setIncludePasswords,
+  exportEncrypted,
+  setExportEncrypted,
+  exportPassword,
+  setExportPassword,
+  isProcessing,
+  handleExport,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-white mb-4">Export Connections</h3>
+        <p className="text-gray-400 mb-4">
+          Export your connections to a file. Configure encryption and password options below.
+        </p>
+        <div className="bg-gray-700 rounded-lg p-4 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-gray-300">Total Connections:</span>
+            <span className="text-white font-medium">{connections.length}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-gray-300">Groups:</span>
+            <span className="text-white font-medium">
+              {connections.filter(c => c.isGroup).length}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">
+          Export Format
+        </label>
+        <div className="grid grid-cols-3 gap-3">
+          {[
+            { value: 'json', label: 'JSON', icon: FileText, desc: 'Structured data format' },
+            { value: 'xml', label: 'XML', icon: Database, desc: 'sortOfRemoteNG compatible' },
+            { value: 'csv', label: 'CSV', icon: Settings, desc: 'Spreadsheet format' },
+          ].map(format => (
+            <button
+              key={format.value}
+              onClick={() => setExportFormat(format.value as any)}
+              className={`p-4 rounded-lg border-2 transition-colors ${
+                exportFormat === format.value
+                  ? 'border-blue-500 bg-blue-500/20'
+                  : 'border-gray-600 hover:border-gray-500'
+              }`}
+            >
+              <format.icon size={24} className="mx-auto mb-2 text-gray-300" />
+              <div className="text-white font-medium">{format.label}</div>
+              <div className="text-xs text-gray-400 mt-1">{format.desc}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={includePasswords}
+            onChange={e => setIncludePasswords(e.target.checked)}
+            className="rounded border-gray-600 bg-gray-700 text-blue-600"
+          />
+          <span className="text-gray-300">Include passwords in export</span>
+        </label>
+
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={exportEncrypted}
+            onChange={e => setExportEncrypted(e.target.checked)}
+            className="rounded border-gray-600 bg-gray-700 text-blue-600"
+          />
+          <span className="text-gray-300">Encrypt export file</span>
+          <Lock size={16} className="text-yellow-400" />
+        </label>
+
+        {exportEncrypted && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">
+              Encryption Password
+            </label>
+            <input
+              type="password"
+              value={exportPassword}
+              onChange={e => setExportPassword(e.target.value)}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter encryption password"
+            />
+          </div>
+        )}
+      </div>
+
+      <button
+        onClick={handleExport}
+        disabled={isProcessing || connections.length === 0 || (exportEncrypted && !exportPassword)}
+        className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors flex items-center justify-center space-x-2"
+      >
+        {isProcessing ? (
+          <>
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+            <span>Exporting...</span>
+          </>
+        ) : (
+          <>
+            <Download size={16} />
+            <span>Export Connections</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default ExportTab;

--- a/src/components/ImportExport/ImportTab.tsx
+++ b/src/components/ImportExport/ImportTab.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Upload, File, FolderOpen, CheckCircle, AlertCircle } from 'lucide-react';
+import { ImportResult } from './types';
+
+interface ImportTabProps {
+  isProcessing: boolean;
+  handleImport: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  importResult: ImportResult | null;
+  handleFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  confirmImport: () => void;
+  cancelImport: () => void;
+}
+
+const ImportTab: React.FC<ImportTabProps> = ({
+  isProcessing,
+  handleImport,
+  fileInputRef,
+  importResult,
+  handleFileSelect,
+  confirmImport,
+  cancelImport,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-white mb-4">Import Connections</h3>
+        <p className="text-gray-400 mb-4">
+          Import connections from JSON, XML, or CSV files. Encrypted files are automatically detected.
+        </p>
+      </div>
+
+      {!importResult && (
+        <div className="border-2 border-dashed border-gray-600 rounded-lg p-8 text-center">
+          <FolderOpen size={48} className="mx-auto mb-4 text-gray-400" />
+          <p className="text-gray-300 mb-4">Select a file to import connections</p>
+          <button
+            onClick={handleImport}
+            disabled={isProcessing}
+            className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white rounded-lg transition-colors flex items-center space-x-2 mx-auto"
+          >
+            {isProcessing ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                <span>Processing...</span>
+              </>
+            ) : (
+              <>
+                <File size={16} />
+                <span>Choose File</span>
+              </>
+            )}
+          </button>
+          <p className="text-xs text-gray-500 mt-2">
+            Supported formats: .json, .xml, .csv (encrypted files supported)
+          </p>
+        </div>
+      )}
+
+      {importResult && (
+        <div className="space-y-4">
+          <div className={`p-4 rounded-lg border ${
+            importResult.success ? 'border-green-500 bg-green-500/20' : 'border-red-500 bg-red-500/20'
+          }`}>
+            <div className="flex items-center space-x-2 mb-2">
+              {importResult.success ? (
+                <CheckCircle size={20} className="text-green-400" />
+              ) : (
+                <AlertCircle size={20} className="text-red-400" />
+              )}
+              <span className={`font-medium ${importResult.success ? 'text-green-400' : 'text-red-400'}`}>
+                {importResult.success ? 'Import Successful' : 'Import Failed'}
+              </span>
+            </div>
+
+            {importResult.success && (
+              <p className="text-gray-300">Found {importResult.imported} connections ready to import.</p>
+            )}
+
+            {importResult.errors.length > 0 && (
+              <div className="mt-2">
+                <p className="text-red-400 text-sm font-medium">Errors:</p>
+                <ul className="text-red-300 text-sm mt-1">
+                  {importResult.errors.map((error, index) => (
+                    <li key={index}>• {error}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {importResult.success && (
+            <div className="flex space-x-3">
+              <button
+                onClick={confirmImport}
+                className="flex-1 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors"
+              >
+                Import {importResult.imported} Connections
+              </button>
+              <button
+                onClick={cancelImport}
+                className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {!importResult.success && (
+            <button
+              onClick={cancelImport}
+              className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+            >
+              Try Again
+            </button>
+          )}
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,.xml,.csv,.encrypted"
+        onChange={handleFileSelect}
+        className="hidden"
+      />
+    </div>
+  );
+};
+
+export default ImportTab;

--- a/src/components/ImportExport/types.ts
+++ b/src/components/ImportExport/types.ts
@@ -1,0 +1,8 @@
+import { Connection } from '../../types/connection';
+
+export interface ImportResult {
+  success: boolean;
+  imported: number;
+  errors: string[];
+  connections: Connection[];
+}

--- a/src/components/SettingsDialog/index.tsx
+++ b/src/components/SettingsDialog/index.tsx
@@ -12,14 +12,14 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings, ProxyConfig } from '../types/settings';
-import GeneralSettings from './settings/GeneralSettings';
-import SecuritySettings from './settings/SecuritySettings';
-import PerformanceSettings from './settings/PerformanceSettings';
-import ProxySettings from './settings/ProxySettings';
-import AdvancedSettings from './settings/AdvancedSettings';
-import { SettingsManager } from '../utils/settingsManager';
-import { ThemeManager } from '../utils/themeManager';
+import { GlobalSettings, ProxyConfig } from '../../types/settings';
+import GeneralSettings from './sections/GeneralSettings';
+import SecuritySettings from './sections/SecuritySettings';
+import PerformanceSettings from './sections/PerformanceSettings';
+import ProxySettings from './sections/ProxySettings';
+import AdvancedSettings from './sections/AdvancedSettings';
+import { SettingsManager } from '../../utils/settingsManager';
+import { ThemeManager } from '../../utils/themeManager';
 
 interface SettingsDialogProps {
   isOpen: boolean;

--- a/src/components/SettingsDialog/sections/AdvancedSettings.tsx
+++ b/src/components/SettingsDialog/sections/AdvancedSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings } from '../../types/settings';
+import { GlobalSettings } from '../../../types/settings';
 
 interface AdvancedSettingsProps {
   settings: GlobalSettings;

--- a/src/components/SettingsDialog/sections/GeneralSettings.tsx
+++ b/src/components/SettingsDialog/sections/GeneralSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings, Theme, ColorScheme } from '../../types/settings';
+import { GlobalSettings, Theme, ColorScheme } from '../../../types/settings';
 
 interface GeneralSettingsProps {
   settings: GlobalSettings;

--- a/src/components/SettingsDialog/sections/PerformanceSettings.tsx
+++ b/src/components/SettingsDialog/sections/PerformanceSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings, StatusCheckMethod } from '../../types/settings';
+import { GlobalSettings, StatusCheckMethod } from '../../../types/settings';
 
 interface PerformanceSettingsProps {
   settings: GlobalSettings;

--- a/src/components/SettingsDialog/sections/ProxySettings.tsx
+++ b/src/components/SettingsDialog/sections/ProxySettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings, ProxyConfig } from '../../types/settings';
+import { GlobalSettings, ProxyConfig } from '../../../types/settings';
 
 interface ProxySettingsProps {
   settings: GlobalSettings;

--- a/src/components/SettingsDialog/sections/SecuritySettings.tsx
+++ b/src/components/SettingsDialog/sections/SecuritySettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { GlobalSettings } from '../../types/settings';
+import { GlobalSettings } from '../../../types/settings';
 
 interface SecuritySettingsProps {
   settings: GlobalSettings;


### PR DESCRIPTION
## Summary
- organize SettingsDialog components into a folder
- split ImportExport into wrapper and subcomponents
- move settings tabs under `SettingsDialog/sections`
- add new `ExportTab` and `ImportTab` components

## Testing
- `npm test` *(fails: prompts for vitest install)*

------
https://chatgpt.com/codex/tasks/task_e_68723a35a2c88325a53ba535dc10de7f