### PR TITLE
fix: robust singleton instance handling

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -3,18 +3,18 @@ import { Connection, ConnectionSession } from '../types/connection';
 import { SettingsManager } from './settingsManager';
 
 export class ScriptEngine {
-  private static instance: ScriptEngine;
+  private static instance: ScriptEngine | null = null;
   private settingsManager = SettingsManager.getInstance();
 
   static getInstance(): ScriptEngine {
-    if (!ScriptEngine.instance) {
+    if (ScriptEngine.instance === null) {
       ScriptEngine.instance = new ScriptEngine();
     }
     return ScriptEngine.instance;
   }
 
   static resetInstance(): void {
-    (ScriptEngine as any).instance = undefined;
+    ScriptEngine.instance = null;
   }
 
   async executeScript(

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -97,21 +97,21 @@ const DEFAULT_SETTINGS: GlobalSettings = {
 };
 
 export class SettingsManager {
-  private static instance: SettingsManager;
+  private static instance: SettingsManager | null = null;
   private settings: GlobalSettings = DEFAULT_SETTINGS;
   private actionLog: ActionLogEntry[] = [];
   private performanceMetrics: PerformanceMetrics[] = [];
   private customScripts: CustomScript[] = [];
 
   static getInstance(): SettingsManager {
-    if (!SettingsManager.instance) {
+    if (SettingsManager.instance === null) {
       SettingsManager.instance = new SettingsManager();
     }
     return SettingsManager.instance;
   }
 
   static resetInstance(): void {
-    (SettingsManager as any).instance = undefined;
+    SettingsManager.instance = null;
   }
 
   async loadSettings(): Promise<GlobalSettings> {

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -2,20 +2,20 @@ import { ThemeConfig, Theme, ColorScheme } from '../types/settings';
 import { IndexedDbService } from './indexedDbService';
 
 export class ThemeManager {
-  private static instance: ThemeManager;
+  private static instance: ThemeManager | null = null;
   private currentTheme: Theme = 'dark';
   private currentColorScheme: ColorScheme = 'blue';
   private systemThemeStop?: () => void;
 
   static getInstance(): ThemeManager {
-    if (!ThemeManager.instance) {
+    if (ThemeManager.instance === null) {
       ThemeManager.instance = new ThemeManager();
     }
     return ThemeManager.instance;
   }
 
   static resetInstance(): void {
-    (ThemeManager as any).instance = undefined;
+    ThemeManager.instance = null;
   }
 
   private themes: Record<string, ThemeConfig> = {


### PR DESCRIPTION
## Summary
- initialize singleton managers with null instance
- simplify getInstance and resetInstance methods for SettingsManager, ThemeManager, and ScriptEngine

## Testing
- `npm run lint` (fails: Unexpected any)
- `npm test` (fails: FileTransferService activeTransfers test timeout)


------
https://chatgpt.com/codex/tasks/task_e_689b8cd6a5f083259b40418337be01ef