### PR TITLE
feat: enhance network scanner protocol detection

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -169,6 +169,8 @@ export interface NetworkDiscoveryConfig {
   timeout: number;
   maxConcurrent: number;
   customPorts: Record<string, number[]>;
+  /** Optional backend endpoint for TCP checks */
+  tcpBackendUrl?: string;
 }
 
 export interface TOTPConfig {


### PR DESCRIPTION
## Summary
- detect HTTP and HTTPS ports and probe them with HEAD requests instead of WebSockets
- add optional backend TCP check for non-web ports with WebSocket fallback
- test new scanPort behavior and configurable backend hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689baecc49c48325804ae7580a8ad4ba