### PR TITLE
Use crypto API for TOTP backup codes

### DIFF
--- a/src/utils/totpService.ts
+++ b/src/utils/totpService.ts
@@ -99,12 +99,26 @@ export class TOTPService {
   // Backup codes generation
   generateBackupCodes(count: number = 10): string[] {
     const codes: string[] = [];
-    
+
+    const globalCrypto = globalThis.crypto as Crypto | undefined;
+    const useCrypto = globalCrypto && typeof globalCrypto.getRandomValues === 'function';
+
     for (let i = 0; i < count; i++) {
-      const code = Math.random().toString(36).substring(2, 10).toUpperCase();
+      let code: string;
+      if (useCrypto) {
+        const randomValues = new Uint32Array(8);
+        globalCrypto!.getRandomValues(randomValues);
+        code = Array.from(randomValues, n => (n % 36).toString(36))
+          .join('')
+          .slice(0, 8)
+          .toUpperCase();
+      } else {
+        console.warn('crypto.getRandomValues is not available; using insecure Math.random.');
+        code = Math.random().toString(36).substring(2, 10).toUpperCase();
+      }
       codes.push(code);
     }
-    
+
     return codes;
   }
 

--- a/tests/totpService.test.ts
+++ b/tests/totpService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { authenticator } from 'otplib';
 import { TOTPService } from '../src/utils/totpService';
 
@@ -11,6 +11,10 @@ describe('TOTPService', () => {
 
   beforeEach(() => {
     service = new TOTPService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('generates and verifies tokens with default options', () => {
@@ -73,5 +77,13 @@ describe('TOTPService', () => {
     await service.generateQRCode(config);
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates unique backup codes of correct length', () => {
+    const codes = service.generateBackupCodes();
+
+    expect(codes).toHaveLength(10);
+    expect(new Set(codes).size).toBe(codes.length);
+    codes.forEach(code => expect(code).toHaveLength(8));
   });
 });


### PR DESCRIPTION
## Summary
- Replace Math.random with crypto.getRandomValues for backup code generation
- Warn and fallback to Math.random if crypto API unavailable
- Test backup code length and uniqueness

## Testing
- `npm test` *(fails: FileTransferService activeTransfers > tracks downloads and cleans up completed entries 10015ms)*

------
https://chatgpt.com/codex/tasks/task_e_689ba18870c88325a1d09c1c05e95c88