### PR TITLE
Switch storage to IndexedDB

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,8 +121,8 @@ const AppContent: React.FC = () => {
     setPasswordError('');
   };
 
-  const handleShowPasswordDialog = () => {
-    if (SecureStorage.isStorageEncrypted()) {
+  const handleShowPasswordDialog = async () => {
+    if (await SecureStorage.isStorageEncrypted()) {
       if (SecureStorage.isStorageUnlocked()) {
         setPasswordDialogMode('setup');
       } else {

--- a/src/components/CollectionSelector.tsx
+++ b/src/components/CollectionSelector.tsx
@@ -41,8 +41,8 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
   }, [isOpen]);
 
-  const loadCollections = () => {
-    const allCollections = collectionManager.getAllCollections();
+  const loadCollections = async () => {
+    const allCollections = await collectionManager.getAllCollections();
     setCollections(allCollections);
   };
 
@@ -150,7 +150,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     setError('');
   };
 
-  const handleUpdateCollection = () => {
+  const handleUpdateCollection = async () => {
     if (!editingCollection) return;
     if (!editingCollection.name.trim()) {
       setError('Collection name is required');
@@ -158,7 +158,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
     }
 
     try {
-      collectionManager.updateCollection(editingCollection);
+      await collectionManager.updateCollection(editingCollection);
       setCollections(collections.map(c => c.id === editingCollection.id ? editingCollection : c));
       setEditingCollection(null);
       setError('');

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Search, Plus, FolderPlus, Settings, Download, Upload, ChevronLeft, ChevronRight, Filter, Tag, Lock, Unlock, FileText, Expand as ExpandAll, ListCollapse as CollapseAll, BarChart3, ScrollText, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionTree } from './ConnectionTree';
@@ -110,7 +110,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const isStorageUnlocked = SecureStorage.isStorageUnlocked();
-  const isStorageEncrypted = SecureStorage.isStorageEncrypted();
+  const [isStorageEncrypted, setIsStorageEncrypted] = useState(false);
+
+  useEffect(() => {
+    SecureStorage.isStorageEncrypted().then(setIsStorageEncrypted);
+  }, []);
 
   return (
     <>

--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -1,27 +1,33 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CollectionManager } from '../collectionManager';
-import { LocalStorageService } from '../localStorageService';
+import { IndexedDbService } from '../indexedDbService';
+import { openDB } from 'idb';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
 
 const sampleData = { connections: [], settings: {}, timestamp: 1 };
 
 describe('CollectionManager', () => {
   let manager: CollectionManager;
 
-  beforeEach(() => {
-    localStorage.clear();
+  beforeEach(async () => {
+    await IndexedDbService.init();
+    const db = await openDB(DB_NAME, 1);
+    await db.clear(STORE_NAME);
     manager = new CollectionManager();
   });
 
   it('creates and persists a collection', async () => {
     const col = await manager.createCollection('Test');
-    const stored = await LocalStorageService.getItem<any[]>('mremote-collections');
+    const stored = await IndexedDbService.getItem<any[]>('mremote-collections');
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe(col.id);
     expect(stored[0].name).toBe('Test');
   });
 
   it('loads collection data', async () => {
-    await LocalStorageService.setItem('mremote-collection-abc', sampleData);
+    await IndexedDbService.setItem('mremote-collection-abc', sampleData);
     const loaded = await manager.loadCollectionData('abc');
     expect(loaded).toEqual(sampleData);
   });
@@ -37,9 +43,9 @@ describe('CollectionManager', () => {
   it('updates and persists changes to a collection', async () => {
     const col = await manager.createCollection('Initial', 'desc');
     const updated = { ...col, name: 'Updated', description: 'changed' };
-    manager.updateCollection(updated);
+    await manager.updateCollection(updated);
 
-    const stored = await LocalStorageService.getItem<any[]>('mremote-collections');
+    const stored = await IndexedDbService.getItem<any[]>('mremote-collections');
     expect(stored[0].name).toBe('Updated');
     expect(stored[0].description).toBe('changed');
   });
@@ -48,7 +54,7 @@ describe('CollectionManager', () => {
     const col = await manager.createCollection('A');
     await manager.selectCollection(col.id);
     const updated = { ...col, name: 'B' };
-    manager.updateCollection(updated);
+    await manager.updateCollection(updated);
     expect(manager.getCurrentCollection()?.name).toBe('B');
   });
 });

--- a/tests/CollectionSelectorEdit.test.tsx
+++ b/tests/CollectionSelectorEdit.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { CollectionSelector } from '../src/components/CollectionSelector';
 import { CollectionManager } from '../src/utils/collectionManager';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import { IndexedDbService } from '../src/utils/indexedDbService';
+import { openDB } from 'idb';
 import { ConnectionCollection } from '../src/types/connection';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
 
 // simple i18n mock for components using react-i18next
 vi.mock('react-i18next', () => ({
@@ -15,7 +19,9 @@ describe('CollectionSelector editing', () => {
   let manager: CollectionManager;
 
   beforeEach(async () => {
-    localStorage.clear();
+    await IndexedDbService.init();
+    const db = await openDB(DB_NAME, 1);
+    await db.clear(STORE_NAME);
     CollectionManager.resetInstance();
     manager = CollectionManager.getInstance();
     await manager.createCollection('First', 'desc');
@@ -26,7 +32,7 @@ describe('CollectionSelector editing', () => {
       <CollectionSelector isOpen onCollectionSelect={() => {}} onClose={() => {}} />
     );
 
-    fireEvent.click(screen.getByTitle('Edit'));
+    fireEvent.click(await screen.findByTitle('Edit'));
 
     const [nameInput, descInput] = screen.getAllByRole('textbox');
     fireEvent.change(nameInput, { target: { value: 'Renamed' } });
@@ -34,8 +40,10 @@ describe('CollectionSelector editing', () => {
 
     fireEvent.click(screen.getByText('Update'));
 
-    const stored = await LocalStorageService.getItem<ConnectionCollection[]>('mremote-collections');
-    expect(stored[0].name).toBe('Renamed');
-    expect(stored[0].description).toBe('updated');
+    await waitFor(async () => {
+      const stored = await IndexedDbService.getItem<ConnectionCollection[]>('mremote-collections');
+      expect(stored[0].name).toBe('Renamed');
+      expect(stored[0].description).toBe('updated');
+    });
   });
 });

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { SecureStorage, StorageData } from '../src/utils/storage';
-import { LocalStorageService } from '../src/utils/localStorageService';
+import { IndexedDbService } from '../src/utils/indexedDbService';
+import { openDB } from 'idb';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
 
 
 describe('SecureStorage encryption', () => {
-  beforeEach(() => {
-    localStorage.clear();
+  beforeEach(async () => {
+    await IndexedDbService.init();
+    const db = await openDB(DB_NAME, 1);
+    await db.clear(STORE_NAME);
     SecureStorage.setPassword('secret');
   });
 
@@ -18,9 +24,9 @@ describe('SecureStorage encryption', () => {
 
     await SecureStorage.saveData(data, true);
 
-    const stored = await LocalStorageService.getItem<string>('mremote-connections');
+    const stored = await IndexedDbService.getItem<string>('mremote-connections');
     expect(typeof stored).toBe('string');
-    const meta = await LocalStorageService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
+    const meta = await IndexedDbService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace LocalStorageService with IndexedDbService
- store collections in IndexedDB instead of localStorage
- update components and tests for async storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872525c8b9883258de3d160e053fb46