### PR TITLE
feat: add REST-based Wake-on-LAN support

### DIFF
--- a/src/utils/__tests__/restApiServer.wol.test.ts
+++ b/src/utils/__tests__/restApiServer.wol.test.ts
@@ -1,0 +1,63 @@
+import request from "supertest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Application } from "express";
+import dgram from "dgram";
+import { RestApiServer } from "../restApiServer";
+
+/**
+ * Integration tests for the Wake-on-LAN REST endpoint
+ */
+describe("Wake-on-LAN REST endpoint", () => {
+  let server: RestApiServer;
+  let app: Application;
+
+  beforeEach(() => {
+    server = new RestApiServer({
+      port: 0,
+      authentication: false,
+      corsEnabled: false,
+      rateLimiting: false,
+      jwtSecret: "secret",
+    });
+    app = (server as unknown as { app: Application }).app;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("broadcasts received packet", async () => {
+    const socketMock = {
+      bind: (cb: () => void) => cb(),
+      setBroadcast: vi.fn(),
+      send: vi.fn(
+        (
+          buf: Buffer,
+          _o: number,
+          _l: number,
+          _p: number,
+          _a: string,
+          cb: (err?: Error) => void,
+        ) => cb(),
+      ),
+      close: vi.fn(),
+    } as unknown as dgram.Socket;
+    const sendSpy = vi.spyOn(socketMock, "send");
+    vi.spyOn(dgram, "createSocket").mockReturnValue(socketMock);
+
+    const res = await request(app)
+      .post("/api/wol")
+      .send({
+        packet: [1, 2, 3],
+        broadcastAddress: "255.255.255.255",
+        port: 7,
+      });
+
+    expect(res.status).toBe(200);
+    expect(sendSpy).toHaveBeenCalled();
+    const args = sendSpy.mock.calls[0];
+    expect(args[0]).toBeInstanceOf(Buffer);
+    expect(args[3]).toBe(7);
+    expect(args[4]).toBe("255.255.255.255");
+  });
+});


### PR DESCRIPTION
## Summary
- replace WebSocket placeholder with REST call for Wake-on-LAN packets
- expose `/api/wol` endpoint to broadcast packets via UDP
- add integration tests for client and server WOL packet flow

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3c13fa670832599f03dcaee01ecca