### PR TITLE
Handle missing collections and bad passwords with custom errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,40 @@
-import React, { useState } from 'react';
-import { Monitor, Zap, Menu, Globe } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { ConnectionProvider, useConnections } from './contexts/ConnectionContext';
-import { Sidebar } from './components/Sidebar';
-import { ConnectionEditor } from './components/ConnectionEditor';
-import { SessionTabs } from './components/SessionTabs';
-import { SessionViewer } from './components/SessionViewer';
-import { QuickConnect } from './components/QuickConnect';
-import { PasswordDialog } from './components/PasswordDialog';
-import { CollectionSelector } from './components/CollectionSelector';
-import { Connection } from './types/connection';
-import { SecureStorage } from './utils/storage';
-import { SettingsManager } from './utils/settingsManager';
-import { StatusChecker } from './utils/statusChecker';
-import { CollectionManager } from './utils/collectionManager';
-import { useSessionManager } from './hooks/useSessionManager';
-import { useAppLifecycle } from './hooks/useAppLifecycle';
+import React, { useState } from "react";
+import { Monitor, Zap, Menu, Globe } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  ConnectionProvider,
+  useConnections,
+} from "./contexts/ConnectionContext";
+import { Sidebar } from "./components/Sidebar";
+import { ConnectionEditor } from "./components/ConnectionEditor";
+import { SessionTabs } from "./components/SessionTabs";
+import { SessionViewer } from "./components/SessionViewer";
+import { QuickConnect } from "./components/QuickConnect";
+import { PasswordDialog } from "./components/PasswordDialog";
+import { CollectionSelector } from "./components/CollectionSelector";
+import { Connection } from "./types/connection";
+import { SecureStorage } from "./utils/storage";
+import { SettingsManager } from "./utils/settingsManager";
+import { StatusChecker } from "./utils/statusChecker";
+import { CollectionManager } from "./utils/collectionManager";
+import { CollectionNotFoundError, InvalidPasswordError } from "./utils/errors";
+import { useSessionManager } from "./hooks/useSessionManager";
+import { useAppLifecycle } from "./hooks/useAppLifecycle";
 
 const AppContent: React.FC = () => {
   const { t, i18n } = useTranslation();
   const { state, dispatch, loadData, saveData } = useConnections();
-  const [editingConnection, setEditingConnection] = useState<Connection | null>(null);
+  const [editingConnection, setEditingConnection] = useState<Connection | null>(
+    null,
+  );
   const [showConnectionEditor, setShowConnectionEditor] = useState(false);
   const [showQuickConnect, setShowQuickConnect] = useState(false);
   const [showPasswordDialog, setShowPasswordDialog] = useState(false);
   const [showCollectionSelector, setShowCollectionSelector] = useState(false);
-  const [passwordDialogMode, setPasswordDialogMode] = useState<'setup' | 'unlock'>('setup');
-  const [passwordError, setPasswordError] = useState<string>('');
+  const [passwordDialogMode, setPasswordDialogMode] = useState<
+    "setup" | "unlock"
+  >("setup");
+  const [passwordError, setPasswordError] = useState<string>("");
 
   const settingsManager = SettingsManager.getInstance();
   const statusChecker = StatusChecker.getInstance();
@@ -49,20 +57,29 @@ const AppContent: React.FC = () => {
     setPasswordDialogMode,
   });
 
