### PR TITLE
Add Protocol enum and refactor usages

### DIFF
--- a/src/components/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save } from 'lucide-react';
-import { Connection } from '../types/connection';
+import { Connection, Protocol } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 import { TagManager } from './TagManager';
 import { SSHLibraryType } from '../utils/sshLibraries';
@@ -23,7 +23,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
   const { state, dispatch } = useConnections();
   const [formData, setFormData] = useState<Partial<Connection & { sshLibrary?: SSHLibraryType }>>({
     name: '',
-    protocol: 'rdp',
+    protocol: Protocol.RDP,
     hostname: '',
     port: 3389,
     username: '',
@@ -79,7 +79,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     } else {
       setFormData({
         name: '',
-        protocol: 'rdp',
+        protocol: Protocol.RDP,
         hostname: '',
         port: 3389,
         username: '',
@@ -120,7 +120,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
     const connectionData: Connection = {
       id: connection?.id || crypto.randomUUID(),
       name: formData.name || 'New Connection',
-      protocol: formData.protocol as Connection['protocol'],
+      protocol: formData.protocol as Protocol,
       hostname: formData.hostname || '',
       port: formData.port || getDefaultPort(formData.protocol as string),
       username: formData.username,

--- a/src/components/ConnectionTree.tsx
+++ b/src/components/ConnectionTree.tsx
@@ -15,22 +15,22 @@ import {
   Copy,
   Play
 } from 'lucide-react';
-import { Connection } from '../types/connection';
+import { Connection, Protocol } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 
-const getProtocolIcon = (protocol: string) => {
+const getProtocolIcon = (protocol: Protocol) => {
   switch (protocol) {
-    case 'rdp':
+    case Protocol.RDP:
       return Monitor;
-    case 'ssh':
+    case Protocol.SSH:
       return Terminal;
-    case 'vnc':
+    case Protocol.VNC:
       return Eye;
-    case 'http':
-    case 'https':
+    case Protocol.HTTP:
+    case Protocol.HTTPS:
       return Globe;
-    case 'telnet':
-    case 'rlogin':
+    case Protocol.TELNET:
+    case Protocol.RLOGIN:
       return Phone;
     default:
       return Monitor;

--- a/src/components/ImportExport.tsx
+++ b/src/components/ImportExport.tsx
@@ -12,7 +12,7 @@ import {
   FolderOpen,
   Lock
 } from 'lucide-react';
-import { Connection } from '../types/connection';
+import { Connection, Protocol } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 import { CollectionManager } from '../utils/collectionManager';
 import CryptoJS from 'crypto-js';
@@ -302,7 +302,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
       const conn: Connection = {
         id: node.getAttribute('Id') || crypto.randomUUID(),
         name: node.getAttribute('Name') || 'Imported Connection',
-        protocol: (node.getAttribute('Type')?.toLowerCase() || 'rdp') as Connection['protocol'],
+        protocol: (node.getAttribute('Type')?.toLowerCase() || Protocol.RDP) as Protocol,
         hostname: node.getAttribute('Server') || '',
         port: parseInt(node.getAttribute('Port') || '3389'),
         username: node.getAttribute('Username') || undefined,
@@ -339,7 +339,7 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
       connections.push({
         id: conn.ID || crypto.randomUUID(),
         name: conn.Name || 'Imported Connection',
-        protocol: (conn.Protocol?.toLowerCase() || 'rdp') as Connection['protocol'],
+        protocol: (conn.Protocol?.toLowerCase() || Protocol.RDP) as Protocol,
         hostname: conn.Hostname || '',
         port: parseInt(conn.Port || '3389'),
         username: conn.Username || undefined,

--- a/src/components/NetworkDiscovery.tsx
+++ b/src/components/NetworkDiscovery.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Search, Wifi, Monitor, Database, HardDrive, Globe, Play, Plus, Settings, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { DiscoveredHost, DiscoveredService } from '../types/connection';
+import { DiscoveredHost, DiscoveredService, Protocol } from '../types/connection';
 import { NetworkDiscoveryConfig } from '../types/settings';
 import { NetworkScanner } from '../utils/networkScanner';
 import { useConnections } from '../contexts/ConnectionContext';
@@ -18,7 +18,13 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({ isOpen, onCl
     enabled: true,
     ipRange: '192.168.1.0/24',
     portRanges: ['22', '80', '443', '3389', '5900'],
-    protocols: ['ssh', 'http', 'https', 'rdp', 'vnc'],
+    protocols: [
+      Protocol.SSH,
+      Protocol.HTTP,
+      Protocol.HTTPS,
+      Protocol.RDP,
+      Protocol.VNC,
+    ],
     timeout: 5000,
     maxConcurrent: 50,
     customPorts: {
@@ -66,7 +72,7 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({ isOpen, onCl
         const connection = {
           id: crypto.randomUUID(),
           name: `${host.hostname || host.ip} (${service.service})`,
-          protocol: service.protocol as any,
+          protocol: service.protocol as Protocol,
           hostname: host.ip,
           port: service.port,
           isGroup: false,
@@ -86,11 +92,11 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({ isOpen, onCl
 
   const getServiceIcon = (service: string) => {
     switch (service.toLowerCase()) {
-      case 'ssh': return Monitor;
-      case 'http':
-      case 'https': return Globe;
-      case 'rdp': return Monitor;
-      case 'vnc': return Monitor;
+      case Protocol.SSH: return Monitor;
+      case Protocol.HTTP:
+      case Protocol.HTTPS: return Globe;
+      case Protocol.RDP: return Monitor;
+      case Protocol.VNC: return Monitor;
       case 'mysql': return Database;
       case 'ftp':
       case 'sftp': return HardDrive;
@@ -206,7 +212,16 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({ isOpen, onCl
                       Protocols to Detect
                     </label>
                     <div className="flex flex-wrap gap-2">
-                      {['ssh', 'http', 'https', 'rdp', 'vnc', 'mysql', 'ftp', 'telnet'].map(protocol => (
+                      {[
+                        Protocol.SSH,
+                        Protocol.HTTP,
+                        Protocol.HTTPS,
+                        Protocol.RDP,
+                        Protocol.VNC,
+                        'mysql',
+                        'ftp',
+                        Protocol.TELNET,
+                      ].map(protocol => (
                         <label key={protocol} className="flex items-center space-x-2">
                           <input
                             type="checkbox"

--- a/src/components/SessionTabs.tsx
+++ b/src/components/SessionTabs.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { X, Monitor, Terminal, Eye, Globe, Phone, Wifi, WifiOff } from 'lucide-react';
-import { ConnectionSession } from '../types/connection';
+import { ConnectionSession, Protocol } from '../types/connection';
 import { useConnections } from '../contexts/ConnectionContext';
 
-const getProtocolIcon = (protocol: string) => {
+const getProtocolIcon = (protocol: Protocol) => {
   switch (protocol) {
-    case 'rdp':
+    case Protocol.RDP:
       return Monitor;
-    case 'ssh':
+    case Protocol.SSH:
       return Terminal;
-    case 'vnc':
+    case Protocol.VNC:
       return Eye;
-    case 'http':
-    case 'https':
+    case Protocol.HTTP:
+    case Protocol.HTTPS:
       return Globe;
-    case 'telnet':
-    case 'rlogin':
+    case Protocol.TELNET:
+    case Protocol.RLOGIN:
       return Phone;
     default:
       return Monitor;
@@ -76,7 +76,7 @@ export const SessionTabs: React.FC<SessionTabsProps> = ({
   return (
     <div className="h-10 bg-gray-800 border-b border-gray-700 flex items-center overflow-x-auto">
       {state.sessions.map((session) => {
-        const ProtocolIcon = getProtocolIcon(session.protocol);
+        const ProtocolIcon = getProtocolIcon(session.protocol as Protocol);
         const StatusIcon = getStatusIcon(session.status);
         const isActive = session.id === activeSessionId;
 

--- a/src/components/SessionViewer.tsx
+++ b/src/components/SessionViewer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Monitor, Terminal, AlertCircle, Loader2, ExternalLink, Shield } from 'lucide-react';
-import { ConnectionSession } from '../types/connection';
+import { ConnectionSession, Protocol } from '../types/connection';
 import { WebTerminal } from './WebTerminal';
 import { WebBrowser } from './WebBrowser';
 import { RDPClient } from './RDPClient';
@@ -25,20 +25,20 @@ export const SessionViewer: React.FC<SessionViewerProps> = ({ session }) => {
 
       case 'connected':
         // Route to appropriate viewer based on protocol
-        switch (session.protocol) {
-          case 'ssh':
-          case 'telnet':
-          case 'rlogin':
+        switch (session.protocol as Protocol) {
+          case Protocol.SSH:
+          case Protocol.TELNET:
+          case Protocol.RLOGIN:
             return <WebTerminal session={session} />;
-          
-          case 'http':
-          case 'https':
+
+          case Protocol.HTTP:
+          case Protocol.HTTPS:
             return <WebBrowser session={session} />;
-          
-          case 'rdp':
+
+          case Protocol.RDP:
             return <RDPClient session={session} />;
-          
-          case 'vnc':
+
+          case Protocol.VNC:
             return (
               <div className="flex flex-col items-center justify-center h-full text-blue-400">
                 <Monitor size={48} className="mb-4" />

--- a/src/components/connectionEditor/GeneralSection.tsx
+++ b/src/components/connectionEditor/GeneralSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Connection } from '../../types/connection';
+import { Connection, Protocol } from '../../types/connection';
 import { SSHLibraryType } from '../../utils/sshLibraries';
 import { getDefaultPort } from '../../utils/defaultPorts';
 
@@ -10,10 +10,10 @@ interface GeneralSectionProps {
 }
 
 export const GeneralSection: React.FC<GeneralSectionProps> = ({ formData, setFormData, availableGroups }) => {
-  const handleProtocolChange = (protocol: string) => {
+  const handleProtocolChange = (protocol: Protocol) => {
     setFormData(prev => ({
       ...prev,
-      protocol: protocol as Connection['protocol'],
+      protocol,
       port: getDefaultPort(protocol),
       authType: ['http', 'https'].includes(protocol) ? 'basic' : 'password',
     }));

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useConnections } from '../contexts/ConnectionContext';
-import { Connection, ConnectionSession } from '../types/connection';
+import { Connection, ConnectionSession, Protocol } from '../types/connection';
 import { SettingsManager } from '../utils/settingsManager';
 import { StatusChecker } from '../utils/statusChecker';
 import { ScriptEngine } from '../utils/scriptEngine';
@@ -183,7 +183,7 @@ export const useSessionManager = () => {
     const tempConnection: Connection = {
       id: crypto.randomUUID(),
       name: `${t('connections.quickConnect')} - ${hostname}`,
-      protocol: protocol as Connection['protocol'],
+      protocol: protocol as Protocol,
       hostname,
       port: getDefaultPort(protocol),
       isGroup: false,

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -1,8 +1,25 @@
 import { ProxyConfig } from "./settings";
+
+export enum Protocol {
+  RDP = 'rdp',
+  SSH = 'ssh',
+  VNC = 'vnc',
+  HTTP = 'http',
+  HTTPS = 'https',
+  TELNET = 'telnet',
+  RLOGIN = 'rlogin',
+  MYSQL = 'mysql',
+  FTP = 'ftp',
+  SFTP = 'sftp',
+  SCP = 'scp',
+  WINRM = 'winrm',
+  RUSTDESK = 'rustdesk',
+  SMB = 'smb',
+}
 export interface Connection {
   id: string;
   name: string;
-  protocol: 'rdp' | 'ssh' | 'vnc' | 'http' | 'https' | 'telnet' | 'rlogin' | 'mysql' | 'ftp' | 'sftp' | 'scp' | 'winrm' | 'rustdesk' | 'smb';
+  protocol: Protocol;
   hostname: string;
   port: number;
   username?: string;

--- a/tests/ConnectionContextAutoSave.test.tsx
+++ b/tests/ConnectionContextAutoSave.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { ConnectionProvider, useConnections } from '../src/contexts/ConnectionContext';
 import { CollectionManager } from '../src/utils/collectionManager';
-import { Connection } from '../src/types/connection';
+import { Connection, Protocol } from '../src/types/connection';
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <ConnectionProvider>{children}</ConnectionProvider>;
@@ -28,7 +28,7 @@ describe('ConnectionProvider auto-save', () => {
     const conn: Connection = {
       id: 'c1',
       name: 'c1',
-      protocol: 'ssh',
+      protocol: Protocol.SSH,
       hostname: 'host',
       port: 22,
       isGroup: false,

--- a/tests/ConnectionEditorSections.test.tsx
+++ b/tests/ConnectionEditorSections.test.tsx
@@ -3,12 +3,12 @@ import { render, screen } from '@testing-library/react';
 import GeneralSection from '../src/components/connectionEditor/GeneralSection';
 import SSHOptions from '../src/components/connectionEditor/SSHOptions';
 import HTTPOptions from '../src/components/connectionEditor/HTTPOptions';
-import { Connection } from '../src/types/connection';
+import { Connection, Protocol } from '../src/types/connection';
 
 describe('ConnectionEditor subcomponents', () => {
   const baseData: Partial<Connection> = {
     name: 'test',
-    protocol: 'ssh',
+    protocol: Protocol.SSH,
     hostname: 'host',
     port: 22,
     isGroup: false,
@@ -17,7 +17,7 @@ describe('ConnectionEditor subcomponents', () => {
   it('shows SSH library selector in GeneralSection when protocol is ssh', () => {
     render(
       <GeneralSection
-        formData={{ ...baseData, protocol: 'ssh' }}
+        formData={{ ...baseData, protocol: Protocol.SSH }}
         setFormData={() => {}}
         availableGroups={[]}
       />
@@ -28,7 +28,7 @@ describe('ConnectionEditor subcomponents', () => {
   it('shows private key textarea in SSHOptions when authType is key', () => {
     render(
       <SSHOptions
-        formData={{ ...baseData, authType: 'key', protocol: 'ssh' }}
+        formData={{ ...baseData, authType: 'key', protocol: Protocol.SSH }}
         setFormData={() => {}}
       />
     );
@@ -38,7 +38,7 @@ describe('ConnectionEditor subcomponents', () => {
   it('shows basic auth fields in HTTPOptions', () => {
     render(
       <HTTPOptions
-        formData={{ ...baseData, protocol: 'http', authType: 'basic' }}
+        formData={{ ...baseData, protocol: Protocol.HTTP, authType: 'basic' }}
         setFormData={() => {}}
       />
     );

--- a/tests/ConnectionTree.test.tsx
+++ b/tests/ConnectionTree.test.tsx
@@ -3,13 +3,13 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, within, fireEvent } from '@testing-library/react';
 import { ConnectionTree } from '../src/components/ConnectionTree';
 import { ConnectionProvider, useConnections } from '../src/contexts/ConnectionContext';
-import { Connection } from '../src/types/connection';
+import { Connection, Protocol } from '../src/types/connection';
 
 const mockConnections: Connection[] = [
   {
     id: 'group1',
     name: 'Group 1',
-    protocol: 'rdp',
+    protocol: Protocol.RDP,
     hostname: '',
     port: 0,
     isGroup: true,
@@ -20,7 +20,7 @@ const mockConnections: Connection[] = [
   {
     id: 'item1',
     name: 'Item 1',
-    protocol: 'rdp',
+    protocol: Protocol.RDP,
     hostname: 'host',
     port: 3389,
     parentId: 'group1',


### PR DESCRIPTION
## Summary
- introduce `Protocol` enum to centralize protocol strings
- update `Connection` interface to use enum type
- refactor components and tests to rely on `Protocol` values

## Testing
- `npm test` *(fails: FileTransferService activeTransfers > tracks downloads and cleans up completed entries)*

------
https://chatgpt.com/codex/tasks/task_e_68723a2dc3d48325b59997605d8dc211