### PR TITLE
refactor: modularize settings manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { PasswordDialog } from './components/PasswordDialog';
 import { CollectionSelector } from './components/CollectionSelector';
 import { Connection } from './types/connection';
 import { SecureStorage } from './utils/storage';
-import { SettingsManager } from './utils/settingsManager';
+import { SettingsManager } from './utils/settings';
 import { StatusChecker } from './utils/statusChecker';
 import { CollectionManager } from './utils/collectionManager';
 import { useSessionManager } from './hooks/useSessionManager';

--- a/src/components/ActionLogViewer.tsx
+++ b/src/components/ActionLogViewer.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ActionLogEntry } from '../types/settings';
-import { SettingsManager } from '../utils/settingsManager';
+import { SettingsManager } from '../utils/settings';
 
 const LEVEL_ICONS: Record<string, JSX.Element> = {
   debug: <Bug className="text-gray-400" size={14} />,

--- a/src/components/PerformanceMonitor.tsx
+++ b/src/components/PerformanceMonitor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X, Download, BarChart3, Activity, Cpu, HardDrive, Wifi, Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { PerformanceMetrics } from '../types/settings';
-import { SettingsManager } from '../utils/settingsManager';
+import { SettingsManager } from '../utils/settings';
 
 interface PerformanceMonitorProps {
   isOpen: boolean;

--- a/src/components/SettingsDialog/index.tsx
+++ b/src/components/SettingsDialog/index.tsx
@@ -18,7 +18,7 @@ import SecuritySettings from './sections/SecuritySettings';
 import PerformanceSettings from './sections/PerformanceSettings';
 import ProxySettings from './sections/ProxySettings';
 import AdvancedSettings from './sections/AdvancedSettings';
-import { SettingsManager } from '../../utils/settingsManager';
+import { SettingsManager } from '../../utils/settings';
 import { ThemeManager } from '../../utils/themeManager';
 
 interface SettingsDialogProps {

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useConnections } from '../contexts/ConnectionContext';
-import { SettingsManager } from '../utils/settingsManager';
+import { SettingsManager } from '../utils/settings';
 import { StatusChecker } from '../utils/statusChecker';
 import { CollectionManager } from '../utils/collectionManager';
 import { ThemeManager } from '../utils/themeManager';

--- a/src/hooks/useSessionManager.ts
+++ b/src/hooks/useSessionManager.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useConnections } from '../contexts/ConnectionContext';
 import { Connection, ConnectionSession } from '../types/connection';
-import { SettingsManager } from '../utils/settingsManager';
+import { SettingsManager } from '../utils/settings';
 import { StatusChecker } from '../utils/statusChecker';
 import { ScriptEngine } from '../utils/scriptEngine';
 import { getDefaultPort } from '../utils/defaultPorts';

--- a/src/utils/__tests__/proxyManager.test.ts
+++ b/src/utils/__tests__/proxyManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ProxyManager } from '../proxyManager';
 import { ProxyConfig } from '../../types/settings';
-import { SettingsManager } from '../settingsManager';
+import { SettingsManager } from '../settings';
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];

--- a/src/utils/__tests__/scriptEngine.test.ts
+++ b/src/utils/__tests__/scriptEngine.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { ScriptEngine } from '../scriptEngine';
-import { SettingsManager } from '../settingsManager';
+import { SettingsManager } from '../settings';
 import { CustomScript } from '../../types/settings';
 
 let dom: JSDOM;

--- a/src/utils/__tests__/settingsManager.test.ts
+++ b/src/utils/__tests__/settingsManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
-import { SettingsManager } from '../settingsManager';
+import { SettingsManager } from '../settings';
 import { IndexedDbService } from '../indexedDbService';
 import { openDB } from 'idb';
 

