### PR TITLE
Add user store auth and env-configured secrets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,37 @@ npm run lint
 
 All code should pass ESLint before committing.
 
+## Authentication
+
+The REST API uses a simple user store with bcrypt-hashed passwords and JWT tokens.
+
+1. Users are defined in a JSON file (`users.json` by default) containing objects with
+   `username` and `passwordHash` fields:
+
+   ```json
+   [
+     { "username": "admin", "passwordHash": "<bcrypt-hash>" }
+   ]
+   ```
+
+   Generate hashes with:
+
+   ```bash
+   node -e "require('bcryptjs').hash('password',10).then(console.log)"
+   ```
+
+2. Obtain a token via `POST /auth/login` with the username and password. Use the
+   returned token in the `Authorization: Bearer <token>` header for all `/api`
+   requests.
+
+3. An API key can be supplied via the `X-API-Key` header.
+
+Environment variables:
+
+- `API_KEY` – optional API key (defaults to none).
+- `JWT_SECRET` – secret for signing JWTs (defaults to `defaultsecret`).
+- `USER_STORE_PATH` – path to the users file (defaults to `users.json`).
+
 ## Appearance
 
 The interface supports selectable color schemes (blue, green, purple, red, orange and teal). Use the settings dialog to choose your preferred scheme.

--- a/src/utils/__tests__/restApiServer.test.ts
+++ b/src/utils/__tests__/restApiServer.test.ts
@@ -1,10 +1,12 @@
 import request from 'supertest';
 import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'path';
+import type { Application } from 'express';
 import { RestApiServer } from '../restApiServer';
 
 describe('RestApiServer routes', () => {
   let server: RestApiServer;
-  let app: any;
+  let app: Application;
 
   beforeEach(() => {
     server = new RestApiServer({
@@ -14,7 +16,7 @@ describe('RestApiServer routes', () => {
       rateLimiting: false,
       jwtSecret: 'secret'
     });
-    app = (server as any).app;
+    app = (server as unknown as { app: Application }).app;
   });
 
   it('health check returns ok', async () => {
@@ -32,5 +34,54 @@ describe('RestApiServer routes', () => {
     const listRes = await request(app).get('/api/connections');
     expect(listRes.body).toHaveLength(1);
     expect(listRes.body[0].name).toBe('test');
+  });
+});
+
+describe('Authentication', () => {
+  let server: RestApiServer;
+  let app: Application;
+
+  beforeEach(() => {
+    server = new RestApiServer({
+      port: 0,
+      authentication: true,
+      corsEnabled: false,
+      rateLimiting: false,
+      jwtSecret: 'secret',
+      userStorePath: path.join(__dirname, '..', '..', '..', 'users.json'),
+    });
+    app = (server as unknown as { app: Application }).app;
+  });
+
+  it('allows login with valid credentials', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ username: 'admin', password: 'admin' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('rejects login with invalid credentials', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ username: 'admin', password: 'wrong' });
+    expect(res.status).toBe(401);
+  });
+
+  it('protects routes without token', async () => {
+    const res = await request(app).get('/api/connections');
+    expect(res.status).toBe(401);
+  });
+
+  it('allows access to protected routes with valid token', async () => {
+    const login = await request(app)
+      .post('/auth/login')
+      .send({ username: 'admin', password: 'admin' });
+    const token = login.body.token;
+
+    const res = await request(app)
+      .get('/api/connections')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
   });
 });

--- a/users.json
+++ b/users.json
@@ -1,0 +1,6 @@
+[
+  {
+    "username": "admin",
+    "passwordHash": "$2a$10$1aBMw8/HlycUk1C/Tvs3deqHlnnahtERUzVDaiWcqh3lGQgYJOtty"
+  }
+]


### PR DESCRIPTION
## Summary
- load user credentials from JSON user store and verify logins with bcrypt hashes
- read API key and JWT secret from environment variables with defaults
- document authentication and add tests for login and protected routes

## Testing
- `npm test -- --run`
- `npx eslint src/utils/restApiServer.ts src/utils/__tests__/restApiServer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ca6ab6878832585099ae8ed949900