### PR TITLE
feat: add reusable confirm dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const AppContent: React.FC = () => {
     handleConnect,
     handleQuickConnect,
     handleSessionClose,
+    confirmDialog,
   } = useSessionManager();
 
   const { isInitialized } = useAppLifecycle({
@@ -252,6 +253,7 @@ const AppContent: React.FC = () => {
         onCancel={handlePasswordCancel}
         error={passwordError}
       />
+      {confirmDialog}
     </div>
   );
 };

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  isOpen,
+  message,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && onCancel) onCancel();
+      }}
+    >
+      <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+        <p className="text-white mb-6">{message}</p>
+        <div className="flex justify-end space-x-3">
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-md transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/tests/ConfirmDialog.test.tsx
+++ b/tests/ConfirmDialog.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmDialog } from '../src/components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('renders and confirms action', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog isOpen message="Confirm?" onConfirm={onConfirm} />);
+    expect(screen.getByText('Confirm?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('OK'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('handles cancel action', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen
+        message="Are you sure?"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `ConfirmDialog` component
- replace `alert`/`confirm` usages in session manager with stateful dialog
- cover dialog behavior with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce294dd34832590acf9e2cb6ce4ca