### PR TITLE
Use LocalStorageService for storage access

### DIFF
--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CollectionManager } from '../collectionManager';
+import { LocalStorageService } from '../localStorageService';
 
 const sampleData = { connections: [], settings: {}, timestamp: 1 };
 
@@ -13,14 +14,14 @@ describe('CollectionManager', () => {
 
   it('creates and persists a collection', async () => {
     const col = await manager.createCollection('Test');
-    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
+    const stored = LocalStorageService.getItem<any[]>('mremote-collections')!;
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe(col.id);
     expect(stored[0].name).toBe('Test');
   });
 
   it('loads collection data', async () => {
-    localStorage.setItem('mremote-collection-abc', JSON.stringify(sampleData));
+    LocalStorageService.setItem('mremote-collection-abc', sampleData);
     const loaded = await manager.loadCollectionData('abc');
     expect(loaded).toEqual(sampleData);
   });
@@ -38,7 +39,7 @@ describe('CollectionManager', () => {
     const updated = { ...col, name: 'Updated', description: 'changed' };
     manager.updateCollection(updated);
 
-    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
+    const stored = LocalStorageService.getItem<any[]>('mremote-collections')!;
     expect(stored[0].name).toBe('Updated');
     expect(stored[0].description).toBe('changed');
   });

--- a/tests/CollectionManagerRemovePassword.test.ts
+++ b/tests/CollectionManagerRemovePassword.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CollectionManager } from '../src/utils/collectionManager';
+import { LocalStorageService } from '../src/utils/localStorageService';
+import { StorageData } from '../src/utils/storage';
+import { ConnectionCollection } from '../src/types/connection';
 
 describe('CollectionManager remove password', () => {
   let manager: CollectionManager;
@@ -15,14 +18,14 @@ describe('CollectionManager remove password', () => {
 
   it('removes encryption with correct password', async () => {
     await manager.selectCollection(collectionId, 'secret');
-    const storedBefore = localStorage.getItem(`mremote-collection-${collectionId}`)!;
-    expect(() => JSON.parse(storedBefore)).toThrow();
+    const storedBefore = LocalStorageService.getItem<string>(`mremote-collection-${collectionId}`);
+    expect(typeof storedBefore).toBe('string');
 
     await manager.removePasswordFromCollection(collectionId, 'secret');
-    const storedAfter = localStorage.getItem(`mremote-collection-${collectionId}`)!;
-    expect(JSON.parse(storedAfter)).toBeTruthy();
+    const storedAfter = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    expect(storedAfter.connections).toBeTruthy();
 
-    const meta = JSON.parse(localStorage.getItem('mremote-collections')!)[0];
+    const meta = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')![0];
     expect(meta.isEncrypted).toBe(false);
   });
 

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { CollectionSelector } from '../src/components/CollectionSelector';
 import { CollectionManager } from '../src/utils/collectionManager';
+import { LocalStorageService } from '../src/utils/localStorageService';
+import { ConnectionCollection } from '../src/types/connection';
 
 // simple i18n mock for components using react-i18next
 vi.mock('react-i18next', () => ({
@@ -11,14 +13,12 @@ vi.mock('react-i18next', () => ({
 
 describe('CollectionSelector editing', () => {
   let manager: CollectionManager;
-  let collectionId: string;
 
   beforeEach(async () => {
     localStorage.clear();
     (CollectionManager as any).instance = undefined;
     manager = CollectionManager.getInstance();
-    const col = await manager.createCollection('First', 'desc');
-    collectionId = col.id;
+    await manager.createCollection('First', 'desc');
   });
 
   it('persists edited name and description', () => {
@@ -34,7 +34,7 @@ describe('CollectionSelector editing', () => {
 
     fireEvent.click(screen.getByText('Update'));
 
-    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
+    const stored = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')!;
     expect(stored[0].name).toBe('Renamed');
     expect(stored[0].description).toBe('updated');
   });

--- a/tests/ConnectionContextAutoSave.test.tsx
+++ b/tests/ConnectionContextAutoSave.test.tsx
@@ -3,7 +3,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { ConnectionProvider, useConnections } from '../src/contexts/ConnectionContext';
 import { CollectionManager } from '../src/utils/collectionManager';
+import { LocalStorageService } from '../src/utils/localStorageService';
 import { Connection } from '../src/types/connection';
+import { StorageData } from '../src/utils/storage';
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <ConnectionProvider>{children}</ConnectionProvider>;
@@ -42,7 +44,7 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    let stored = JSON.parse(localStorage.getItem(`mremote-collection-${collectionId}`)!);
+    let stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
     expect(stored.connections).toHaveLength(1);
 
     await act(async () => {
@@ -51,7 +53,7 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    stored = JSON.parse(localStorage.getItem(`mremote-collection-${collectionId}`)!);
+    stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
     expect(stored.connections).toEqual([]);
   });
 });

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SecureStorage, StorageData } from '../src/utils/storage';
+import { LocalStorageService } from '../src/utils/localStorageService';
 
 
 describe('SecureStorage encryption', () => {
@@ -17,9 +18,9 @@ describe('SecureStorage encryption', () => {
 
     await SecureStorage.saveData(data, true);
 
-    const stored = localStorage.getItem('mremote-connections')!;
-    expect(() => JSON.parse(stored)).toThrow();
-    const meta = JSON.parse(localStorage.getItem('mremote-storage-meta')!);
+    const stored = LocalStorageService.getItem<string>('mremote-connections');
+    expect(typeof stored).toBe('string');
+    const meta = LocalStorageService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- switch collection manager and secure storage to LocalStorageService
- update related unit tests to use LocalStorageService

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_687242eb678083259fb8f27f682d7921