### PR TITLE
Migrate storage to IndexedDB

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,8 +121,8 @@ const AppContent: React.FC = () => {
     setPasswordError('');
   };
 
-  const handleShowPasswordDialog = () => {
-    if (SecureStorage.isStorageEncrypted()) {
+  const handleShowPasswordDialog = async () => {
+    if (await SecureStorage.isStorageEncrypted()) {
       if (SecureStorage.isStorageUnlocked()) {
         setPasswordDialogMode('setup');
       } else {

--- a/src/components/CollectionSelector.tsx
+++ b/src/components/CollectionSelector.tsx
@@ -41,8 +41,8 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
   }, [isOpen]);
 
-  const loadCollections = () => {
-    const allCollections = collectionManager.getAllCollections();
+  const loadCollections = async () => {
+    const allCollections = await collectionManager.getAllCollections();
     setCollections(allCollections);
   };
 
@@ -150,7 +150,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     setError('');
   };
 
-  const handleUpdateCollection = () => {
+  const handleUpdateCollection = async () => {
     if (!editingCollection) return;
     if (!editingCollection.name.trim()) {
       setError('Collection name is required');
@@ -158,7 +158,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
 
     try {
-      collectionManager.updateCollection(editingCollection);
+      await collectionManager.updateCollection(editingCollection);
       setCollections(collections.map(c => c.id === editingCollection.id ? editingCollection : c));
       setEditingCollection(null);
       setError('');

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Search, Plus, FolderPlus, Settings, Download, Upload, ChevronLeft, ChevronRight, Filter, Tag, Lock, Unlock, FileText, Expand as ExpandAll, ListCollapse as CollapseAll, BarChart3, ScrollText, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionTree } from './ConnectionTree';
@@ -110,7 +110,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const isStorageUnlocked = SecureStorage.isStorageUnlocked();
-  const isStorageEncrypted = SecureStorage.isStorageEncrypted();
+  const [isStorageEncrypted, setIsStorageEncrypted] = useState(false);
+
+  useEffect(() => {
+    SecureStorage.isStorageEncrypted().then(setIsStorageEncrypted);
+  }, []);
 
   return (
     <>

--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -1,6 +1,7 @@
 import CryptoJS from 'crypto-js';
 import { ConnectionCollection } from '../types/connection';
 import { StorageData } from './storage';
+import { IndexedDbService } from './indexedDbService';
 
 export class CollectionManager {
   private static instance: CollectionManager;
@@ -31,9 +32,9 @@ export class CollectionManager {
       lastAccessed: new Date(),
     };
 
-    const collections = this.getAllCollections();
+    const collections = await this.getAllCollections();
     collections.push(collection);
-    this.saveCollections(collections);
+    await this.saveCollections(collections);
 
     // Initialize empty data for the collection
     if (isEncrypted && password) {
@@ -45,12 +46,11 @@ export class CollectionManager {
     return collection;
   }
 
-  getAllCollections(): ConnectionCollection[] {
+  async getAllCollections(): Promise<ConnectionCollection[]> {
     try {
-      const stored = localStorage.getItem(this.collectionsKey);
+      const stored = await IndexedDbService.getItem<any[]>(this.collectionsKey);
       if (stored) {
-        const collections = JSON.parse(stored);
-        return collections.map((c: any) => ({
+        return stored.map((c: any) => ({
           ...c,
           createdAt: new Date(c.createdAt),
           updatedAt: new Date(c.updatedAt),
@@ -64,13 +64,13 @@ export class CollectionManager {
     }
   }
 
-  getCollection(id: string): ConnectionCollection | null {
-    const collections = this.getAllCollections();
+  async getCollection(id: string): Promise<ConnectionCollection | null> {
+    const collections = await this.getAllCollections();
     return collections.find(c => c.id === id) || null;
   }
 
   async selectCollection(id: string, password?: string): Promise<void> {
-    const collection = this.getCollection(id);
+    const collection = await this.getCollection(id);
     if (!collection) {
       throw new Error('Collection not found');
     }
@@ -87,7 +87,7 @@ export class CollectionManager {
       
       // Update last accessed time
       collection.lastAccessed = new Date();
-      this.updateCollection(collection);
+      await this.updateCollection(collection);
     } catch (error) {
       throw new Error('Invalid password or corrupted collection data');
     }
@@ -97,12 +97,12 @@ export class CollectionManager {
     return this.currentCollection;
   }
 
-  updateCollection(collection: ConnectionCollection): void {
-    const collections = this.getAllCollections();
+  async updateCollection(collection: ConnectionCollection): Promise<void> {
+    const collections = await this.getAllCollections();
     const index = collections.findIndex(c => c.id === collection.id);
     if (index >= 0) {
       collections[index] = { ...collection, updatedAt: new Date() };
-      this.saveCollections(collections);
+      await this.saveCollections(collections);
       if (this.currentCollection?.id === collection.id) {
         this.currentCollection = { ...collections[index] };
       }
@@ -110,12 +110,12 @@ export class CollectionManager {
   }
 
   async deleteCollection(id: string): Promise<void> {
-    const collections = this.getAllCollections();
+    const collections = await this.getAllCollections();
     const filteredCollections = collections.filter(c => c.id !== id);
-    this.saveCollections(filteredCollections);
+    await this.saveCollections(filteredCollections);
 
     // Remove collection data
-    localStorage.removeItem(`mremote-collection-${id}`);
+    await IndexedDbService.removeItem(`mremote-collection-${id}`);
 
     if (this.currentCollection?.id === id) {
       this.currentCollection = null;
@@ -123,8 +123,8 @@ export class CollectionManager {
     }
   }
 
-  private saveCollections(collections: ConnectionCollection[]): void {
-    localStorage.setItem(this.collectionsKey, JSON.stringify(collections));
+  private async saveCollections(collections: ConnectionCollection[]): Promise<void> {
+    await IndexedDbService.setItem(this.collectionsKey, collections);
   }
 
   // Collection data management
@@ -134,15 +134,15 @@ export class CollectionManager {
 
     if (password) {
       const encrypted = CryptoJS.AES.encrypt(dataToStore, password).toString();
-      localStorage.setItem(key, encrypted);
+      await IndexedDbService.setItem(key, encrypted);
     } else {
-      localStorage.setItem(key, dataToStore);
+      await IndexedDbService.setItem(key, dataToStore);
     }
   }
 
   async loadCollectionData(collectionId: string, password?: string): Promise<StorageData | null> {
     const key = `mremote-collection-${collectionId}`;
-    const stored = localStorage.getItem(key);
+    const stored = await IndexedDbService.getItem<string>(key);
 
     if (!stored) return null;
 
@@ -154,7 +154,7 @@ export class CollectionManager {
         }
         return JSON.parse(decrypted);
       } else {
-        return JSON.parse(stored);
+        return typeof stored === 'string' ? JSON.parse(stored) : stored;
       }
     } catch (error) {
       throw new Error('Failed to load collection data or invalid password');
@@ -178,7 +178,7 @@ export class CollectionManager {
 
   // Export collection with encryption
   async exportCollection(collectionId: string, includePasswords: boolean = false, exportPassword?: string): Promise<string> {
-    const collection = this.getCollection(collectionId);
+    const collection = await this.getCollection(collectionId);
     if (!collection) {
       throw new Error('Collection not found');
     }
@@ -212,7 +212,7 @@ export class CollectionManager {
   }
 
   async removePasswordFromCollection(collectionId: string, password: string): Promise<void> {
-    const collection = this.getCollection(collectionId);
+    const collection = await this.getCollection(collectionId);
     if (!collection) throw new Error('Collection not found');
 
     const data = await this.loadCollectionData(collectionId, password);
@@ -220,7 +220,7 @@ export class CollectionManager {
 
     await this.saveCollectionData(collectionId, data);
     collection.isEncrypted = false;
-    this.updateCollection(collection);
+    await this.updateCollection(collection);
 
     if (this.currentCollection?.id === collectionId) {
       this.currentPassword = null;

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
 import { CollectionSelector } from '../src/components/CollectionSelector';
 import { CollectionManager } from '../src/utils/collectionManager';
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 
 // simple i18n mock for components using react-i18next
 vi.mock('react-i18next', () => ({
@@ -14,28 +17,39 @@ describe('CollectionSelector editing', () => {
   let collectionId: string;
 
   beforeEach(async () => {
-    localStorage.clear();
+    await IndexedDbService.init();
+    const db = await openDB('mremote-keyval', 1);
+    await db.clear('keyval');
     (CollectionManager as any).instance = undefined;
     manager = CollectionManager.getInstance();
     const col = await manager.createCollection('First', 'desc');
     collectionId = col.id;
   });
 
-  it('persists edited name and description', () => {
-    render(
-      <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
-    );
+  it('persists edited name and description', async () => {
+    await act(async () => {
+      render(
+        <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
+      );
+    });
 
-    fireEvent.click(screen.getByTitle('Edit'));
+    const editButton = await screen.findByTitle('Edit');
+    await act(async () => {
+      fireEvent.click(editButton);
+    });
 
     const [nameInput, descInput] = screen.getAllByRole('textbox');
-    fireEvent.change(nameInput, { target: { value: 'Renamed' } });
-    fireEvent.change(descInput, { target: { value: 'updated' } });
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'Renamed' } });
+      fireEvent.change(descInput, { target: { value: 'updated' } });
+    });
 
-    fireEvent.click(screen.getByText('Update'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Update'));
+    });
 
-    const stored = JSON.parse(localStorage.getItem('mremote-collections')!);
-    expect(stored[0].name).toBe('Renamed');
-    expect(stored[0].description).toBe('updated');
+    const stored = await IndexedDbService.getItem<any[]>('mremote-collections');
+    expect(stored![0].name).toBe('Renamed');
+    expect(stored![0].description).toBe('updated');
   });
 });

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SecureStorage, StorageData } from '../src/utils/storage';
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 
 
 describe('SecureStorage encryption', () => {
-  beforeEach(() => {
-    localStorage.clear();
+  beforeEach(async () => {
+    await IndexedDbService.init();
+    const db = await openDB('mremote-keyval', 1);
+    await db.clear('keyval');
     SecureStorage.setPassword('secret');
   });
 
@@ -17,9 +22,9 @@ describe('SecureStorage encryption', () => {
 
     await SecureStorage.saveData(data, true);
 
-    const stored = localStorage.getItem('mremote-connections')!;
-    expect(() => JSON.parse(stored)).toThrow();
-    const meta = JSON.parse(localStorage.getItem('mremote-storage-meta')!);
+    const stored = await IndexedDbService.getItem<string>('mremote-connections');
+    expect(() => JSON.parse(stored!)).toThrow();
+    const meta = await IndexedDbService.getItem<any>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace localStorage API calls with IndexedDBService in SecureStorage
- store collections in IndexedDB via CollectionManager
- adapt UI components and tests for async storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872467cd79883259db30cefd1c7c8f0