### PR TITLE
Validate IPv4 input and secure ARP lookup

### DIFF
--- a/src/utils/restApiServer.ts
+++ b/src/utils/restApiServer.ts
@@ -1,20 +1,22 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
-import jwt from 'jsonwebtoken';
-import { Server } from 'http';
-import dns from 'node:dns/promises';
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
-import { z } from 'zod';
-import { AuthService } from './authService';
-import { Connection, ConnectionSession } from '../types/connection';
-import { debugLog } from './debugLogger';
-import { generateId } from './id';
-import { loadJson, saveJson } from './fileStorage';
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import jwt from "jsonwebtoken";
+import { Server } from "http";
+import dns from "node:dns/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { z } from "zod";
+import { AuthService } from "./authService";
+import { Connection, ConnectionSession } from "../types/connection";
+import { debugLog } from "./debugLogger";
+import { generateId } from "./id";
+import { loadJson, saveJson } from "./fileStorage";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+const ipv4Regex =
+  /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/;
 
 interface ApiConfig {
   port: number;
@@ -55,17 +57,18 @@ export class RestApiServer {
       authentication: config.authentication,
       corsEnabled: config.corsEnabled,
       rateLimiting: config.rateLimiting,
-      apiKey: config.apiKey ?? process.env.API_KEY ?? '',
-      jwtSecret: config.jwtSecret ?? process.env.JWT_SECRET ?? 'defaultsecret',
-      userStorePath: config.userStorePath ?? process.env.USER_STORE_PATH ?? 'users.json',
+      apiKey: config.apiKey ?? process.env.API_KEY ?? "",
+      jwtSecret: config.jwtSecret ?? process.env.JWT_SECRET ?? "defaultsecret",
+      userStorePath:
+        config.userStorePath ?? process.env.USER_STORE_PATH ?? "users.json",
       connectionsStorePath:
         config.connectionsStorePath ??
         process.env.CONNECTIONS_STORE_PATH ??
-        'connections.json',
+        "connections.json",
       sessionsStorePath:
         config.sessionsStorePath ??
         process.env.SESSIONS_STORE_PATH ??
-        'sessions.json',
+        "sessions.json",
     };
     this.config = defaultConfig;
     this.app = express();
@@ -77,11 +80,11 @@ export class RestApiServer {
   private async loadPersistedData(): Promise<void> {
     this.connections = await loadJson<Connection[]>(
       this.config.connectionsStorePath,
-      []
+      [],
     );
     this.sessions = await loadJson<ConnectionSession[]>(
       this.config.sessionsStorePath,
-      []
+      [],
     );
   }
 
@@ -99,10 +102,12 @@ export class RestApiServer {
 
     // CORS
     if (this.config.corsEnabled) {
-      this.app.use(cors({
-        origin: true,
-        credentials: true,
-      }));
+      this.app.use(
+        cors({
+          origin: true,
+          credentials: true,
+        }),
+      );
     }
 
     // Rate limiting
@@ -120,94 +125,100 @@ export class RestApiServer {
           }
           next();
         } catch {
-          res.status(429).json({ error: 'Too many requests' });
+          res.status(429).json({ error: "Too many requests" });
         }
       });
     }
 
     // Body parsing
-    this.app.use(express.json({ limit: '10mb' }));
+    this.app.use(express.json({ limit: "10mb" }));
     this.app.use(express.urlencoded({ extended: true }));
 
     // Authentication middleware
     if (this.config.authentication) {
-      this.app.use('/api', this.authenticateRequest.bind(this));
+      this.app.use("/api", this.authenticateRequest.bind(this));
     }
   }
 
