### PR TITLE
Refactor storage save to migrate meta earlier

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -63,11 +63,11 @@ export class SecureStorage {
 
   static async saveData(data: StorageData, usePassword: boolean = false): Promise<void> {
     try {
-      const serialized = JSON.stringify(data);
+      await this.migrateMetaKey();
 
       if (usePassword && this.password) {
+        const serialized = JSON.stringify(data);
         const encrypted = CryptoJS.AES.encrypt(serialized, this.password).toString();
-        await this.migrateMetaKey();
         await IndexedDbService.setItem(STORAGE_KEY, encrypted);
         await IndexedDbService.setItem(STORAGE_META_KEY, {
           isEncrypted: true,
@@ -75,7 +75,6 @@ export class SecureStorage {
           timestamp: Date.now()
         });
       } else {
-        await this.migrateMetaKey();
         await IndexedDbService.setItem(STORAGE_KEY, data);
         await IndexedDbService.setItem(STORAGE_META_KEY, {
           isEncrypted: false,


### PR DESCRIPTION
## Summary
- Move metadata migration ahead of encryption branch
- Only serialize data when encryption is used

## Testing
- `npm test` *(fails: FileTransferService activeTransfers > tracks downloads and cleans up completed entries – Test timed out in 10000ms)*
- `npm run lint` *(fails: 184 problems (161 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689b6228c5308325a37bec32d1b0a004