### PR TITLE
Handle WebSocket constructor errors in network scanner

### DIFF
--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -57,4 +57,9 @@ describe('NetworkScanner helper methods', () => {
     expect(result.service).toBe('unknown');
     expect(result.protocol).toBe('unknown');
   });
+
+  it('scanPort resolves false on invalid hostname without rejection', async () => {
+    const result = await scanner.scanPort('invalid host', 80, 50);
+    expect(result.isOpen).toBe(false);
+  });
 });

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -163,9 +163,15 @@ export class NetworkScanner {
     return new Promise((resolve) => {
       const startTime = Date.now();
       let resolved = false;
+      let ws: WebSocket;
 
       // Use WebSocket for port scanning (limited but works for many services)
-      const ws = new WebSocket(`ws://${ip}:${port}`);
+      try {
+        ws = new WebSocket(`ws://${ip}:${port}`);
+      } catch (error) {
+        resolve({ isOpen: false, elapsed: Date.now() - startTime });
+        return;
+      }
 
       const timeoutId = setTimeout(() => {
         ws.close();


### PR DESCRIPTION
## Summary
- guard WebSocket construction in network scanner scanPort and return closed result on failure
- add test verifying invalid hostnames resolve without unhandled rejections

## Testing
- `npx vitest run src/utils/__tests__/networkScanner.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689bbb67bba48325b580e6dedfb35870