### PR TITLE
Add singleton reset methods

### DIFF
--- a/src/utils/__tests__/proxyManager.test.ts
+++ b/src/utils/__tests__/proxyManager.test.ts
@@ -26,7 +26,7 @@ describe('ProxyManager.createProxiedConnection', () => {
   beforeEach(() => {
     (global as any).WebSocket = MockWebSocket;
     MockWebSocket.instances = [];
-    (ProxyManager as any).instance = undefined;
+    ProxyManager.resetInstance();
     (SettingsManager as any).instance = {
       getSettings: () => ({ globalProxy: { enabled: false } }),
       logAction: vi.fn()

--- a/src/utils/__tests__/scriptEngine.test.ts
+++ b/src/utils/__tests__/scriptEngine.test.ts
@@ -11,8 +11,8 @@ beforeEach(() => {
   (global as any).window = dom.window;
   (global as any).document = dom.window.document;
   localStorage.clear();
-  (SettingsManager as any).instance = undefined;
-  (ScriptEngine as any).instance = undefined;
+  SettingsManager.resetInstance();
+  ScriptEngine.resetInstance();
 });
 
 describe('ScriptEngine.setSetting', () => {
@@ -34,7 +34,7 @@ describe('ScriptEngine.setSetting', () => {
 
     await engine.executeScript(script, { trigger: 'manual' });
 
-    (SettingsManager as any).instance = undefined;
+    SettingsManager.resetInstance();
     const again = SettingsManager.getInstance();
     const loaded = await again.loadSettings();
     expect(loaded.colorScheme).toBe('purple');

--- a/src/utils/__tests__/settingsManager.test.ts
+++ b/src/utils/__tests__/settingsManager.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   (global as any).window = dom.window;
   (global as any).document = dom.window.document;
   localStorage.clear();
-  (SettingsManager as any).instance = undefined;
+  SettingsManager.resetInstance();
 });
 
 describe('SettingsManager colorScheme', () => {
@@ -24,7 +24,7 @@ describe('SettingsManager colorScheme', () => {
     await manager.loadSettings();
     await manager.saveSettings({ colorScheme: 'green' });
 
-    (SettingsManager as any).instance = undefined;
+    SettingsManager.resetInstance();
     const again = SettingsManager.getInstance();
     const loaded = await again.loadSettings();
     expect(loaded.colorScheme).toBe('green');
@@ -35,7 +35,7 @@ describe('SettingsManager colorScheme', () => {
     await manager.loadSettings();
     await manager.saveSettings({ colorScheme: 'grey' });
 
-    (SettingsManager as any).instance = undefined;
+    SettingsManager.resetInstance();
     const again = SettingsManager.getInstance();
     const loaded = await again.loadSettings();
     expect(loaded.colorScheme).toBe('grey');

--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -15,6 +15,10 @@ export class CollectionManager {
     return CollectionManager.instance;
   }
 
+  static resetInstance(): void {
+    (CollectionManager as any).instance = undefined;
+  }
+
   async createCollection(
     name: string,
     description?: string,

--- a/src/utils/proxyManager.ts
+++ b/src/utils/proxyManager.ts
@@ -12,6 +12,10 @@ export class ProxyManager {
     return ProxyManager.instance;
   }
 
+  static resetInstance(): void {
+    (ProxyManager as any).instance = undefined;
+  }
+
   async createProxiedConnection(
     targetHost: string,
     targetPort: number,

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -13,6 +13,10 @@ export class ScriptEngine {
     return ScriptEngine.instance;
   }
 
+  static resetInstance(): void {
+    (ScriptEngine as any).instance = undefined;
+  }
+
   async executeScript(
     script: CustomScript,
     context: {

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -110,6 +110,10 @@ export class SettingsManager {
     return SettingsManager.instance;
   }
 
+  static resetInstance(): void {
+    (SettingsManager as any).instance = undefined;
+  }
+
   async loadSettings(): Promise<GlobalSettings> {
     try {
       const stored = LocalStorageService.getItem<GlobalSettings>('mremote-settings');

--- a/src/utils/statusChecker.ts
+++ b/src/utils/statusChecker.ts
@@ -14,6 +14,10 @@ export class StatusChecker {
     return StatusChecker.instance;
   }
 
+  static resetInstance(): void {
+    (StatusChecker as any).instance = undefined;
+  }
+
   startChecking(connection: Connection): void {
     if (!this.settingsManager.getSettings().enableStatusChecking) return;
     if (!connection.statusCheck?.enabled) return;

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -14,6 +14,10 @@ export class ThemeManager {
     return ThemeManager.instance;
   }
 
+  static resetInstance(): void {
+    (ThemeManager as any).instance = undefined;
+  }
+
   private themes: Record<string, ThemeConfig> = {
     dark: {
       name: 'Dark',

--- a/tests/CollectionManagerRemovePassword.test.ts
+++ b/tests/CollectionManagerRemovePassword.test.ts
@@ -7,7 +7,7 @@ describe('CollectionManager remove password', () => {
 
   beforeEach(async () => {
     localStorage.clear();
-    (CollectionManager as any).instance = undefined;
+    CollectionManager.resetInstance();
     manager = CollectionManager.getInstance();
     const col = await manager.createCollection('Secure', 'desc', true, 'secret');
     collectionId = col.id;

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -15,7 +15,7 @@ describe('CollectionSelector editing', () => {
 
   beforeEach(async () => {
     localStorage.clear();
-    (CollectionManager as any).instance = undefined;
+    CollectionManager.resetInstance();
     manager = CollectionManager.getInstance();
     const col = await manager.createCollection('First', 'desc');
     collectionId = col.id;

--- a/tests/ConnectionContextAutoSave.test.tsx
+++ b/tests/ConnectionContextAutoSave.test.tsx
@@ -15,7 +15,7 @@ describe('ConnectionProvider auto-save', () => {
 
   beforeEach(async () => {
     localStorage.clear();
-    (CollectionManager as any).instance = undefined;
+    CollectionManager.resetInstance();
     manager = CollectionManager.getInstance();
     const col = await manager.createCollection('Test');
     await manager.selectCollection(col.id);


### PR DESCRIPTION
## Summary
- add `resetInstance` to singletons
- update tests to use new reset methods

## Testing
- `npm ci`
- `npm test` *(fails to exit; pressed Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_687242d776748325bb48e0312865a381