### PR TITLE
Add IndexedDB migration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,3 +32,11 @@ All code should pass ESLint before committing.
 ## Appearance
 
 The interface supports selectable color schemes (blue, green, purple, red, orange and teal). Use the settings dialog to choose your preferred scheme.
+
+## Data Storage and Migration
+
+sortOfRemoteNG now stores all persistent data in IndexedDB. When the application
+starts, it checks for any `mremote-` keys in `localStorage` and moves them into
+IndexedDB. After migration these keys are removed from `localStorage`.
+Ensure your browser supports IndexedDB so settings and collections can be
+preserved across sessions.

--- a/src/utils/__tests__/indexedDbService.test.ts
+++ b/src/utils/__tests__/indexedDbService.test.ts
@@ -10,6 +10,9 @@ beforeEach(async () => {
   await IndexedDbService.init();
   const db = await openDB(DB_NAME, 1);
   await db.clear(STORE_NAME);
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear();
+  }
 });
 
 describe('IndexedDbService', () => {
@@ -25,5 +28,21 @@ describe('IndexedDbService', () => {
     await db.put(STORE_NAME, 'notjson', 'bad');
     const result = await IndexedDbService.getItem('bad');
     expect(result).toBeNull();
+  });
+
+  it('migrates data from localStorage on init', async () => {
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+    (global as any).window = dom.window;
+    (global as any).document = dom.window.document;
+    (global as any).localStorage = dom.window.localStorage;
+
+    localStorage.setItem('mremote-test', JSON.stringify({ foo: 'bar' }));
+
+    await IndexedDbService.init();
+
+    const migrated = await IndexedDbService.getItem<{ foo: string }>('mremote-test');
+    expect(migrated).toEqual({ foo: 'bar' });
+    expect(localStorage.getItem('mremote-test')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- move all persistent storage to IndexedDB
- migrate any existing mremote-keys from localStorage on init
- document the new migration behaviour
- test migration logic

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68743181bd5c83259c3fb7cbc546f75d