### PR TITLE
feat: use Web Crypto for secure storage

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,11 +1,31 @@
-import CryptoJS from 'crypto-js';
-
 const STORAGE_KEY = 'mremote-connections';
 const STORAGE_META_KEY = 'mremote-storage-meta';
 const OLD_STORAGE_META_KEY = 'mremote-settings';
 
 import { Connection } from '../types/connection';
 import { IndexedDbService } from './indexedDbService';
+
+const getCrypto = (): Crypto => globalThis.crypto as Crypto;
+
+const toBase64 = (buffer: ArrayBuffer | Uint8Array): string => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  bytes.forEach(b => (binary += String.fromCharCode(b)));
+  return btoa(binary);
+};
+
+const fromBase64 = (str: string): Uint8Array => {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(str, 'base64'));
+  }
+  const binary = atob(str);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
 
 export interface StorageData {
   connections: Connection[];
@@ -16,6 +36,30 @@ export interface StorageData {
 export class SecureStorage {
   private static password: string | null = null;
   private static isUnlocked: boolean = false;
+
+  private static async deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+    const crypto = getCrypto();
+    const enc = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw',
+      enc.encode(password),
+      'PBKDF2',
+      false,
+      ['deriveKey']
+    );
+    return crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt,
+        iterations: 100000,
+        hash: 'SHA-256'
+      },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
 
   // Migrate old metadata key to the new one if needed
   private static async migrateMetaKey(): Promise<void> {
@@ -66,13 +110,25 @@ export class SecureStorage {
       await this.migrateMetaKey();
 
       if (usePassword && this.password) {
+        const crypto = getCrypto();
         const serialized = JSON.stringify(data);
-        const encrypted = CryptoJS.AES.encrypt(serialized, this.password).toString();
+        const encoder = new TextEncoder();
+        const salt = crypto.getRandomValues(new Uint8Array(16));
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const key = await this.deriveKey(this.password, salt);
+        const encryptedBuffer = await crypto.subtle.encrypt(
+          { name: 'AES-GCM', iv },
+          key,
+          encoder.encode(serialized)
+        );
+        const encrypted = toBase64(encryptedBuffer);
         await IndexedDbService.setItem(STORAGE_KEY, encrypted);
         await IndexedDbService.setItem(STORAGE_META_KEY, {
           isEncrypted: true,
           hasPassword: true,
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          salt: toBase64(salt),
+          iv: toBase64(iv)
         });
       } else {
         await IndexedDbService.setItem(STORAGE_KEY, data);
@@ -101,13 +157,21 @@ export class SecureStorage {
           throw new Error('Password is required to load encrypted data');
         }
         if (parsedSettings.isEncrypted) {
-          const decrypted = CryptoJS.AES.decrypt(storedData as string, this.password as string).toString(
-            CryptoJS.enc.Utf8
-          );
-          if (!decrypted) {
+          try {
+            const crypto = getCrypto();
+            const salt = fromBase64(parsedSettings.salt);
+            const iv = fromBase64(parsedSettings.iv);
+            const key = await this.deriveKey(this.password as string, salt);
+            const decryptedBuffer = await crypto.subtle.decrypt(
+              { name: 'AES-GCM', iv },
+              key,
+              fromBase64(storedData as string)
+            );
+            const decoded = new TextDecoder().decode(decryptedBuffer);
+            return JSON.parse(decoded);
+          } catch {
             throw new Error('Invalid password');
           }
-          return JSON.parse(decrypted);
         }
       }
 

--- a/tests/SecureStorageEncryption.test.ts
+++ b/tests/SecureStorageEncryption.test.ts
@@ -26,7 +26,16 @@ describe('SecureStorage encryption', () => {
 
     const stored = await IndexedDbService.getItem<string>('mremote-connections');
     expect(typeof stored).toBe('string');
-    const meta = await IndexedDbService.getItem<{ isEncrypted: boolean }>('mremote-storage-meta');
+    const meta = await IndexedDbService.getItem<{
+      isEncrypted: boolean;
+      salt: string;
+      iv: string;
+    }>('mremote-storage-meta');
     expect(meta.isEncrypted).toBe(true);
+    expect(typeof meta.salt).toBe('string');
+    expect(typeof meta.iv).toBe('string');
+
+    const loaded = await SecureStorage.loadData();
+    expect(loaded?.connections).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- derive AES-GCM key via PBKDF2 using Web Crypto
- persist salt and IV alongside encrypted payloads
- test storage encryption with new metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce28eea6c8325849727f5a256ba15