### PR TITLE
refactor: use async fs operations

### DIFF
--- a/src/utils/fileStorage.ts
+++ b/src/utils/fileStorage.ts
@@ -11,19 +11,29 @@ function dateReviver(key: string, value: any): any {
   return value;
 }
 
-export function loadJson<T>(filePath: string, defaultValue: T): T {
+export async function loadJson<T>(
+  filePath: string,
+  defaultValue: T
+): Promise<T> {
   try {
     const fullPath = path.resolve(filePath);
-    const data = fs.readFileSync(fullPath, 'utf8');
+    const data = await fs.promises.readFile(fullPath, 'utf8');
     return JSON.parse(data, dateReviver) as T;
   } catch {
     return defaultValue;
   }
 }
 
-export function saveJson<T>(filePath: string, data: T): void {
+export async function saveJson<T>(
+  filePath: string,
+  data: T
+): Promise<void> {
   const fullPath = path.resolve(filePath);
-  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-  fs.writeFileSync(fullPath, JSON.stringify(data, null, 2), 'utf8');
+  await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.promises.writeFile(
+    fullPath,
+    JSON.stringify(data, null, 2),
+    'utf8'
+  );
 }
 


### PR DESCRIPTION
## Summary
- refactor auth service to use fs.promises with async load/persist
- switch fileStorage helpers to async fs.promises
- await async persistence in REST API server routes

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3bcdc50a88325a6f1b5aef9e556b5