### PR TITLE
Add explicit password check for encrypted SecureStorage

### DIFF
--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDB } from 'idb';
+import { SecureStorage, type StorageData } from '../storage';
+import { IndexedDbService } from '../indexedDbService';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
+
+beforeEach(async () => {
+  await IndexedDbService.init();
+  const db = await openDB(DB_NAME, 1);
+  await db.clear(STORE_NAME);
+  SecureStorage.clearPassword();
+});
+
+describe('SecureStorage', () => {
+  it('rejects when loading encrypted data without a password', async () => {
+    const data: StorageData = { connections: [], settings: {}, timestamp: Date.now() };
+    SecureStorage.setPassword('secret');
+    await SecureStorage.saveData(data, true);
+    SecureStorage.clearPassword();
+    await expect(SecureStorage.loadData()).rejects.toThrow('Password is required to load encrypted data');
+  });
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -97,11 +97,13 @@ export class SecureStorage {
 
       if (settings) {
         const parsedSettings = settings;
+        if (parsedSettings.isEncrypted && !this.password) {
+          throw new Error('Password is required to load encrypted data');
+        }
         if (parsedSettings.isEncrypted) {
-          if (!this.password) {
-            throw new Error('Password is required');
-          }
-          const decrypted = CryptoJS.AES.decrypt(storedData as string, this.password).toString(CryptoJS.enc.Utf8);
+          const decrypted = CryptoJS.AES.decrypt(storedData as string, this.password as string).toString(
+            CryptoJS.enc.Utf8
+          );
           if (!decrypted) {
             throw new Error('Invalid password');
           }


### PR DESCRIPTION
## Summary
- ensure `SecureStorage.loadData` throws a clear error when encrypted data is loaded without a password
- add unit test covering encrypted load without password scenario

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689bd7dda49883258bb4e28ce0fd385c