### PR TITLE
Add fake-indexeddb and await storage ops in tests

### DIFF
--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -14,14 +14,14 @@ describe('CollectionManager', () => {
 
   it('creates and persists a collection', async () => {
     const col = await manager.createCollection('Test');
-    const stored = LocalStorageService.getItem<any[]>('mremote-collections')!;
+    const stored = await LocalStorageService.getItem<any[]>('mremote-collections');
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe(col.id);
     expect(stored[0].name).toBe('Test');
   });
 
   it('loads collection data', async () => {
-    LocalStorageService.setItem('mremote-collection-abc', sampleData);
+    await LocalStorageService.setItem('mremote-collection-abc', sampleData);
     const loaded = await manager.loadCollectionData('abc');
     expect(loaded).toEqual(sampleData);
   });
@@ -39,7 +39,7 @@ describe('CollectionManager', () => {
     const updated = { ...col, name: 'Updated', description: 'changed' };
     manager.updateCollection(updated);
 
-    const stored = LocalStorageService.getItem<any[]>('mremote-collections')!;
+    const stored = await LocalStorageService.getItem<any[]>('mremote-collections');
     expect(stored[0].name).toBe('Updated');
     expect(stored[0].description).toBe('changed');
   });

--- a/src/utils/__tests__/fileTransferService.test.ts
+++ b/src/utils/__tests__/fileTransferService.test.ts
@@ -36,10 +36,12 @@ describe('FileTransferService activeTransfers', () => {
     // jsdom does not implement URL.createObjectURL so mock it
     const originalCreate = URL.createObjectURL;
     const originalRevoke = URL.revokeObjectURL;
+    const originalClick = HTMLAnchorElement.prototype.click;
     // @ts-ignore
     URL.createObjectURL = vi.fn(() => 'blob:mock');
     // @ts-ignore
     URL.revokeObjectURL = vi.fn();
+    HTMLAnchorElement.prototype.click = vi.fn();
 
     const promise = service.downloadFile('c2', '/remote/file.bin', 'file.bin');
 
@@ -59,5 +61,6 @@ describe('FileTransferService activeTransfers', () => {
     // restore URL functions
     URL.createObjectURL = originalCreate;
     URL.revokeObjectURL = originalRevoke;
-  });
+    HTMLAnchorElement.prototype.click = originalClick;
+  }, 10000);
 });

--- a/src/utils/__tests__/localStorageService.test.ts
+++ b/src/utils/__tests__/localStorageService.test.ts
@@ -6,16 +6,16 @@ beforeEach(() => {
 });
 
 describe('LocalStorageService', () => {
-  it('stores and retrieves objects', () => {
+  it('stores and retrieves objects', async () => {
     const value = { a: 1, b: 'two' };
-    LocalStorageService.setItem('obj', value);
-    const result = LocalStorageService.getItem<typeof value>('obj');
+    await LocalStorageService.setItem('obj', value);
+    const result = await LocalStorageService.getItem<typeof value>('obj');
     expect(result).toEqual(value);
   });
 
-  it('returns null for invalid JSON', () => {
+  it('returns null for invalid JSON', async () => {
     localStorage.setItem('bad', 'notjson');
-    const result = LocalStorageService.getItem('bad');
+    const result = await LocalStorageService.getItem('bad');
     expect(result).toBeNull();
   });
 });

--- a/tests/CollectionManagerRemovePassword.test.ts
+++ b/tests/CollectionManagerRemovePassword.test.ts
@@ -18,14 +18,20 @@ describe('CollectionManager remove password', () => {
 
   it('removes encryption with correct password', async () => {
     await manager.selectCollection(collectionId, 'secret');
-    const storedBefore = LocalStorageService.getItem<string>(`mremote-collection-${collectionId}`);
+    const storedBefore = await LocalStorageService.getItem<string>(
+      `mremote-collection-${collectionId}`
+    );
     expect(typeof storedBefore).toBe('string');
 
     await manager.removePasswordFromCollection(collectionId, 'secret');
-    const storedAfter = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    const storedAfter = await LocalStorageService.getItem<StorageData>(
+      `mremote-collection-${collectionId}`
+    );
     expect(storedAfter.connections).toBeTruthy();
 
-    const meta = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')![0];
+    const meta = (await LocalStorageService.getItem<ConnectionCollection[]>(
+      'mremote-collections'
+    ))![0];
     expect(meta.isEncrypted).toBe(false);
   });
 

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -21,7 +21,7 @@ describe('CollectionSelector editing', () => {
     await manager.createCollection('First', 'desc');
   });
 
-  it('persists edited name and description', () => {
+  it('persists edited name and description', async () => {
     render(
       <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
     );
@@ -34,7 +34,7 @@ describe('CollectionSelector editing', () => {
 
     fireEvent.click(screen.getByText('Update'));
 
-    const stored = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')!;
+    const stored = await LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections');
     expect(stored[0].name).toBe('Renamed');
     expect(stored[0].description).toBe('updated');
   });

--- a/tests/ConnectionContextAutoSave.test.tsx
+++ b/tests/ConnectionContextAutoSave.test.tsx
@@ -44,7 +44,9 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    let stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    let stored = await LocalStorageService.getItem<StorageData>(
+      `mremote-collection-${collectionId}`
+    );
     expect(stored.connections).toHaveLength(1);
 
     await act(async () => {
@@ -53,7 +55,9 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    stored = await LocalStorageService.getItem<StorageData>(
+      `mremote-collection-${collectionId}`
+    );
     expect(stored.connections).toEqual([]);
   });
 });

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -18,9 +18,9 @@ describe('SecureStorage encryption', () => {
 
     await SecureStorage.saveData(data, true);
 
-    const stored = LocalStorageService.getItem<string>('mremote-connections');
+    const stored = await LocalStorageService.getItem<string>('mremote-connections');
     expect(typeof stored).toBe('string');
-    const meta = LocalStorageService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
+    const meta = await LocalStorageService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom';
+// Provide a browser-like IndexedDB implementation for tests
+import 'fake-indexeddb/auto';


### PR DESCRIPTION
## Summary
- mock IndexedDB globally using `fake-indexeddb`
- await storage service calls in unit tests
- stub download link click for FileTransferService tests

## Testing
- `npx vitest run`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68724951b2dc8325b92d20229039b884