### PR TITLE
Add optional host to testProxy

### DIFF
--- a/src/utils/proxyManager.ts
+++ b/src/utils/proxyManager.ts
@@ -127,11 +127,12 @@ export class ProxyManager {
   }
 
   // Test proxy connectivity
-  async testProxy(proxy: ProxyConfig): Promise<boolean> {
+  async testProxy(
+    proxy: ProxyConfig,
+    testHost = 'httpbin.org',
+    testPort = 80
+  ): Promise<boolean> {
     try {
-      const testHost = 'httpbin.org';
-      const testPort = 80;
-      
       const ws = await this.createProxiedConnection(testHost, testPort, proxy);
       ws.close();
       


### PR DESCRIPTION
## Summary
- allow providing custom host/port when testing proxies
- exercise `testProxy` with mocked connections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b2b785b48325bc119fd9a4e129f4