--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -1,4 +1,4 @@
-import { SettingsManager } from './settingsManager';
+import { SettingsManager } from './settings';
 
 export function debugLog(...args: unknown[]): void {
   const settings = SettingsManager.getInstance().getSettings();

--- a/src/utils/proxyManager.ts
+++ b/src/utils/proxyManager.ts
@@ -1,5 +1,5 @@
 import { ProxyConfig } from '../types/settings';
-import { SettingsManager } from './settingsManager';
+import { SettingsManager } from './settings';
 
 export class ProxyManager {
   private static instance: ProxyManager;

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -1,6 +1,6 @@
 import { CustomScript } from '../types/settings';
 import { Connection, ConnectionSession } from '../types/connection';
-import { SettingsManager } from './settingsManager';
+import { SettingsManager } from './settings';
 import { generateId } from './id';
 
 export class ScriptEngine {

--- a/src/utils/settings/actionLogManager.ts
+++ b/src/utils/settings/actionLogManager.ts
@@ -1,0 +1,73 @@
+import { ActionLogEntry, GlobalSettings } from '../../types/settings';
+import { IndexedDbService } from '../indexedDbService';
+import { generateId } from '../id';
+
+export class ActionLogManager {
+  private actionLog: ActionLogEntry[] = [];
+
+  constructor(
+    private getSettings: () => GlobalSettings,
+    private getConnectionName: (id: string) => string,
+  ) {}
+
+  async load(): Promise<void> {
+    try {
+      const stored = await IndexedDbService.getItem<any[]>('mremote-action-log');
+      if (stored) {
+        this.actionLog = stored.map(entry => ({
+          ...entry,
+          timestamp: new Date(entry.timestamp),
+        }));
+      }
+    } catch (error) {
+      console.error('Failed to load action log:', error);
+    }
+  }
+
+  logAction(
+    level: 'debug' | 'info' | 'warn' | 'error',
+    action: string,
+    connectionId?: string,
+    details: string = '',
+    duration?: number,
+  ): void {
+    if (!this.getSettings().enableActionLog) return;
+
+    const entry: ActionLogEntry = {
+      id: generateId(),
+      timestamp: new Date(),
+      level,
+      action,
+      connectionId,
+      connectionName: connectionId ? this.getConnectionName(connectionId) : undefined,
+      details,
+      duration,
+    };
+
+    this.actionLog.unshift(entry);
+
+    if (this.actionLog.length > this.getSettings().maxLogEntries) {
+      this.actionLog = this.actionLog.slice(0, this.getSettings().maxLogEntries);
+    }
+
+    void this.save();
+  }
+
+  getActionLog(): ActionLogEntry[] {
+    return this.actionLog;
+  }
+
+  clearActionLog(): void {
+    this.actionLog = [];
+    void this.save();
+  }
+
+  private async save(): Promise<void> {
+    try {
+      await IndexedDbService.setItem('mremote-action-log', this.actionLog);
+    } catch (error) {
+      console.error('Failed to save action log:', error);
+    }
+  }
+}
+

--- a/src/utils/settings/customScriptManager.ts
+++ b/src/utils/settings/customScriptManager.ts
@@ -1,0 +1,80 @@
+import { CustomScript } from '../../types/settings';
+import { IndexedDbService } from '../indexedDbService';
+import { generateId } from '../id';
+
+export class CustomScriptManager {
+  private customScripts: CustomScript[] = [];
+
+  constructor(
+    private logAction: (
+      level: 'debug' | 'info' | 'warn' | 'error',
+      action: string,
+      connectionId?: string,
+      details?: string,
+      duration?: number,
+    ) => void,
+  ) {}
+
+  async load(): Promise<void> {
+    try {
+      const stored = await IndexedDbService.getItem<any[]>('mremote-custom-scripts');
+      if (stored) {
+        this.customScripts = stored.map(script => ({
+          ...script,
+          createdAt: new Date(script.createdAt),
+          updatedAt: new Date(script.updatedAt),
+        }));
+      }
+    } catch (error) {
+      console.error('Failed to load custom scripts:', error);
+    }
+  }
+
+  addCustomScript(script: Omit<CustomScript, 'id' | 'createdAt' | 'updatedAt'>): CustomScript {
+    const newScript: CustomScript = {
+      ...script,
+      id: generateId(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    this.customScripts.push(newScript);
+    void this.save();
+    this.logAction('info', 'Custom script added', undefined, `Script "${script.name}" created`);
+
+    return newScript;
+  }
+
+  updateCustomScript(id: string, updates: Partial<CustomScript>): void {
+    const index = this.customScripts.findIndex(script => script.id === id);
+    if (index !== -1) {
+      this.customScripts[index] = {
+        ...this.customScripts[index],
+        ...updates,
+        updatedAt: new Date(),
+      };
+      void this.save();
+      this.logAction('info', 'Custom script updated', undefined, `Script "${this.customScripts[index].name}" updated`);
+    }
+  }
+
+  deleteCustomScript(id: string): void {
+    const script = this.customScripts.find(s => s.id === id);
+    this.customScripts = this.customScripts.filter(s => s.id !== id);
+    void this.save();
+    this.logAction('info', 'Custom script deleted', undefined, `Script "${script?.name}" deleted`);
+  }
+
+  getCustomScripts(): CustomScript[] {
+    return this.customScripts;
+  }
+
+  private async save(): Promise<void> {
+    try {
+      await IndexedDbService.setItem('mremote-custom-scripts', this.customScripts);
+    } catch (error) {
+      console.error('Failed to save custom scripts:', error);
+    }
+  }
+}
+

--- a/src/utils/settings/index.ts
+++ b/src/utils/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsManager } from './settingsManager';

--- a/src/utils/settings/performanceMetricsManager.ts
+++ b/src/utils/settings/performanceMetricsManager.ts
@@ -1,0 +1,42 @@
+import { PerformanceMetrics, GlobalSettings } from '../../types/settings';
+import { IndexedDbService } from '../indexedDbService';
+
+export class PerformanceMetricsManager {
+  private performanceMetrics: PerformanceMetrics[] = [];
+
+  constructor(private getSettings: () => GlobalSettings) {}
+
+  async load(): Promise<void> {
+    try {
+      const stored = await IndexedDbService.getItem<PerformanceMetrics[]>('mremote-performance-metrics');
+      if (stored) {
+        this.performanceMetrics = stored;
+      }
+    } catch (error) {
+      console.error('Failed to load performance metrics:', error);
+    }
+  }
+
+  recordPerformanceMetric(metric: PerformanceMetrics): void {
+    if (!this.getSettings().enablePerformanceTracking) return;
+
+    this.performanceMetrics.unshift(metric);
+    if (this.performanceMetrics.length > 1000) {
+      this.performanceMetrics = this.performanceMetrics.slice(0, 1000);
+    }
+    void this.save();
+  }
+
+  getPerformanceMetrics(): PerformanceMetrics[] {
+    return this.performanceMetrics;
+  }
+
+  private async save(): Promise<void> {
+    try {
+      await IndexedDbService.setItem('mremote-performance-metrics', this.performanceMetrics);
+    } catch (error) {
+      console.error('Failed to save performance metrics:', error);
+    }
+  }
+}
+

--- a/src/utils/settings/settingsManager.ts
+++ b/src/utils/settings/settingsManager.ts
@@ -1,7 +1,9 @@
-import { GlobalSettings, ActionLogEntry, PerformanceMetrics, CustomScript } from '../types/settings';
-import { SecureStorage } from './storage';
-import { IndexedDbService } from './indexedDbService';
-import { generateId } from './id';
+import { GlobalSettings, PerformanceMetrics, CustomScript, ActionLogEntry } from '../../types/settings';
+import { IndexedDbService } from '../indexedDbService';
+import { generateId } from '../id';
+import { ActionLogManager } from './actionLogManager';
+import { PerformanceMetricsManager } from './performanceMetricsManager';
+import { CustomScriptManager } from './customScriptManager';
 
 const DEFAULT_SETTINGS: GlobalSettings = {
   language: 'en',
@@ -101,9 +103,13 @@ const DEFAULT_SETTINGS: GlobalSettings = {
 export class SettingsManager {
   private static instance: SettingsManager | null = null;
   private settings: GlobalSettings = DEFAULT_SETTINGS;
-  private actionLog: ActionLogEntry[] = [];
-  private performanceMetrics: PerformanceMetrics[] = [];
-  private customScripts: CustomScript[] = [];
+
+  private actionLogManager = new ActionLogManager(
+    () => this.settings,
+    this.getConnectionName.bind(this),
+  );
+  private performanceMetricsManager = new PerformanceMetricsManager(() => this.settings);
+  private customScriptManager = new CustomScriptManager(this.logAction.bind(this));
 
   static getInstance(): SettingsManager {
     if (SettingsManager.instance === null) {
@@ -144,174 +150,52 @@ export class SettingsManager {
     return this.settings;
   }
 
-  // Action Logging
   logAction(
     level: 'debug' | 'info' | 'warn' | 'error',
     action: string,
     connectionId?: string,
     details: string = '',
-    duration?: number
+    duration?: number,
   ): void {
-    if (!this.settings.enableActionLog) return;
-
-    const entry: ActionLogEntry = {
-      id: generateId(),
-      timestamp: new Date(),
-      level,
-      action,
-      connectionId,
-      connectionName: connectionId ? this.getConnectionName(connectionId) : undefined,
-      details,
-      duration,
-    };
-
-    this.actionLog.unshift(entry);
-
-    // Limit log size
-    if (this.actionLog.length > this.settings.maxLogEntries) {
-      this.actionLog = this.actionLog.slice(0, this.settings.maxLogEntries);
-    }
-
-    // Persist to localStorage
-    this.saveActionLog();
+    this.actionLogManager.logAction(level, action, connectionId, details, duration);
   }
 
   getActionLog(): ActionLogEntry[] {
-    return this.actionLog;
+    return this.actionLogManager.getActionLog();
   }
 
   clearActionLog(): void {
-    this.actionLog = [];
-    this.saveActionLog();
+    this.actionLogManager.clearActionLog();
   }
 
-  private async saveActionLog(): Promise<void> {
-    try {
-      await IndexedDbService.setItem('mremote-action-log', this.actionLog);
-    } catch (error) {
-      console.error('Failed to save action log:', error);
-    }
-  }
-
-  private async loadActionLog(): Promise<void> {
-    try {
-      const stored = await IndexedDbService.getItem<any[]>('mremote-action-log');
-      if (stored) {
-        this.actionLog = stored.map((entry: any) => ({
-          ...entry,
-          timestamp: new Date(entry.timestamp),
-        }));
-      }
-    } catch (error) {
-      console.error('Failed to load action log:', error);
-    }
-  }
-
-  // Performance Metrics
   recordPerformanceMetric(metric: PerformanceMetrics): void {
-    if (!this.settings.enablePerformanceTracking) return;
-
-    this.performanceMetrics.unshift(metric);
-
-    // Keep only last 1000 metrics
-    if (this.performanceMetrics.length > 1000) {
-      this.performanceMetrics = this.performanceMetrics.slice(0, 1000);
-    }
-
-    void this.savePerformanceMetrics();
+    this.performanceMetricsManager.recordPerformanceMetric(metric);
   }
 
   getPerformanceMetrics(): PerformanceMetrics[] {
-    return this.performanceMetrics;
+    return this.performanceMetricsManager.getPerformanceMetrics();
   }
 
-  private async savePerformanceMetrics(): Promise<void> {
-    try {
-      await IndexedDbService.setItem('mremote-performance-metrics', this.performanceMetrics);
-    } catch (error) {
-      console.error('Failed to save performance metrics:', error);
-    }
-  }
-
-  private async loadPerformanceMetrics(): Promise<void> {
-    try {
-      const stored = await IndexedDbService.getItem<PerformanceMetrics[]>('mremote-performance-metrics');
-      if (stored) {
-        this.performanceMetrics = stored;
-      }
-    } catch (error) {
-      console.error('Failed to load performance metrics:', error);
-    }
-  }
-
-  // Custom Scripts
   addCustomScript(script: Omit<CustomScript, 'id' | 'createdAt' | 'updatedAt'>): CustomScript {
-    const newScript: CustomScript = {
-      ...script,
-      id: generateId(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    this.customScripts.push(newScript);
-    void this.saveCustomScripts();
-    this.logAction('info', 'Custom script added', undefined, `Script "${script.name}" created`);
-
-    return newScript;
+    return this.customScriptManager.addCustomScript(script);
   }
 
   updateCustomScript(id: string, updates: Partial<CustomScript>): void {
-    const index = this.customScripts.findIndex(script => script.id === id);
-    if (index !== -1) {
-      this.customScripts[index] = {
-        ...this.customScripts[index],
-        ...updates,
-        updatedAt: new Date(),
-      };
-      void this.saveCustomScripts();
-      this.logAction('info', 'Custom script updated', undefined, `Script "${this.customScripts[index].name}" updated`);
-    }
+    this.customScriptManager.updateCustomScript(id, updates);
   }
 
   deleteCustomScript(id: string): void {
-    const script = this.customScripts.find(s => s.id === id);
-    this.customScripts = this.customScripts.filter(script => script.id !== id);
-    void this.saveCustomScripts();
-    this.logAction('info', 'Custom script deleted', undefined, `Script "${script?.name}" deleted`);
+    this.customScriptManager.deleteCustomScript(id);
   }
 
   getCustomScripts(): CustomScript[] {
-    return this.customScripts;
+    return this.customScriptManager.getCustomScripts();
   }
 
-  private async saveCustomScripts(): Promise<void> {
-    try {
-      await IndexedDbService.setItem('mremote-custom-scripts', this.customScripts);
-    } catch (error) {
-      console.error('Failed to save custom scripts:', error);
-    }
-  }
-
-  private async loadCustomScripts(): Promise<void> {
-    try {
-      const stored = await IndexedDbService.getItem<any[]>('mremote-custom-scripts');
-      if (stored) {
-        this.customScripts = stored.map((script: any) => ({
-          ...script,
-          createdAt: new Date(script.createdAt),
-          updatedAt: new Date(script.updatedAt),
-        }));
-      }
-    } catch (error) {
-      console.error('Failed to load custom scripts:', error);
-    }
-  }
-
-  // Key Derivation Benchmarking
   async benchmarkKeyDerivation(
     targetTimeSeconds: number = 1,
     maxTimeSeconds: number = 30,
-    maxIterations: number = 20
+    maxIterations: number = 20,
   ): Promise<number> {
     if (
       typeof globalThis.performance?.now !== 'function' ||
@@ -333,23 +217,19 @@ export class SettingsManager {
       'info',
       'Key derivation benchmark started',
       undefined,
-      `Target time: ${targetTimeSeconds}s`
+      `Target time: ${targetTimeSeconds}s`,
     );
 
-    // Binary search for optimal iterations
     while (iterationCount < maxIterations && elapsedTime < maxElapsedMs) {
       const startTime = globalThis.performance.now();
       iterationCount++;
 
-      // Simulate key derivation (simplified)
       for (let i = 0; i < iterations; i++) {
-        // Simple hash operation to simulate work
         await globalThis.crypto.subtle.digest(
           'SHA-256',
-          new TextEncoder().encode(testPassword + testSalt + i)
+          new TextEncoder().encode(testPassword + testSalt + i),
         );
 
-        // Track elapsed time inside the loop and break if exceeded
         elapsedTime = globalThis.performance.now() - benchmarkStart;
         if (elapsedTime >= maxElapsedMs) {
           break;
@@ -370,7 +250,6 @@ export class SettingsManager {
 
       iterations = Math.floor(iterations * (targetTimeSeconds / duration));
 
-      // Prevent infinite loop
       if (Math.abs(duration - lastTime) < 0.01) {
         break;
       }
@@ -381,7 +260,6 @@ export class SettingsManager {
     return iterations;
   }
 
-  // Single Window Management
   async checkSingleWindow(): Promise<boolean> {
     if (!this.settings.singleWindowMode) return true;
 
@@ -396,27 +274,23 @@ export class SettingsManager {
     }
 
     if (activeWindowId && activeWindowId !== windowId) {
-      return false; // Another window is active
+      return false;
     }
 
     await IndexedDbService.setItem('mremote-active-window', windowId);
     return true;
   }
 
-  // Helper methods
   private getConnectionName(connectionId: string): string {
-    // This would need to be implemented to get connection name from context
     return `Connection ${connectionId.slice(0, 8)}`;
   }
 
-  // Initialize all data
   async initialize(): Promise<void> {
     await this.loadSettings();
-    await this.loadActionLog();
-    await this.loadPerformanceMetrics();
-    await this.loadCustomScripts();
+    await this.actionLogManager.load();
+    await this.performanceMetricsManager.load();
+    await this.customScriptManager.load();
 
-    // Auto-benchmark if enabled
     if (this.settings.autoBenchmarkIterations) {
       try {
         const optimalIterations = await this.benchmarkKeyDerivation(this.settings.benchmarkTimeSeconds);
@@ -427,3 +301,4 @@ export class SettingsManager {
     }
   }
 }
+

--- a/src/utils/statusChecker.ts
+++ b/src/utils/statusChecker.ts
@@ -1,5 +1,5 @@
 import { Connection, ConnectionStatus } from '../types/connection';
-import { SettingsManager } from './settingsManager';
+import { SettingsManager } from './settings';
 
 export class StatusChecker {
   private static instance: StatusChecker;

--- a/tests/SettingsDialog.test.tsx
+++ b/tests/SettingsDialog.test.tsx
@@ -56,7 +56,7 @@ const mockSettings: GlobalSettings = {
   exportPassword: undefined,
 };
 
-vi.mock('../src/utils/settingsManager', () => ({
+vi.mock('../src/utils/settings', () => ({
   SettingsManager: {
     getInstance: () => ({
       loadSettings: vi.fn().mockResolvedValue(mockSettings),


### PR DESCRIPTION
## Summary
- split settings logic into ActionLogManager, PerformanceMetricsManager, and CustomScriptManager
- expose lightweight SettingsManager that composes sub-modules
- update imports to new settings module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce29162d4832587f12b869a981c18