### PR TITLE
Fix network scanning CIDR handling

### DIFF
--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -10,6 +10,18 @@ describe('NetworkScanner helper methods', () => {
     expect(ips).toEqual(['192.168.0.1', '192.168.0.2']);
   });
 
+  it('masks non-network-base addresses before generating hosts', () => {
+    const ips = scanner.generateIPRange('192.168.0.5/30');
+    expect(ips).toEqual(['192.168.0.5', '192.168.0.6']);
+  });
+
+  it('handles edge prefix /24', () => {
+    const ips = scanner.generateIPRange('10.0.0.42/24');
+    expect(ips.length).toBe(254);
+    expect(ips[0]).toBe('10.0.0.1');
+    expect(ips[253]).toBe('10.0.0.254');
+  });
+
   it('compareIPs sorts numerically', () => {
     const result = scanner.compareIPs('192.168.0.2', '192.168.0.10');
     expect(result).toBeLessThan(0);
@@ -23,6 +35,10 @@ describe('NetworkScanner helper methods', () => {
   it('throws on malformed CIDR strings', () => {
     expect(() => scanner.generateIPRange('192.168.0.0')).toThrow();
     expect(() => scanner.generateIPRange('192.168.0.0/abc')).toThrow();
+  });
+
+  it('throws when IP does not have four octets', () => {
+    expect(() => scanner.generateIPRange('192.168.0/24')).toThrow();
   });
 
   it('throws when prefix is outside supported range', () => {


### PR DESCRIPTION
## Summary
- Mask input IP with subnet before host iteration
- Validate IPv4 octet count and prefix range
- Add tests for non-network-base inputs and edge prefixes

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689baec90d2083258fda2bed1111ba96