### PR TITLE
refactor(storage): derive AES key with PBKDF2

### DIFF
--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { openDB } from 'idb';
-import { SecureStorage, type StorageData } from '../storage';
-import { IndexedDbService } from '../indexedDbService';
+import { describe, it, expect, beforeEach } from "vitest";
+import { openDB } from "idb";
+import { SecureStorage, type StorageData } from "../storage";
+import { IndexedDbService } from "../indexedDbService";
 
-const DB_NAME = 'mremote-keyval';
-const STORE_NAME = 'keyval';
+const DB_NAME = "mremote-keyval";
+const STORE_NAME = "keyval";
 
 beforeEach(async () => {
   await IndexedDbService.init();
@@ -13,12 +13,45 @@ beforeEach(async () => {
   SecureStorage.clearPassword();
 });
 
-describe('SecureStorage', () => {
-  it('rejects when loading encrypted data without a password', async () => {
-    const data: StorageData = { connections: [], settings: {}, timestamp: Date.now() };
-    SecureStorage.setPassword('secret');
+describe("SecureStorage", () => {
+  it("rejects when loading encrypted data without a password", async () => {
+    const data: StorageData = {
+      connections: [],
+      settings: {},
+      timestamp: Date.now(),
+    };
+    SecureStorage.setPassword("secret");
     await SecureStorage.saveData(data, true);
     SecureStorage.clearPassword();
-    await expect(SecureStorage.loadData()).rejects.toThrow('Password is required to load encrypted data');
+    await expect(SecureStorage.loadData()).rejects.toThrow(
+      "Password is required to load encrypted data",
+    );
+  });
+
+  it("round-trips encrypted data with the correct password", async () => {
+    const data: StorageData = {
+      connections: [],
+      settings: {},
+      timestamp: Date.now(),
+    };
+    SecureStorage.setPassword("hunter2");
+    await SecureStorage.saveData(data, true);
+    SecureStorage.clearPassword();
+    SecureStorage.setPassword("hunter2");
+    const loaded = await SecureStorage.loadData();
+    expect(loaded).toEqual(data);
+  });
+
+  it("throws when decrypting with the wrong password", async () => {
+    const data: StorageData = {
+      connections: [],
+      settings: {},
+      timestamp: Date.now(),
+    };
+    SecureStorage.setPassword("correct");
+    await SecureStorage.saveData(data, true);
+    SecureStorage.clearPassword();
+    SecureStorage.setPassword("wrong");
+    await expect(SecureStorage.loadData()).rejects.toThrow("Invalid password");
   });
 });


### PR DESCRIPTION
## Summary
- switch SecureStorage to AES-GCM with PBKDF2-derived keys
- expand SecureStorage tests for encrypt/decrypt flows and bad passwords

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a26e65b42c8325a8daa96ecb3be221