### PR TITLE
Require password for loading encrypted data

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -97,7 +97,10 @@ export class SecureStorage {
 
       if (settings) {
         const parsedSettings = settings;
-        if (parsedSettings.isEncrypted && this.password) {
+        if (parsedSettings.isEncrypted) {
+          if (!this.password) {
+            throw new Error('Password is required');
+          }
           const decrypted = CryptoJS.AES.decrypt(storedData as string, this.password).toString(CryptoJS.enc.Utf8);
           if (!decrypted) {
             throw new Error('Invalid password');
@@ -107,7 +110,10 @@ export class SecureStorage {
       }
 
       return storedData as StorageData;
-    } catch {
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
       throw new Error('Failed to load data or invalid password');
     }
   }

--- a/tests/SecureStorageLoadData.test.ts
+++ b/tests/SecureStorageLoadData.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SecureStorage, StorageData } from '../src/utils/storage';
+import { IndexedDbService } from '../src/utils/indexedDbService';
+import { openDB } from 'idb';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
+
+describe('SecureStorage loadData', () => {
+  beforeEach(async () => {
+    await IndexedDbService.init();
+    const db = await openDB(DB_NAME, 1);
+    await db.clear(STORE_NAME);
+    SecureStorage.clearPassword();
+  });
+
+  it('returns stored data when not encrypted', async () => {
+    const data: StorageData = { connections: [], settings: {}, timestamp: Date.now() };
+    await SecureStorage.saveData(data, false);
+    const loaded = await SecureStorage.loadData();
+    expect(loaded).toEqual(data);
+  });
+
+  it('returns decrypted data when password is set', async () => {
+    const data: StorageData = { connections: [], settings: {}, timestamp: Date.now() };
+    SecureStorage.setPassword('secret');
+    await SecureStorage.saveData(data, true);
+    const loaded = await SecureStorage.loadData();
+    expect(loaded).toEqual(data);
+  });
+
+  it('throws error when encrypted data loaded without password', async () => {
+    const data: StorageData = { connections: [], settings: {}, timestamp: Date.now() };
+    SecureStorage.setPassword('secret');
+    await SecureStorage.saveData(data, true);
+    SecureStorage.clearPassword();
+    await expect(SecureStorage.loadData()).rejects.toThrow('Password is required');
+  });
+});


### PR DESCRIPTION
## Summary
- throw explicit error when attempting to load encrypted data without a password
- return stored data only when unencrypted or successfully decrypted
- add tests covering loadData behavior for encrypted and unencrypted cases

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689b64edc84c83259dc180711aab5e16