### PR TITLE
Add global error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { SessionViewer } from "./components/SessionViewer";
 import { QuickConnect } from "./components/QuickConnect";
 import { PasswordDialog } from "./components/PasswordDialog";
 import { CollectionSelector } from "./components/CollectionSelector";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Connection } from "./types/connection";
 import { SecureStorage } from "./utils/storage";
 import { SettingsManager } from "./utils/settingsManager";
@@ -295,7 +296,9 @@ const AppContent: React.FC = () => {
 
 const App: React.FC = () => (
   <ConnectionProvider>
-    <AppContent />
+    <ErrorBoundary>
+      <AppContent />
+    </ErrorBoundary>
   </ConnectionProvider>
 );
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<React.PropsWithChildren, ErrorBoundaryState> {
+  constructor(props: React.PropsWithChildren) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 text-red-500">
+          Something went wrong.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorBoundary } from '../src/components/ErrorBoundary';
+
+const Bomb: React.FC = () => {
+  throw new Error('Boom');
+};
+
+describe('ErrorBoundary', () => {
+  it('renders fallback UI when child throws', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>Safe</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Safe')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component to render a fallback when children throw
- wrap `AppContent` with `ErrorBoundary` to protect root rendering
- test that error boundaries show a fallback and normal rendering continues

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a26e64d7088325b90dceba506f604c