### PR TITLE
Fix iteration calculation in benchmarking

### DIFF
--- a/src/utils/__tests__/settingsManager.test.ts
+++ b/src/utils/__tests__/settingsManager.test.ts
@@ -41,3 +41,16 @@ describe('SettingsManager colorScheme', () => {
     expect(loaded.colorScheme).toBe('grey');
   });
 });
+
+describe('SettingsManager.benchmarkKeyDerivation', () => {
+  it('returns a positive iteration count and logs completion', async () => {
+    const manager = SettingsManager.getInstance();
+    await manager.loadSettings();
+
+    const iterations = await manager.benchmarkKeyDerivation(0.01);
+
+    expect(iterations).toBeGreaterThan(0);
+    const [last] = manager.getActionLog();
+    expect(last.action).toBe('Key derivation benchmark completed');
+  });
+});

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -327,11 +327,7 @@ export class SettingsManager {
         break;
       }
 
-      if (duration < targetTimeSeconds) {
-        iterations = Math.floor(iterations * (targetTimeSeconds / duration));
-      } else {
-        iterations = Math.floor(iterations * (targetTimeSeconds / duration));
-      }
+      iterations = Math.floor(iterations * (targetTimeSeconds / duration));
 
       // Prevent infinite loop
       if (Math.abs(duration - lastTime) < 0.01) {


### PR DESCRIPTION
## Summary
- remove redundant `if/else` when adjusting iteration count
- add unit test for `benchmarkKeyDerivation` to verify it returns a positive value and logs completion

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68724170f488832591364ee9b060b284