### PR TITLE
refactor(storage): derive key via subtle.deriveKey

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -49,9 +49,9 @@ export class SecureStorage {
       enc.encode(password),
       "PBKDF2",
       false,
-      ["deriveBits"],
+      ["deriveKey"],
     );
-    const derivedBits = await crypto.subtle.deriveBits(
+    return crypto.subtle.deriveKey(
       {
         name: "PBKDF2",
         salt,
@@ -59,12 +59,7 @@ export class SecureStorage {
         hash: "SHA-256",
       },
       keyMaterial,
-      256,
-    );
-    return crypto.subtle.importKey(
-      "raw",
-      derivedBits,
-      { name: "AES-GCM" },
+      { name: "AES-GCM", length: 256 },
       false,
       ["encrypt", "decrypt"],
     );


### PR DESCRIPTION
## Summary
- simplify deriveKey by using crypto.subtle.deriveKey directly

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aa4821b580832589069d400afc64d5