### PR TITLE
fix: improve error handling

### DIFF
--- a/src/utils/restApiServer.ts
+++ b/src/utils/restApiServer.ts
@@ -295,11 +295,20 @@ export class RestApiServer {
     });
 
     // Error handling
-    this.app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
-      console.error('API Error:', err);
-      res.status(500).json({ error: 'Internal server error' });
-      next();
-    });
+    this.app.use(
+      (
+        err: Error,
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction
+      ) => {
+        console.error('API Error:', err);
+        if (res.headersSent) {
+          return next(err);
+        }
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    );
 
     // 404 handler
     this.app.use((req, res) => {


### PR DESCRIPTION
## Summary
- ensure error handler passes errors correctly and avoids next() after responses

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf5e422c8325bec520b1687fdde9