### PR TITLE
Handle CRLF endings in CSV import

### DIFF
--- a/src/components/ImportExport/index.tsx
+++ b/src/components/ImportExport/index.tsx
@@ -14,6 +14,69 @@ interface ImportExportProps {
   onClose: () => void;
 }
 
+export const parseCSVLine = (line: string): string[] => {
+  const values: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      values.push(current.trim().replace(/\r$/, ''));
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  values.push(current.trim().replace(/\r$/, ''));
+  return values;
+};
+
+export const importFromCSV = async (content: string): Promise<Connection[]> => {
+  const lines = content.split(/\r?\n/).filter(line => line.trim());
+  if (lines.length < 2) throw new Error('CSV file must have headers and at least one data row');
+
+  const headers = lines[0].split(',').map(h => h.trim().replace(/"/g, ''));
+  const connections: Connection[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = parseCSVLine(lines[i]);
+    if (values.length !== headers.length) continue;
+
+    const conn: any = {};
+    headers.forEach((header, index) => {
+      conn[header] = values[index];
+    });
+
+    connections.push({
+      id: conn.ID || generateId(),
+      name: conn.Name || 'Imported Connection',
+      protocol: (conn.Protocol?.toLowerCase() || 'rdp') as Connection['protocol'],
+      hostname: conn.Hostname || '',
+      port: parseInt(conn.Port || '3389'),
+      username: conn.Username || undefined,
+      domain: conn.Domain || undefined,
+      description: conn.Description || undefined,
+      parentId: conn.ParentId || undefined,
+      isGroup: conn.IsGroup === 'true',
+      tags: conn.Tags?.split(';').filter((t: string) => t.trim()) || [],
+      createdAt: new Date(conn.CreatedAt || Date.now()),
+      updatedAt: new Date(conn.UpdatedAt || Date.now())
+    });
+  }
+
+  return connections;
+};
+
 
 export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) => {
   const { state, dispatch } = useConnections();
@@ -304,69 +367,6 @@ export const ImportExport: React.FC<ImportExportProps> = ({ isOpen, onClose }) =
     });
     
     return connections;
-  };
-
-  const importFromCSV = async (content: string): Promise<Connection[]> => {
-    const lines = content.split('\n').filter(line => line.trim());
-    if (lines.length < 2) throw new Error('CSV file must have headers and at least one data row');
-    
-    const headers = lines[0].split(',').map(h => h.trim().replace(/"/g, ''));
-    const connections: Connection[] = [];
-    
-    for (let i = 1; i < lines.length; i++) {
-      const values = parseCSVLine(lines[i]);
-      if (values.length !== headers.length) continue;
-      
-      const conn: any = {};
-      headers.forEach((header, index) => {
-        conn[header] = values[index];
-      });
-      
-      connections.push({
-        id: conn.ID || generateId(),
-        name: conn.Name || 'Imported Connection',
-        protocol: (conn.Protocol?.toLowerCase() || 'rdp') as Connection['protocol'],
-        hostname: conn.Hostname || '',
-        port: parseInt(conn.Port || '3389'),
-        username: conn.Username || undefined,
-        domain: conn.Domain || undefined,
-        description: conn.Description || undefined,
-        parentId: conn.ParentId || undefined,
-        isGroup: conn.IsGroup === 'true',
-        tags: conn.Tags?.split(';').filter((t: string) => t.trim()) || [],
-        createdAt: new Date(conn.CreatedAt || Date.now()),
-        updatedAt: new Date(conn.UpdatedAt || Date.now())
-      });
-    }
-    
-    return connections;
-  };
-
-  const parseCSVLine = (line: string): string[] => {
-    const values: string[] = [];
-    let current = '';
-    let inQuotes = false;
-    
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-      
-      if (char === '"') {
-        if (inQuotes && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = !inQuotes;
-        }
-      } else if (char === ',' && !inQuotes) {
-        values.push(current.trim());
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-    
-    values.push(current.trim());
-    return values;
   };
 
   const confirmImport = () => {

--- a/tests/ImportExportCSV.test.ts
+++ b/tests/ImportExportCSV.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { importFromCSV } from '../src/components/ImportExport';
+
+const csvHeaders = 'ID,Name,Protocol,Hostname,Port,Username,Domain,Description,ParentId,IsGroup,Tags,CreatedAt,UpdatedAt';
+const csvRow = '1,Test,RDP,example.com,3389,user,,desc,,false,tag1;tag2,2024-01-01T00:00:00.000Z,2024-01-01T00:00:00.000Z';
+
+describe('importFromCSV', () => {
+  it('imports CSV with LF line endings', async () => {
+    const csv = `${csvHeaders}\n${csvRow}\n`;
+    const connections = await importFromCSV(csv);
+    expect(connections).toHaveLength(1);
+    expect(connections[0].hostname).toBe('example.com');
+  });
+
+  it('imports CSV with CRLF line endings', async () => {
+    const csv = `${csvHeaders}\r\n${csvRow}\r\n`;
+    const connections = await importFromCSV(csv);
+    expect(connections).toHaveLength(1);
+    expect(connections[0].hostname).toBe('example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- improve CSV import to handle both LF and CRLF line endings and strip trailing carriage returns
- add tests for CSV import with LF and CRLF endings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689be2ad8ae08325a7070ef6cf4f9cd0