### PR TITLE
feat: sandbox script engine

### DIFF
--- a/src/utils/__tests__/scriptEngine.test.ts
+++ b/src/utils/__tests__/scriptEngine.test.ts
@@ -75,6 +75,57 @@ describe('ScriptEngine sandbox', () => {
     const result = await engine.executeScript(script, { trigger: 'manual' });
     expect(result).toBe('undefined');
   });
+
+  it('hides globalThis and process', async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: 's-global',
+      name: 'global access',
+      type: 'javascript',
+      content: "return [typeof globalThis, typeof process];",
+      trigger: 'manual',
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const result = await engine.executeScript(script, { trigger: 'manual' });
+    expect(result).toEqual(['undefined', 'undefined']);
+  });
+});
+
+describe('ScriptEngine error handling', () => {
+  it('reports script errors', async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: 's-error',
+      name: 'error script',
+      type: 'javascript',
+      content: "throw new Error('boom');",
+      trigger: 'manual',
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    await expect(engine.executeScript(script, { trigger: 'manual' })).rejects.toThrow('boom');
+  });
+
+  it('enforces execution timeout', async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: 's-timeout',
+      name: 'timeout script',
+      type: 'javascript',
+      content: 'while(true) {}',
+      trigger: 'manual',
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    await expect(engine.executeScript(script, { trigger: 'manual' })).rejects.toThrow(/timed out/);
+  });
 });
 
 describe('ScriptEngine.httpRequest', () => {


### PR DESCRIPTION
## Summary
- restrict scripts to whitelisted APIs and hide global objects
- add web worker sandbox with RPC for browser execution
- test isolation, error handling, and timeouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a26e69e370832585f86b3f55f54b04