### PR TITLE
Switch storage to IndexedDB

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,8 +121,8 @@ const AppContent: React.FC = () => {
     setPasswordError('');
   };
 
-  const handleShowPasswordDialog = () => {
-    if (SecureStorage.isStorageEncrypted()) {
+  const handleShowPasswordDialog = async () => {
+    if (await SecureStorage.isStorageEncrypted()) {
       if (SecureStorage.isStorageUnlocked()) {
         setPasswordDialogMode('setup');
       } else {

--- a/src/components/CollectionSelector.tsx
+++ b/src/components/CollectionSelector.tsx
@@ -41,8 +41,8 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
   }, [isOpen]);
 
-  const loadCollections = () => {
-    const allCollections = collectionManager.getAllCollections();
+  const loadCollections = async () => {
+    const allCollections = await collectionManager.getAllCollections();
     setCollections(allCollections);
   };
 
@@ -150,7 +150,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     setError('');
   };
 
-  const handleUpdateCollection = () => {
+  const handleUpdateCollection = async () => {
     if (!editingCollection) return;
     if (!editingCollection.name.trim()) {
       setError('Collection name is required');
@@ -158,7 +158,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
 
     try {
-      collectionManager.updateCollection(editingCollection);
+      await collectionManager.updateCollection(editingCollection);
       setCollections(collections.map(c => c.id === editingCollection.id ? editingCollection : c));
       setEditingCollection(null);
       setError('');

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Search, Plus, FolderPlus, Settings, Download, Upload, ChevronLeft, ChevronRight, Filter, Tag, Lock, Unlock, FileText, Expand as ExpandAll, ListCollapse as CollapseAll, BarChart3, ScrollText, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionTree } from './ConnectionTree';
@@ -110,7 +110,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const isStorageUnlocked = SecureStorage.isStorageUnlocked();
-  const isStorageEncrypted = SecureStorage.isStorageEncrypted();
+  const [isStorageEncrypted, setIsStorageEncrypted] = useState(false);
+
+  useEffect(() => {
+    SecureStorage.isStorageEncrypted().then(setIsStorageEncrypted);
+  }, []);
 
   return (
     <>

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -5,6 +5,7 @@ const STORAGE_META_KEY = 'mremote-storage-meta';
 const OLD_STORAGE_META_KEY = 'mremote-settings';
 
 import { Connection } from '../types/connection';
+import { IndexedDbService } from './indexedDbService';
 import { LocalStorageService } from './localStorageService';
 
 export interface StorageData {
@@ -18,10 +19,11 @@ export class SecureStorage {
   private static isUnlocked: boolean = false;
 
   // Migrate old metadata key to the new one if needed
-  private static migrateMetaKey(): void {
+  private static async migrateMetaKey(): Promise<void> {
     const oldData = LocalStorageService.getItem<any>(OLD_STORAGE_META_KEY);
-    if (oldData && !LocalStorageService.getItem(STORAGE_META_KEY)) {
-      LocalStorageService.setItem(STORAGE_META_KEY, oldData);
+    const existing = await IndexedDbService.getItem(STORAGE_META_KEY);
+    if (oldData && !existing) {
+      await IndexedDbService.setItem(STORAGE_META_KEY, oldData);
       LocalStorageService.removeItem(OLD_STORAGE_META_KEY);
     }
   }
@@ -44,13 +46,13 @@ export class SecureStorage {
     return this.isUnlocked;
   }
 
-  static hasStoredData(): boolean {
-    return LocalStorageService.getItem(STORAGE_KEY) !== null;
+  static async hasStoredData(): Promise<boolean> {
+    return (await IndexedDbService.getItem(STORAGE_KEY)) !== null;
   }
 
-  static isStorageEncrypted(): boolean {
-    this.migrateMetaKey();
-    const settings = LocalStorageService.getItem<any>(STORAGE_META_KEY);
+  static async isStorageEncrypted(): Promise<boolean> {
+    await this.migrateMetaKey();
+    const settings = await IndexedDbService.getItem<any>(STORAGE_META_KEY);
     if (settings) {
       try {
         return settings.isEncrypted === true;
@@ -67,17 +69,17 @@ export class SecureStorage {
 
       if (usePassword && this.password) {
         const encrypted = CryptoJS.AES.encrypt(serialized, this.password).toString();
-        this.migrateMetaKey();
-        LocalStorageService.setItem(STORAGE_KEY, encrypted);
-        LocalStorageService.setItem(STORAGE_META_KEY, {
+        await this.migrateMetaKey();
+        await IndexedDbService.setItem(STORAGE_KEY, encrypted);
+        await IndexedDbService.setItem(STORAGE_META_KEY, {
           isEncrypted: true,
           hasPassword: true,
           timestamp: Date.now()
         });
       } else {
-        this.migrateMetaKey();
-        LocalStorageService.setItem(STORAGE_KEY, data);
-        LocalStorageService.setItem(STORAGE_META_KEY, {
+        await this.migrateMetaKey();
+        await IndexedDbService.setItem(STORAGE_KEY, data);
+        await IndexedDbService.setItem(STORAGE_META_KEY, {
           isEncrypted: false,
           hasPassword: false,
           timestamp: Date.now()
@@ -90,9 +92,9 @@ export class SecureStorage {
 
   static async loadData(): Promise<StorageData | null> {
     try {
-      this.migrateMetaKey();
-      const storedData = LocalStorageService.getItem<any>(STORAGE_KEY);
-      const settings = LocalStorageService.getItem<any>(STORAGE_META_KEY);
+      await this.migrateMetaKey();
+      const storedData = await IndexedDbService.getItem<any>(STORAGE_KEY);
+      const settings = await IndexedDbService.getItem<any>(STORAGE_META_KEY);
       
       if (!storedData) return null;
 
@@ -113,10 +115,10 @@ export class SecureStorage {
     }
   }
 
-  static clearStorage(): void {
-    this.migrateMetaKey();
-    LocalStorageService.removeItem(STORAGE_KEY);
-    LocalStorageService.removeItem(STORAGE_META_KEY);
+  static async clearStorage(): Promise<void> {
+    await this.migrateMetaKey();
+    await IndexedDbService.removeItem(STORAGE_KEY);
+    await IndexedDbService.removeItem(STORAGE_META_KEY);
     this.clearPassword();
   }
 }

--- a/tests/CollectionManagerRemovePassword.test.ts
+++ b/tests/CollectionManagerRemovePassword.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CollectionManager } from '../src/utils/collectionManager';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import 'fake-indexeddb/auto';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 import { StorageData } from '../src/utils/storage';
 import { ConnectionCollection } from '../src/types/connection';
 
@@ -18,14 +19,14 @@ describe('CollectionManager remove password', () => {
 
   it('removes encryption with correct password', async () => {
     await manager.selectCollection(collectionId, 'secret');
-    const storedBefore = LocalStorageService.getItem<string>(`mremote-collection-${collectionId}`);
+    const storedBefore = await IndexedDbService.getItem<string>(`mremote-collection-${collectionId}`);
     expect(typeof storedBefore).toBe('string');
 
     await manager.removePasswordFromCollection(collectionId, 'secret');
-    const storedAfter = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    const storedAfter = await IndexedDbService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
     expect(storedAfter.connections).toBeTruthy();
 
-    const meta = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')![0];
+    const meta = (await IndexedDbService.getItem<ConnectionCollection[]>('mremote-collections'))![0];
     expect(meta.isEncrypted).toBe(false);
   });
 

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { CollectionSelector } from '../src/components/CollectionSelector';
 import { CollectionManager } from '../src/utils/collectionManager';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import 'fake-indexeddb/auto';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 import { ConnectionCollection } from '../src/types/connection';
 
 // simple i18n mock for components using react-i18next
@@ -21,21 +22,24 @@ describe('CollectionSelector editing', () => {
     await manager.createCollection('First', 'desc');
   });
 
-  it('persists edited name and description', () => {
+  it('persists edited name and description', async () => {
     render(
       <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
     );
 
-    fireEvent.click(screen.getByTitle('Edit'));
+    const editButton = await screen.findByTitle('Edit');
+    fireEvent.click(editButton);
+    await Promise.resolve();
 
     const [nameInput, descInput] = screen.getAllByRole('textbox');
     fireEvent.change(nameInput, { target: { value: 'Renamed' } });
     fireEvent.change(descInput, { target: { value: 'updated' } });
 
     fireEvent.click(screen.getByText('Update'));
-
-    const stored = LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections')!;
-    expect(stored[0].name).toBe('Renamed');
-    expect(stored[0].description).toBe('updated');
+    await waitFor(async () => {
+      const stored = await IndexedDbService.getItem<ConnectionCollection[]>('mremote-collections');
+      expect(stored![0].name).toBe('Renamed');
+      expect(stored![0].description).toBe('updated');
+    });
   });
 });

--- a/tests/ConnectionContextAutoSave.test.tsx
+++ b/tests/ConnectionContextAutoSave.test.tsx
@@ -3,7 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { ConnectionProvider, useConnections } from '../src/contexts/ConnectionContext';
 import { CollectionManager } from '../src/utils/collectionManager';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import 'fake-indexeddb/auto';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 import { Connection } from '../src/types/connection';
 import { StorageData } from '../src/utils/storage';
 
@@ -44,7 +45,7 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    let stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    let stored = await IndexedDbService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
     expect(stored.connections).toHaveLength(1);
 
     await act(async () => {
@@ -53,7 +54,7 @@ describe('ConnectionProvider auto-save', () => {
 
     await Promise.resolve();
 
-    stored = LocalStorageService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
+    stored = await IndexedDbService.getItem<StorageData>(`mremote-collection-${collectionId}`)!;
     expect(stored.connections).toEqual([]);
   });
 });

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SecureStorage, StorageData } from '../src/utils/storage';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import 'fake-indexeddb/auto';
+import { IndexedDbService } from '../src/utils/indexedDbService';
 
 
 describe('SecureStorage encryption', () => {
@@ -18,9 +19,9 @@ describe('SecureStorage encryption', () => {
 
     await SecureStorage.saveData(data, true);
 
-    const stored = LocalStorageService.getItem<string>('mremote-connections');
+    const stored = await IndexedDbService.getItem<string>('mremote-connections');
     expect(typeof stored).toBe('string');
-    const meta = LocalStorageService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
+    const meta = await IndexedDbService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- use `IndexedDbService` for encrypted storage
- update collection manager to persist collections in IndexedDB
- adjust components and tests for async storage APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68724d5df0648325bea6ce98c5fb6cd8