### PR TITLE
Handle server start errors in REST API server

### DIFF
--- a/src/utils/restApiServer.ts
+++ b/src/utils/restApiServer.ts
@@ -326,9 +326,13 @@ export class RestApiServer {
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
-        this.server = this.app.listen(this.config.port, () => {
+        this.server = this.app.listen(this.config.port);
+        this.server.once('listening', () => {
           debugLog(`REST API server started on port ${this.config.port}`);
           resolve();
+        });
+        this.server.once('error', (error: Error) => {
+          reject(error);
         });
       } catch (error) {
         reject(error);


### PR DESCRIPTION
## Summary
- Resolve `start()` only after server begins listening
- Reject `start()` on server `error` events

## Testing
- `npm test`
- `npm run lint` *(fails: 190 problems; 167 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf5b6ef08325bd7b96c28e59f557