### PR TITLE
Add server-side proxies for SSH, FTP, and RDP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
+        "basic-ftp": "^5.0.5",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
@@ -2952,6 +2953,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "basic-ftp": "^5.0.5",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",

--- a/src/utils/fileTransferAdapters.ts
+++ b/src/utils/fileTransferAdapters.ts
@@ -1,8 +1,9 @@
-import type { File as NodeFile } from 'buffer';
+import type { File as NodeFile } from "buffer";
+import { Readable } from "stream";
 
 export interface FileItem {
   name: string;
-  type: 'file' | 'directory';
+  type: "file" | "directory";
   size: number;
   modified: Date;
   permissions?: string;
@@ -14,14 +15,89 @@ export interface FileTransferAdapter {
     file: File | NodeFile | Buffer,
     remotePath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void>;
   download(
     remotePath: string,
     localPath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void>;
+}
+
+// FTP implementation using basic-ftp
+export class FTPAdapter implements FileTransferAdapter {
+  private client: any;
+  constructor(private config: any) {}
+
+  private async getClient() {
+    if (!this.client) {
+      const { Client } = await import(/* @vite-ignore */ "basic-ftp");
+      this.client = new Client();
+      await this.client.access({
+        host: this.config.host,
+        port: this.config.port,
+        user: this.config.username,
+        password: this.config.password,
+        secure: this.config.secure,
+      });
+    }
+    return this.client;
+  }
+
+  async list(path: string, signal?: AbortSignal): Promise<FileItem[]> {
+    const client = await this.getClient();
+    if (signal?.aborted) throw new Error("aborted");
+    const items = await client.list(path);
+    return items.map((item: any) => ({
+      name: item.name,
+      type: item.isDirectory ? "directory" : "file",
+      size: item.size ?? 0,
+      modified: item.modifiedAt || new Date(),
+    }));
+  }
+
+  async upload(
+    file: File | NodeFile | Buffer,
+    remotePath: string,
+    onProgress?: (transferred: number, total: number) => void,
+    _signal?: AbortSignal,
+  ): Promise<void> {
+    const client = await this.getClient();
+    const buffer =
+      file instanceof Buffer
+        ? file
+        : Buffer.from(await (file as any).arrayBuffer());
+    const stream = Readable.from(buffer);
+    await client.uploadFrom(stream, remotePath);
+    onProgress?.(buffer.length, buffer.length);
+  }
+
+  async download(
+    remotePath: string,
+    localPath: string,
+    onProgress?: (transferred: number, total: number) => void,
+    _signal?: AbortSignal,
+  ): Promise<void> {
+    const client = await this.getClient();
+    await client.downloadTo(localPath, remotePath);
+    onProgress?.(1, 1);
+  }
+
+  async delete(remotePath: string): Promise<void> {
+    const client = await this.getClient();
+    await client.remove(remotePath);
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const client = await this.getClient();
+    await client.ensureDir(path);
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const client = await this.getClient();
+    await client.rename(oldPath, newPath);
+  }
 }
 
 // SFTP implementation using ssh2-sftp-client
@@ -31,7 +107,8 @@ export class SFTPAdapter implements FileTransferAdapter {
 
   private async getClient() {
     if (!this.client) {
-      const SftpClient = (await import(/* @vite-ignore */ 'ssh2-sftp-client')).default;
+      const SftpClient = (await import(/* @vite-ignore */ "ssh2-sftp-client"))
+        .default;
       this.client = new SftpClient();
       await this.client.connect(this.config);
     }
@@ -40,11 +117,11 @@ export class SFTPAdapter implements FileTransferAdapter {
 
   async list(path: string, signal?: AbortSignal): Promise<FileItem[]> {
     const client = await this.getClient();
-    if (signal?.aborted) throw new Error('aborted');
+    if (signal?.aborted) throw new Error("aborted");
     const items = await client.list(path);
     return items.map((item: any) => ({
       name: item.name,
-      type: item.type === 'd' ? 'directory' : 'file',
+      type: item.type === "d" ? "directory" : "file",
       size: item.size,
       modified: new Date(item.modifyTime || Date.now()),
       permissions: item.rights?.user + item.rights?.group + item.rights?.other,
@@ -55,17 +132,24 @@ export class SFTPAdapter implements FileTransferAdapter {
     file: File | NodeFile | Buffer,
     remotePath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void> {
     const client = await this.getClient();
-    const buffer = file instanceof Buffer ? file : Buffer.from(await (file as any).arrayBuffer());
+    const buffer =
+      file instanceof Buffer
+        ? file
+        : Buffer.from(await (file as any).arrayBuffer());
     const total = buffer.length;
     const options: any = {};
     if (onProgress) {
-      options.step = (transferred: number, _chunk: number, totalSize: number) => {
+      options.step = (
+        transferred: number,
+        _chunk: number,
+        totalSize: number,
+      ) => {
         onProgress(transferred, totalSize);
         if (signal?.aborted) {
-          throw new Error('aborted');
+          throw new Error("aborted");
         }
       };
     }
@@ -76,15 +160,19 @@ export class SFTPAdapter implements FileTransferAdapter {
     remotePath: string,
     localPath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void> {
     const client = await this.getClient();
     const options: any = {};
     if (onProgress) {
-      options.step = (transferred: number, _chunk: number, totalSize: number) => {
+      options.step = (
+        transferred: number,
+        _chunk: number,
+        totalSize: number,
+      ) => {
         onProgress(transferred, totalSize);
         if (signal?.aborted) {
-          throw new Error('aborted');
+          throw new Error("aborted");
         }
       };
     }
@@ -99,7 +187,7 @@ export class SCPAdapter implements FileTransferAdapter {
 
   private async getClient() {
     if (!this.client) {
-      const scp2 = await import(/* @vite-ignore */ 'scp2');
+      const scp2 = await import(/* @vite-ignore */ "scp2");
       this.client = new (scp2 as any).Client();
       this.client.defaults(this.config);
     }
@@ -107,28 +195,33 @@ export class SCPAdapter implements FileTransferAdapter {
   }
 
   async list(_path: string, _signal?: AbortSignal): Promise<FileItem[]> {
-    throw new Error('SCP does not support directory listing');
+    throw new Error("SCP does not support directory listing");
   }
 
   async upload(
     file: File | NodeFile | Buffer,
     remotePath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void> {
     const client = await this.getClient();
-    const buffer = file instanceof Buffer ? file : Buffer.from(await (file as any).arrayBuffer());
+    const buffer =
+      file instanceof Buffer
+        ? file
+        : Buffer.from(await (file as any).arrayBuffer());
     const total = buffer.length;
     await new Promise<void>((resolve, reject) => {
-      client.upload(buffer, remotePath, (err: Error) => {
-        if (err) return reject(err);
-        resolve();
-      }).on('transfer', (buf: Buffer, uploaded: number, _remote: string) => {
-        onProgress?.(uploaded, total);
-        if (signal?.aborted) {
-          reject(new Error('aborted'));
-        }
-      });
+      client
+        .upload(buffer, remotePath, (err: Error) => {
+          if (err) return reject(err);
+          resolve();
+        })
+        .on("transfer", (buf: Buffer, uploaded: number, _remote: string) => {
+          onProgress?.(uploaded, total);
+          if (signal?.aborted) {
+            reject(new Error("aborted"));
+          }
+        });
     });
   }
 
@@ -136,20 +229,21 @@ export class SCPAdapter implements FileTransferAdapter {
     remotePath: string,
     localPath: string,
     onProgress?: (transferred: number, total: number) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void> {
     const client = await this.getClient();
     await new Promise<void>((resolve, reject) => {
-      client.download(remotePath, localPath, (err: Error) => {
-        if (err) return reject(err);
-        resolve();
-      }).on('transfer', (buf: Buffer, downloaded: number, _remote: string) => {
-        onProgress?.(downloaded, buf.length);
-        if (signal?.aborted) {
-          reject(new Error('aborted'));
-        }
-      });
+      client
+        .download(remotePath, localPath, (err: Error) => {
+          if (err) return reject(err);
+          resolve();
+        })
+        .on("transfer", (buf: Buffer, downloaded: number, _remote: string) => {
+          onProgress?.(downloaded, buf.length);
+          if (signal?.aborted) {
+            reject(new Error("aborted"));
+          }
+        });
     });
   }
 }
-

--- a/src/utils/ftpServer.ts
+++ b/src/utils/ftpServer.ts
@@ -1,0 +1,67 @@
+import { Client } from "basic-ftp";
+import { WebSocketServer } from "ws";
+import type { Server } from "http";
+
+interface FTPServerConfig {
+  host: string;
+  port: number;
+  user: string;
+  password?: string;
+  secure?: boolean;
+}
+
+/**
+ * Minimal FTP proxy server using basic-ftp. Clients connect via WebSocket and
+ * send JSON messages. The first message must be `auth` with connection
+ * parameters. Supported commands: `list` to retrieve directory listings.
+ */
+export function createFTPProxyServer(server: Server, path = "/ftp"): void {
+  const wss = new WebSocketServer({ server, path });
+
+  wss.on("connection", (ws) => {
+    const client = new Client();
+    let connected = false;
+
+    ws.on("message", async (msg) => {
+      try {
+        const data = JSON.parse(msg.toString());
+        switch (data.type) {
+          case "auth": {
+            const cfg: FTPServerConfig = data;
+            await client.access({
+              host: cfg.host,
+              port: cfg.port,
+              user: cfg.user,
+              password: cfg.password,
+              secure: cfg.secure,
+            });
+            connected = true;
+            ws.send(JSON.stringify({ type: "auth_success" }));
+            break;
+          }
+          case "list": {
+            if (!connected) break;
+            const items = await client.list(data.path || "/");
+            ws.send(JSON.stringify({ type: "list", items }));
+            break;
+          }
+          default:
+            ws.send(
+              JSON.stringify({ type: "error", message: "Unsupported command" }),
+            );
+        }
+      } catch (err) {
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            message: (err as Error).message || "FTP error",
+          }),
+        );
+      }
+    });
+
+    ws.on("close", () => {
+      client.close();
+    });
+  });
+}

--- a/src/utils/rdpServer.ts
+++ b/src/utils/rdpServer.ts
@@ -1,0 +1,22 @@
+import { WebSocketServer } from "ws";
+import type { Server } from "http";
+
+/**
+ * Placeholder RDP proxy server. A real implementation would leverage a library
+ * such as Guacamole or node-rdpjs to connect to the remote desktop and stream
+ * graphics over the WebSocket connection. Currently this just informs clients
+ * that RDP support is not implemented.
+ */
+export function createRDPProxyServer(server: Server, path = "/rdp"): void {
+  const wss = new WebSocketServer({ server, path });
+
+  wss.on("connection", (ws) => {
+    ws.send(
+      JSON.stringify({
+        type: "error",
+        message: "RDP proxy not implemented",
+      }),
+    );
+    ws.close();
+  });
+}

--- a/src/utils/sshServer.ts
+++ b/src/utils/sshServer.ts
@@ -1,0 +1,80 @@
+import { NodeSSH } from "node-ssh";
+import { WebSocketServer } from "ws";
+import type { Server } from "http";
+
+interface SSHServerConfig {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  privateKey?: string;
+  passphrase?: string;
+}
+
+/**
+ * Creates a WebSocket based SSH proxy using node-ssh.
+ * The client must send an initial `auth` message with connection details.
+ * Subsequent `input` messages are written to the shell and `resize` messages
+ * adjust the pty size. Data from the remote host is broadcast back to the
+ * connected WebSocket client.
+ */
+export function createSSHProxyServer(server: Server, path = "/ssh"): void {
+  const wss = new WebSocketServer({ server, path });
+
+  wss.on("connection", (ws) => {
+    const ssh = new NodeSSH();
+    let shell: any;
+
+    ws.on("message", async (msg) => {
+      try {
+        const data = JSON.parse(msg.toString());
+        switch (data.type) {
+          case "auth": {
+            const config: SSHServerConfig = data;
+            await ssh.connect({
+              host: config.host,
+              port: config.port,
+              username: config.username,
+              password: config.password,
+              privateKey: config.privateKey,
+              passphrase: config.passphrase,
+            });
+            shell = await ssh.requestShell({
+              cols: 80,
+              rows: 24,
+              term: "xterm-256color",
+            });
+            shell.on("data", (d: Buffer) => {
+              ws.send(JSON.stringify({ type: "data", content: d.toString() }));
+            });
+            shell.on("close", () => ws.close());
+            ws.send(JSON.stringify({ type: "auth_success" }));
+            break;
+          }
+          case "input":
+            if (shell) shell.write(data.data);
+            break;
+          case "resize":
+            if (shell) shell.setWindow(data.rows, data.cols);
+            break;
+        }
+      } catch (err) {
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            message: (err as Error).message || "SSH error",
+          }),
+        );
+      }
+    });
+
+    ws.on("close", () => {
+      try {
+        shell?.end();
+        ssh.dispose();
+      } catch {
+        /* ignore */
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a Node-SSH powered WebSocket proxy for server-side SSH connections
- expose an FTP proxy using basic-ftp and provide an FTP file transfer adapter
- stub a WebSocket-based RDP proxy for future implementation

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a59e97ff188325864bc671810e12de