-  private authenticateRequest(req: express.Request, res: express.Response, next: express.NextFunction): void {
+  private authenticateRequest(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ): void {
     // Skip auth for login endpoint
-    if (req.path === '/auth/login') {
+    if (req.path === "/auth/login") {
       return next();
     }
 
     const authHeader = req.headers.authorization;
-    const apiKey = req.headers['x-api-key'] as string;
+    const apiKey = req.headers["x-api-key"] as string;
 
     // API Key authentication
     if (apiKey) {
       if (apiKey === this.config.apiKey) {
         return next();
       } else {
-        return res.status(401).json({ error: 'Invalid API key' });
+        return res.status(401).json({ error: "Invalid API key" });
       }
     }
 
     // JWT authentication
-    if (authHeader && authHeader.startsWith('Bearer ')) {
+    if (authHeader && authHeader.startsWith("Bearer ")) {
       const token = authHeader.substring(7);
-      
+
       try {
         const decoded = jwt.verify(token, this.config.jwtSecret);
         (req as AuthRequest).user = decoded;
         next();
       } catch {
-        res.status(401).json({ error: 'Invalid token' });
+        res.status(401).json({ error: "Invalid token" });
       }
     } else {
-      res.status(401).json({ error: 'Authentication required' });
+      res.status(401).json({ error: "Authentication required" });
     }
   }
 
   private setupRoutes(): void {
     // Health check
-    this.app.get('/health', (req, res) => {
-      res.json({ status: 'ok', timestamp: new Date().toISOString() });
+    this.app.get("/health", (req, res) => {
+      res.json({ status: "ok", timestamp: new Date().toISOString() });
     });
 
     // Network utilities
-    this.app.get('/api/resolve-hostname', async (req, res) => {
+    this.app.get("/api/resolve-hostname", async (req, res) => {
       const ip = req.query.ip as string;
-      if (!ip) {
-        return res.status(400).json({ error: 'IP parameter required' });
+      if (!ip || !ipv4Regex.test(ip)) {
+        return res.status(400).json({ error: "Invalid IP address" });
       }
       try {
         const hostnames = await dns.reverse(ip);
         if (hostnames.length > 0) {
           res.json({ hostname: hostnames[0] });
         } else {
-          res.status(404).json({ error: 'Hostname not found' });
+          res.status(404).json({ error: "Hostname not found" });
         }
-      } catch {
-        res.status(500).json({ error: 'Lookup failed' });
+      } catch (error) {
+        console.error("Hostname lookup failed", error);
+        res.status(500).json({ error: "Lookup failed" });
       }
     });
 
-    this.app.get('/api/arp-lookup', async (req, res) => {
+    this.app.get("/api/arp-lookup", async (req, res) => {
       const ip = req.query.ip as string;
-      if (!ip) {
-        return res.status(400).json({ error: 'IP parameter required' });
+      if (!ip || !ipv4Regex.test(ip)) {
+        return res.status(400).json({ error: "Invalid IP address" });
       }
       try {
-        const { stdout } = await execAsync(`arp -n ${ip}`);
+        const { stdout } = await execFileAsync("arp", ["-n", ip]);
         const match = stdout.match(/([0-9a-f]{2}[:-]){5}[0-9a-f]{2}/i);
         if (match) {
           res.json({ mac: match[0].toLowerCase() });
         } else {
-          res.status(404).json({ error: 'MAC not found' });
+          res.status(404).json({ error: "MAC not found" });
         }
-      } catch {
-        res.status(500).json({ error: 'Lookup failed' });
+      } catch (error) {
+        console.error("ARP lookup failed", error);
+        res.status(500).json({ error: "Lookup failed" });
       }
     });
 
@@ -226,7 +237,7 @@ export class RestApiServer {
     const connectionUpdateSchema = connectionSchema.partial();
     const sessionSchema = z.object({ connectionId: z.string() });
     const bulkSchema = z.object({
-      action: z.enum(['delete', 'connect']),
+      action: z.enum(["delete", "connect"]),
       connectionIds: z.array(z.string()),
     });
     const importSchema = z.object({
@@ -234,36 +245,36 @@ export class RestApiServer {
     });
 
     // Authentication
-    this.app.post('/auth/login', async (req, res) => {
+    this.app.post("/auth/login", async (req, res) => {
       const result = loginSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid request' });
+        return res.status(400).json({ error: "Invalid request" });
       }
       const { username, password } = result.data;
 
       const valid = await this.authService.verifyUser(username, password);
       if (!valid) {
-        return res.status(401).json({ error: 'Invalid credentials' });
+        return res.status(401).json({ error: "Invalid credentials" });
       }
 
       const token = jwt.sign(
-        { username, role: 'admin' },
+        { username, role: "admin" },
         this.config.jwtSecret,
-        { expiresIn: '24h' }
+        { expiresIn: "24h" },
       );
 
-      res.json({ token, expiresIn: '24h' });
+      res.json({ token, expiresIn: "24h" });
     });
 
     // Connections API
-    this.app.get('/api/connections', (req, res) => {
+    this.app.get("/api/connections", (req, res) => {
       res.json(this.connections);
     });
 
-    this.app.post('/api/connections', async (req, res) => {
+    this.app.post("/api/connections", async (req, res) => {
       const result = connectionSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid connection data' });
+        return res.status(400).json({ error: "Invalid connection data" });
       }
 
       const connection: Connection = {
@@ -277,26 +288,26 @@ export class RestApiServer {
       try {
         await this.persistConnections();
       } catch {
-        return res.status(500).json({ error: 'Failed to save connection' });
+        return res.status(500).json({ error: "Failed to save connection" });
       }
       res.status(201).json(connection);
     });
 
-    this.app.get('/api/connections/:id', (req, res) => {
-      const connection = this.connections.find(c => c.id === req.params.id);
+    this.app.get("/api/connections/:id", (req, res) => {
+      const connection = this.connections.find((c) => c.id === req.params.id);
       if (connection) {
         res.json(connection);
       } else {
-        res.status(404).json({ error: 'Connection not found' });
+        res.status(404).json({ error: "Connection not found" });
       }
     });
 
-    this.app.put('/api/connections/:id', async (req, res) => {
+    this.app.put("/api/connections/:id", async (req, res) => {
       const result = connectionUpdateSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid connection data' });
+        return res.status(400).json({ error: "Invalid connection data" });
       }
-      const index = this.connections.findIndex(c => c.id === req.params.id);
+      const index = this.connections.findIndex((c) => c.id === req.params.id);
       if (index >= 0) {
         this.connections[index] = {
           ...this.connections[index],
@@ -306,51 +317,51 @@ export class RestApiServer {
         try {
           await this.persistConnections();
         } catch {
-          return res.status(500).json({ error: 'Failed to update connection' });
+          return res.status(500).json({ error: "Failed to update connection" });
         }
         res.json(this.connections[index]);
       } else {
-        res.status(404).json({ error: 'Connection not found' });
+        res.status(404).json({ error: "Connection not found" });
       }
     });
 
-    this.app.delete('/api/connections/:id', async (req, res) => {
-      const index = this.connections.findIndex(c => c.id === req.params.id);
+    this.app.delete("/api/connections/:id", async (req, res) => {
+      const index = this.connections.findIndex((c) => c.id === req.params.id);
       if (index >= 0) {
         this.connections.splice(index, 1);
         try {
           await this.persistConnections();
         } catch {
-          return res.status(500).json({ error: 'Failed to delete connection' });
+          return res.status(500).json({ error: "Failed to delete connection" });
         }
         res.status(204).send();
       } else {
-        res.status(404).json({ error: 'Connection not found' });
+        res.status(404).json({ error: "Connection not found" });
       }
     });
 
     // Sessions API
-    this.app.get('/api/sessions', (req, res) => {
+    this.app.get("/api/sessions", (req, res) => {
       res.json(this.sessions);
     });
 
-    this.app.post('/api/sessions', async (req, res) => {
+    this.app.post("/api/sessions", async (req, res) => {
       const result = sessionSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid session data' });
+        return res.status(400).json({ error: "Invalid session data" });
       }
       const { connectionId } = result.data;
-      const connection = this.connections.find(c => c.id === connectionId);
+      const connection = this.connections.find((c) => c.id === connectionId);
 
       if (!connection) {
-        return res.status(404).json({ error: 'Connection not found' });
+        return res.status(404).json({ error: "Connection not found" });
       }
 
       const session: ConnectionSession = {
         id: generateId(),
         connectionId,
         name: connection.name,
-        status: 'connecting',
+        status: "connecting",
         startTime: new Date(),
         protocol: connection.protocol,
         hostname: connection.hostname,
@@ -360,49 +371,49 @@ export class RestApiServer {
       try {
         await this.persistSessions();
       } catch {
-        return res.status(500).json({ error: 'Failed to save session' });
+        return res.status(500).json({ error: "Failed to save session" });
       }
       res.status(201).json(session);
     });
 
-    this.app.delete('/api/sessions/:id', async (req, res) => {
-      const index = this.sessions.findIndex(s => s.id === req.params.id);
+    this.app.delete("/api/sessions/:id", async (req, res) => {
+      const index = this.sessions.findIndex((s) => s.id === req.params.id);
       if (index >= 0) {
         this.sessions.splice(index, 1);
         try {
           await this.persistSessions();
         } catch {
-          return res.status(500).json({ error: 'Failed to delete session' });
+          return res.status(500).json({ error: "Failed to delete session" });
         }
         res.status(204).send();
       } else {
-        res.status(404).json({ error: 'Session not found' });
+        res.status(404).json({ error: "Session not found" });
       }
     });
 
     // Bulk operations
-    this.app.post('/api/connections/bulk', async (req, res) => {
+    this.app.post("/api/connections/bulk", async (req, res) => {
       const result = bulkSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid bulk request' });
+        return res.status(400).json({ error: "Invalid bulk request" });
       }
       const { action, connectionIds } = result.data;
 
       switch (action) {
-        case 'delete':
+        case "delete":
           this.connections = this.connections.filter(
-            c => !connectionIds.includes(c.id)
+            (c) => !connectionIds.includes(c.id),
           );
           break;
-        case 'connect':
+        case "connect":
           connectionIds.forEach((id: string) => {
-            const connection = this.connections.find(c => c.id === id);
+            const connection = this.connections.find((c) => c.id === id);
             if (connection) {
               const session: ConnectionSession = {
                 id: generateId(),
                 connectionId: id,
                 name: connection.name,
-                status: 'connecting',
+                status: "connecting",
                 startTime: new Date(),
                 protocol: connection.protocol,
                 hostname: connection.hostname,
@@ -412,7 +423,7 @@ export class RestApiServer {
           });
           break;
         default:
-          return res.status(400).json({ error: 'Invalid action' });
+          return res.status(400).json({ error: "Invalid action" });
       }
 
       try {
@@ -421,19 +432,19 @@ export class RestApiServer {
       } catch {
         return res
           .status(500)
-          .json({ error: 'Failed to process bulk request' });
+          .json({ error: "Failed to process bulk request" });
       }
       res.json({ success: true, affected: connectionIds.length });
     });
 
     // Import/Export
-    this.app.post('/api/connections/import', async (req, res) => {
+    this.app.post("/api/connections/import", async (req, res) => {
       const result = importSchema.safeParse(req.body);
       if (!result.success) {
-        return res.status(400).json({ error: 'Invalid import data' });
+        return res.status(400).json({ error: "Invalid import data" });
       }
 
-      const imported = result.data.connections.map(conn => ({
+      const imported = result.data.connections.map((conn) => ({
         ...conn,
         id: generateId(),
         createdAt: new Date(),
@@ -444,23 +455,26 @@ export class RestApiServer {
       try {
         await this.persistConnections();
       } catch {
-        return res.status(500).json({ error: 'Failed to import connections' });
+        return res.status(500).json({ error: "Failed to import connections" });
       }
       res.json({ imported: imported.length });
     });
 
-    this.app.get('/api/connections/export', (req, res) => {
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Content-Disposition', 'attachment; filename=connections.json');
+    this.app.get("/api/connections/export", (req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.setHeader(
+        "Content-Disposition",
+        "attachment; filename=connections.json",
+      );
       res.json({
-        version: '1.0',
+        version: "1.0",
         exportDate: new Date().toISOString(),
         connections: this.connections,
       });
     });
 
     // Statistics
-    this.app.get('/api/stats', (req, res) => {
+    this.app.get("/api/stats", (req, res) => {
       res.json({
         totalConnections: this.connections.length,
         activeSessions: this.sessions.length,
@@ -475,25 +489,25 @@ export class RestApiServer {
         err: Error,
         req: express.Request,
         res: express.Response,
-        next: express.NextFunction
+        next: express.NextFunction,
       ) => {
-        console.error('API Error:', err);
+        console.error("API Error:", err);
         if (res.headersSent) {
           return next(err);
         }
-        res.status(500).json({ error: 'Internal server error' });
-      }
+        res.status(500).json({ error: "Internal server error" });
+      },
     );
 
     // 404 handler
     this.app.use((req, res) => {
-      res.status(404).json({ error: 'Endpoint not found' });
+      res.status(404).json({ error: "Endpoint not found" });
     });
   }
 
   private getConnectionsByProtocol(): Record<string, number> {
     const stats: Record<string, number> = {};
-    this.connections.forEach(conn => {
+    this.connections.forEach((conn) => {
       stats[conn.protocol] = (stats[conn.protocol] || 0) + 1;
     });
     return stats;
@@ -501,7 +515,7 @@ export class RestApiServer {
 
   private getSessionsByStatus(): Record<string, number> {
     const stats: Record<string, number> = {};
-    this.sessions.forEach(session => {
+    this.sessions.forEach((session) => {
       stats[session.status] = (stats[session.status] || 0) + 1;
     });
     return stats;
@@ -512,11 +526,11 @@ export class RestApiServer {
     return new Promise((resolve, reject) => {
       try {
         this.server = this.app.listen(this.config.port);
-        this.server.once('listening', () => {
+        this.server.once("listening", () => {
           debugLog(`REST API server started on port ${this.config.port}`);
           resolve();
         });
-        this.server.once('error', (error: Error) => {
+        this.server.once("error", (error: Error) => {
           reject(error);
         });
       } catch (error) {
@@ -529,7 +543,7 @@ export class RestApiServer {
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {
-          debugLog('REST API server stopped');
+          debugLog("REST API server stopped");
           resolve();
         });
       } else {
@@ -544,7 +558,7 @@ export class RestApiServer {
     try {
       await this.persistConnections();
     } catch (error) {
-      console.error('Failed to persist connections', error);
+      console.error("Failed to persist connections", error);
     }
   }
 
@@ -553,7 +567,7 @@ export class RestApiServer {
     try {
       await this.persistSessions();
     } catch (error) {
-      console.error('Failed to persist sessions', error);
+      console.error("Failed to persist sessions", error);
     }
   }
 }


### PR DESCRIPTION
## Summary
- validate IP addresses with a strict IPv4 regex before performing network lookups
- use `execFile` to run `arp` without a shell and log execution failures

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3bf8dacac832597fa96136b513553