### PR TITLE
Validate CIDR network parts

### DIFF
--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -54,7 +54,20 @@ export class NetworkScanner {
       throw new Error('Only /24 to /30 networks are supported');
     }
 
-    const networkParts = network.split('.').map(Number);
+    const networkPartsRaw = network.split('.');
+    if (networkPartsRaw.length !== 4) {
+      throw new Error(`Invalid network address in CIDR: ${cidr}`);
+    }
+    const networkParts = networkPartsRaw.map(part => {
+      if (!/^\d+$/.test(part)) {
+        throw new Error(`Invalid network address in CIDR: ${cidr}`);
+      }
+      const num = Number(part);
+      if (num < 0 || num > 255) {
+        throw new Error(`Invalid network address in CIDR: ${cidr}`);
+      }
+      return num;
+    });
     const hostBits = 32 - prefix;
     const hostCount = Math.pow(2, hostBits) - 2; // Exclude network and broadcast
     


### PR DESCRIPTION
## Summary
- ensure network addresses in CIDR notation have four parts and each octet is 0-255

## Testing
- `npm test -- --run` *(fails: FileTransferService activeTransfers tracks downloads and cleans up completed entries)*

------
https://chatgpt.com/codex/tasks/task_e_689b8cd853908325a6981f16c73a0468