-  const handleCollectionSelect = async (collectionId: string, password?: string) => {
+  const handleCollectionSelect = async (
+    collectionId: string,
+    password?: string,
+  ) => {
     try {
       await collectionManager.selectCollection(collectionId, password);
       await loadData();
       setShowCollectionSelector(false);
       settingsManager.logAction(
-        'info',
-        'Collection selected',
+        "info",
+        "Collection selected",
         undefined,
         `Collection: ${collectionManager.getCurrentCollection()?.name}`,
       );
     } catch (error) {
-      console.error('Failed to select collection:', error);
-      alert('Failed to access collection. Please check your password.');
+      console.error("Failed to select collection:", error);
+      if (error instanceof CollectionNotFoundError) {
+        alert("Collection not found");
+      } else if (error instanceof InvalidPasswordError) {
+        alert("Invalid or missing password");
+      } else {
+        alert("Failed to access collection. Please check your password.");
+      }
     }
   };
 
@@ -78,16 +95,17 @@ const AppContent: React.FC = () => {
 
   const handleDeleteConnection = (connection: Connection) => {
     const settings = settingsManager.getSettings();
-    const confirmMessage = connection.warnOnClose || settings.warnOnClose
-      ? t('dialogs.confirmDelete')
-      : null;
+    const confirmMessage =
+      connection.warnOnClose || settings.warnOnClose
+        ? t("dialogs.confirmDelete")
+        : null;
 
     if (!confirmMessage || confirm(confirmMessage)) {
-      dispatch({ type: 'DELETE_CONNECTION', payload: connection.id });
+      dispatch({ type: "DELETE_CONNECTION", payload: connection.id });
       statusChecker.stopChecking(connection.id);
       settingsManager.logAction(
-        'info',
-        'Connection deleted',
+        "info",
+        "Connection deleted",
         connection.id,
         `Connection "${connection.name}" deleted`,
       );
@@ -96,41 +114,55 @@ const AppContent: React.FC = () => {
 
   const handlePasswordSubmit = async (password: string) => {
     try {
-      setPasswordError('');
+      setPasswordError("");
       SecureStorage.setPassword(password);
 
-      if (passwordDialogMode === 'unlock') {
+      if (passwordDialogMode === "unlock") {
         await loadData();
       } else {
         await saveData();
       }
 
       setShowPasswordDialog(false);
-      settingsManager.logAction('info', 'Storage unlocked', undefined, 'Data storage unlocked successfully');
+      settingsManager.logAction(
+        "info",
+        "Storage unlocked",
+        undefined,
+        "Data storage unlocked successfully",
+      );
     } catch (error) {
-      setPasswordError(passwordDialogMode === 'unlock' ? t('dialogs.invalidPassword') : 'Failed to secure data');
+      setPasswordError(
+        passwordDialogMode === "unlock"
+          ? t("dialogs.invalidPassword")
+          : "Failed to secure data",
+      );
       SecureStorage.clearPassword();
-      settingsManager.logAction('error', 'Storage unlock failed', undefined, error instanceof Error ? error.message : 'Unknown error');
+      settingsManager.logAction(
+        "error",
+        "Storage unlock failed",
+        undefined,
+        error instanceof Error ? error.message : "Unknown error",
+      );
     }
   };
 
   const handlePasswordCancel = () => {
-    if (passwordDialogMode === 'setup') {
+    if (passwordDialogMode === "setup") {
       saveData().catch(console.error);
     }
     setShowPasswordDialog(false);
-    setPasswordError('');
+    setPasswordError("");
   };
 
   const handleShowPasswordDialog = async () => {
     if (await SecureStorage.isStorageEncrypted()) {
       if (SecureStorage.isStorageUnlocked()) {
-        setPasswordDialogMode('setup');
+        setPasswordDialogMode("setup");
       } else {
-        setPasswordDialogMode('unlock');
+        setPasswordDialogMode("unlock");
       }
     } else {
-      setPasswordDialogMode('setup');
+      setPasswordDialogMode("setup");
     }
     setShowPasswordDialog(true);
   };
@@ -141,8 +173,8 @@ const AppContent: React.FC = () => {
       <div className="h-12 bg-gray-800 border-b border-gray-700 flex items-center justify-between px-4">
         <div className="flex items-center space-x-3">
           <Monitor size={20} className="text-blue-400" />
-          <span className="font-semibold">{t('app.title')}</span>
-          <span className="text-sm text-gray-400">{t('app.subtitle')}</span>
+          <span className="font-semibold">{t("app.title")}</span>
+          <span className="text-sm text-gray-400">{t("app.subtitle")}</span>
           {collectionManager.getCurrentCollection() && (
             <span className="text-xs text-blue-400 bg-blue-900/30 px-2 py-1 rounded">
               {collectionManager.getCurrentCollection()?.name}
@@ -156,7 +188,7 @@ const AppContent: React.FC = () => {
             className="flex items-center space-x-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors text-sm"
           >
             <Zap size={14} />
-            <span>{t('connections.quickConnect')}</span>
+            <span>{t("connections.quickConnect")}</span>
           </button>
 
           <div className="flex items-center space-x-1 text-xs text-gray-400">
@@ -203,23 +235,26 @@ const AppContent: React.FC = () => {
             ) : (
               <div className="h-full flex flex-col items-center justify-center text-gray-400">
                 <Monitor size={64} className="mb-4" />
-                <h2 className="text-xl font-medium mb-2">Welcome to {t('app.title')}</h2>
+                <h2 className="text-xl font-medium mb-2">
+                  Welcome to {t("app.title")}
+                </h2>
                 <p className="text-center max-w-md mb-6">
-                  Manage your remote connections efficiently. Create new connections or select
-                  an existing one from the sidebar to get started.
+                  Manage your remote connections efficiently. Create new
+                  connections or select an existing one from the sidebar to get
+                  started.
                 </p>
                 <div className="flex space-x-4">
                   <button
                     onClick={handleNewConnection}
                     className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
                   >
-                    {t('connections.new')} Connection
+                    {t("connections.new")} Connection
                   </button>
                   <button
                     onClick={() => setShowQuickConnect(true)}
                     className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors"
                   >
-                    {t('connections.quickConnect')}
+                    {t("connections.quickConnect")}
                   </button>
                 </div>
               </div>

--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { CollectionManager } from '../collectionManager';
-import { IndexedDbService } from '../indexedDbService';
-import { openDB } from 'idb';
+import { describe, it, expect, beforeEach } from "vitest";
+import { CollectionManager } from "../collectionManager";
+import { IndexedDbService } from "../indexedDbService";
+import { CollectionNotFoundError, InvalidPasswordError } from "../errors";
+import { openDB } from "idb";
 
-const DB_NAME = 'mremote-keyval';
-const STORE_NAME = 'keyval';
+const DB_NAME = "mremote-keyval";
+const STORE_NAME = "keyval";
 
 const sampleData = { connections: [], settings: {}, timestamp: 1 };
 
-describe('CollectionManager', () => {
+describe("CollectionManager", () => {
   let manager: CollectionManager;
 
   beforeEach(async () => {
@@ -18,21 +19,21 @@ describe('CollectionManager', () => {
     manager = new CollectionManager();
   });
 
-  it('creates and persists a collection', async () => {
-    const col = await manager.createCollection('Test');
-    const stored = await IndexedDbService.getItem<any[]>('mremote-collections');
+  it("creates and persists a collection", async () => {
+    const col = await manager.createCollection("Test");
+    const stored = await IndexedDbService.getItem<any[]>("mremote-collections");
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe(col.id);
-    expect(stored[0].name).toBe('Test');
+    expect(stored[0].name).toBe("Test");
   });
 
-  it('loads collection data', async () => {
-    await IndexedDbService.setItem('mremote-collection-abc', sampleData);
-    const loaded = await manager.loadCollectionData('abc');
+  it("loads collection data", async () => {
+    await IndexedDbService.setItem("mremote-collection-abc", sampleData);
+    const loaded = await manager.loadCollectionData("abc");
     expect(loaded).toEqual(sampleData);
   });
 
-  it('generates export filenames', () => {
+  it("generates export filenames", () => {
     const a = manager.generateExportFilename();
     const b = manager.generateExportFilename();
     expect(a).toMatch(/sortofremoteng-exports-.*\.json/);
@@ -40,21 +41,39 @@ describe('CollectionManager', () => {
     expect(a).not.toBe(b);
   });
 
-  it('updates and persists changes to a collection', async () => {
-    const col = await manager.createCollection('Initial', 'desc');
-    const updated = { ...col, name: 'Updated', description: 'changed' };
+  it("updates and persists changes to a collection", async () => {
+    const col = await manager.createCollection("Initial", "desc");
+    const updated = { ...col, name: "Updated", description: "changed" };
     await manager.updateCollection(updated);
 
-    const stored = await IndexedDbService.getItem<any[]>('mremote-collections');
-    expect(stored[0].name).toBe('Updated');
-    expect(stored[0].description).toBe('changed');
+    const stored = await IndexedDbService.getItem<any[]>("mremote-collections");
+    expect(stored[0].name).toBe("Updated");
+    expect(stored[0].description).toBe("changed");
   });
 
-  it('updates currentCollection when editing selected collection', async () => {
-    const col = await manager.createCollection('A');
+  it("updates currentCollection when editing selected collection", async () => {
+    const col = await manager.createCollection("A");
     await manager.selectCollection(col.id);
-    const updated = { ...col, name: 'B' };
+    const updated = { ...col, name: "B" };
     await manager.updateCollection(updated);
-    expect(manager.getCurrentCollection()?.name).toBe('B');
+    expect(manager.getCurrentCollection()?.name).toBe("B");
+  });
+
+  it("throws CollectionNotFoundError when selecting missing collection", async () => {
+    await expect(manager.selectCollection("missing")).rejects.toBeInstanceOf(
+      CollectionNotFoundError,
+    );
+  });
+
+  it("throws InvalidPasswordError when password is incorrect", async () => {
+    const col = await manager.createCollection(
+      "Secure",
+      "desc",
+      true,
+      "secret",
+    );
+    await expect(
+      manager.loadCollectionData(col.id, "wrong"),
+    ).rejects.toBeInstanceOf(InvalidPasswordError);
   });
 });

--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -1,12 +1,13 @@
-import CryptoJS from 'crypto-js';
-import { ConnectionCollection } from '../types/connection';
-import { StorageData } from './storage';
-import { IndexedDbService } from './indexedDbService';
-import { generateId } from './id';
+import CryptoJS from "crypto-js";
+import { ConnectionCollection } from "../types/connection";
+import { StorageData } from "./storage";
+import { IndexedDbService } from "./indexedDbService";
+import { generateId } from "./id";
+import { CollectionNotFoundError, InvalidPasswordError } from "./errors";
 
 export class CollectionManager {
   private static instance: CollectionManager;
-  private readonly collectionsKey = 'mremote-collections';
+  private readonly collectionsKey = "mremote-collections";
   private currentCollection: ConnectionCollection | null = null;
   private currentPassword: string | null = null;
 
@@ -25,7 +26,7 @@ export class CollectionManager {
     name: string,
     description?: string,
     isEncrypted: boolean = false,
-    password?: string
+    password?: string,
   ): Promise<ConnectionCollection> {
     const collection: ConnectionCollection = {
       id: generateId(),
@@ -43,9 +44,17 @@ export class CollectionManager {
 
     // Initialize empty data for the collection
     if (isEncrypted && password) {
-      await this.saveCollectionData(collection.id, { connections: [], settings: {}, timestamp: Date.now() }, password);
+      await this.saveCollectionData(
+        collection.id,
+        { connections: [], settings: {}, timestamp: Date.now() },
+        password,
+      );
     } else {
-      await this.saveCollectionData(collection.id, { connections: [], settings: {}, timestamp: Date.now() });
+      await this.saveCollectionData(collection.id, {
+        connections: [],
+        settings: {},
+        timestamp: Date.now(),
+      });
     }
 
     return collection;
@@ -53,9 +62,9 @@ export class CollectionManager {
 
   async getAllCollections(): Promise<ConnectionCollection[]> {
     try {
-      const collections = await IndexedDbService.getItem<ConnectionCollection[]>(
-        this.collectionsKey
-      );
+      const collections = await IndexedDbService.getItem<
+        ConnectionCollection[]
+      >(this.collectionsKey);
       if (collections) {
         return collections.map((c: any) => ({
           ...c,
@@ -66,38 +75,35 @@ export class CollectionManager {
       }
       return [];
     } catch (error) {
-      console.error('Failed to load collections:', error);
+      console.error("Failed to load collections:", error);
       return [];
     }
   }
 
   async getCollection(id: string): Promise<ConnectionCollection | null> {
     const collections = await this.getAllCollections();
-    return collections.find(c => c.id === id) || null;
+    return collections.find((c) => c.id === id) || null;
   }
 
   async selectCollection(id: string, password?: string): Promise<void> {
     const collection = await this.getCollection(id);
     if (!collection) {
-      throw new Error('Collection not found');
+      throw new CollectionNotFoundError();
     }
 
     if (collection.isEncrypted && !password) {
-      throw new Error('Password required for encrypted collection');
+      throw new InvalidPasswordError(
+        "Password required for encrypted collection",
+      );
     }
 
-    // Test access to the collection data
-    try {
-      await this.loadCollectionData(id, password);
-      this.currentCollection = collection;
-      this.currentPassword = password || null;
-      
-      // Update last accessed time
-      collection.lastAccessed = new Date();
-      await this.updateCollection(collection);
-    } catch (error) {
-      throw new Error('Invalid password or corrupted collection data');
-    }
+    await this.loadCollectionData(id, password);
+    this.currentCollection = collection;
+    this.currentPassword = password || null;
+
+    // Update last accessed time
+    collection.lastAccessed = new Date();
+    await this.updateCollection(collection);
   }
 
   getCurrentCollection(): ConnectionCollection | null {
@@ -106,7 +112,7 @@ export class CollectionManager {
 
   async updateCollection(collection: ConnectionCollection): Promise<void> {
     const collections = await this.getAllCollections();
-    const index = collections.findIndex(c => c.id === collection.id);
+    const index = collections.findIndex((c) => c.id === collection.id);
     if (index >= 0) {
       collections[index] = { ...collection, updatedAt: new Date() };
       await this.saveCollections(collections);
@@ -118,7 +124,7 @@ export class CollectionManager {
 
   async deleteCollection(id: string): Promise<void> {
     const collections = await this.getAllCollections();
-    const filteredCollections = collections.filter(c => c.id !== id);
+    const filteredCollections = collections.filter((c) => c.id !== id);
     await this.saveCollections(filteredCollections);
 
     // Remove collection data
@@ -130,68 +136,101 @@ export class CollectionManager {
     }
   }
 
-  private async saveCollections(collections: ConnectionCollection[]): Promise<void> {
+  private async saveCollections(
+    collections: ConnectionCollection[],
+  ): Promise<void> {
     await IndexedDbService.setItem(this.collectionsKey, collections);
   }
 
   // Collection data management
-  async saveCollectionData(collectionId: string, data: StorageData, password?: string): Promise<void> {
+  async saveCollectionData(
+    collectionId: string,
+    data: StorageData,
+    password?: string,
+  ): Promise<void> {
     const key = `mremote-collection-${collectionId}`;
 
     if (password) {
-      const encrypted = CryptoJS.AES.encrypt(JSON.stringify(data), password).toString();
+      const encrypted = CryptoJS.AES.encrypt(
+        JSON.stringify(data),
+        password,
+      ).toString();
       await IndexedDbService.setItem(key, encrypted);
     } else {
       await IndexedDbService.setItem(key, data);
     }
   }
 
-  async loadCollectionData(collectionId: string, password?: string): Promise<StorageData | null> {
+  async loadCollectionData(
+    collectionId: string,
+    password?: string,
+  ): Promise<StorageData | null> {
     const key = `mremote-collection-${collectionId}`;
     const stored = await IndexedDbService.getItem<any>(key);
 
-    if (!stored) return null;
+    if (!stored) {
+      throw new CollectionNotFoundError();
+    }
 
     try {
       if (password) {
-        const decrypted = CryptoJS.AES.decrypt(stored, password).toString(CryptoJS.enc.Utf8);
+        const decrypted = CryptoJS.AES.decrypt(stored, password).toString(
+          CryptoJS.enc.Utf8,
+        );
         if (!decrypted) {
-          throw new Error('Invalid password');
+          throw new InvalidPasswordError();
         }
         return JSON.parse(decrypted);
       } else {
         return stored as StorageData;
       }
     } catch (error) {
-      throw new Error('Failed to load collection data or invalid password');
+      if (error instanceof InvalidPasswordError) {
+        throw error;
+      }
+      throw new InvalidPasswordError();
     }
   }
 
   // Current collection data access
   async saveCurrentCollectionData(data: StorageData): Promise<void> {
     if (!this.currentCollection) {
-      throw new Error('No collection selected');
+      throw new Error("No collection selected");
     }
-    await this.saveCollectionData(this.currentCollection.id, data, this.currentPassword || undefined);
+    await this.saveCollectionData(
+      this.currentCollection.id,
+      data,
+      this.currentPassword || undefined,
+    );
   }
 
   async loadCurrentCollectionData(): Promise<StorageData | null> {
     if (!this.currentCollection) {
-      throw new Error('No collection selected');
+      throw new Error("No collection selected");
     }
-    return this.loadCollectionData(this.currentCollection.id, this.currentPassword || undefined);
+    return this.loadCollectionData(
+      this.currentCollection.id,
+      this.currentPassword || undefined,
+    );
   }
 
   // Export collection with encryption
-  async exportCollection(collectionId: string, includePasswords: boolean = false, exportPassword?: string): Promise<string> {
+  async exportCollection(
+    collectionId: string,
+    includePasswords: boolean = false,
+    exportPassword?: string,
+  ): Promise<string> {
     const collection = await this.getCollection(collectionId);
     if (!collection) {
-      throw new Error('Collection not found');
+      throw new Error("Collection not found");
     }
 
-    const data = await this.loadCollectionData(collectionId, this.currentPassword || undefined);
+    const data = await this.loadCollectionData(
+      collectionId,
+      this.currentPassword || undefined,
+    );
     if (!data) {
-      throw new Error('Failed to load collection data');
+      throw new Error("Failed to load collection data");
     }
 
     const exportData = {
@@ -200,11 +239,15 @@ export class CollectionManager {
         description: collection.description,
         exportDate: new Date().toISOString(),
       },
-      connections: includePasswords ? data.connections : data.connections.map((conn: any) => ({
-        ...conn,
-        password: conn.password ? '***ENCRYPTED***' : undefined,
-        basicAuthPassword: conn.basicAuthPassword ? '***ENCRYPTED***' : undefined,
-      })),
+      connections: includePasswords
+        ? data.connections
+        : data.connections.map((conn: any) => ({
+            ...conn,
+            password: conn.password ? "***ENCRYPTED***" : undefined,
+            basicAuthPassword: conn.basicAuthPassword
+              ? "***ENCRYPTED***"
+              : undefined,
+          })),
       settings: data.settings,
     };
 
@@ -217,12 +260,15 @@ export class CollectionManager {
     return jsonData;
   }
 
-  async removePasswordFromCollection(collectionId: string, password: string): Promise<void> {
+  async removePasswordFromCollection(
+    collectionId: string,
+    password: string,
+  ): Promise<void> {
     const collection = await this.getCollection(collectionId);
-    if (!collection) throw new Error('Collection not found');
+    if (!collection) throw new Error("Collection not found");
 
     const data = await this.loadCollectionData(collectionId, password);
-    if (data === null) throw new Error('Invalid password');
+    if (data === null) throw new Error("Invalid password");
 
     await this.saveCollectionData(collectionId, data);
     collection.isEncrypted = false;
@@ -237,7 +283,7 @@ export class CollectionManager {
   // Generate export filename
   generateExportFilename(): string {
     const now = new Date();
-    const datetime = now.toISOString().replace(/[:.]/g, '-').slice(0, -5);
+    const datetime = now.toISOString().replace(/[:.]/g, "-").slice(0, -5);
     const randomHex = Math.random().toString(16).substring(2, 8);
     return `sortofremoteng-exports-${datetime}-${randomHex}.json`;
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,13 @@
+export class CollectionNotFoundError extends Error {
+  constructor(message: string = "Collection not found") {
+    super(message);
+    this.name = "CollectionNotFoundError";
+  }
+}
+
+export class InvalidPasswordError extends Error {
+  constructor(message: string = "Invalid password") {
+    super(message);
+    this.name = "InvalidPasswordError";
+  }
+}


### PR DESCRIPTION
## Summary
- add `CollectionNotFoundError` and `InvalidPasswordError`
- update CollectionManager to throw and propagate new errors
- surface explicit error messages when selecting a collection
- test both error scenarios for CollectionManager

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689d0c25c47c83259a4fef721735c1a2