### PR TITLE
feat: make PBKDF2 iterations configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,6 @@ A sort of remoteNG inspired web app that runs on the browser. Very broken and no
 
 ## Testing
 
-
 To run the unit tests, you **must** install dependencies first:
 
 ```bash
@@ -37,9 +36,7 @@ The REST API uses a simple user store with bcrypt-hashed passwords and JWT token
    `username` and `passwordHash` fields:
 
    ```json
-   [
-     { "username": "admin", "passwordHash": "<bcrypt-hash>" }
-   ]
+   [{ "username": "admin", "passwordHash": "<bcrypt-hash>" }]
    ```
 
    Generate hashes with:
@@ -59,6 +56,7 @@ Environment variables:
 - `API_KEY` – optional API key (defaults to none).
 - `JWT_SECRET` – secret for signing JWTs (defaults to `defaultsecret`).
 - `USER_STORE_PATH` – path to the users file (defaults to `users.json`).
+- `PBKDF2_ITERATIONS` – overrides key derivation iterations (defaults to `150000`).
 
 ## Appearance
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,11 @@
+const DEFAULT_PBKDF2_ITERATIONS = 150000;
+
+const envValue =
+  typeof process !== "undefined" ? process.env.PBKDF2_ITERATIONS : undefined;
+
+export const PBKDF2_ITERATIONS =
+  envValue && !Number.isNaN(Number(envValue))
+    ? Number(envValue)
+    : DEFAULT_PBKDF2_ITERATIONS;
+
+export { DEFAULT_PBKDF2_ITERATIONS };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,6 +4,7 @@ const OLD_STORAGE_META_KEY = "mremote-settings";
 
 import { Connection } from "../types/connection";
 import { IndexedDbService } from "./indexedDbService";
+import { PBKDF2_ITERATIONS } from "../config";
 
 const getCrypto = (): Crypto => globalThis.crypto as Crypto;
 
@@ -54,7 +55,7 @@ export class SecureStorage {
       {
         name: "PBKDF2",
         salt,
-        iterations: 150000,
+        iterations: PBKDF2_ITERATIONS,
         hash: "SHA-256",
       },
       keyMaterial,


### PR DESCRIPTION
## Summary
- add configurable `PBKDF2_ITERATIONS` with default of 150000
- use configurable iteration count in secure storage key derivation
- document `PBKDF2_ITERATIONS` environment variable

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a3c1424ba8832581e9f476af464822