### PR TITLE
Refine collection data error handling

### DIFF
--- a/src/utils/__tests__/collectionManager.test.ts
+++ b/src/utils/__tests__/collectionManager.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import CryptoJS from "crypto-js";
 import { CollectionManager } from "../collectionManager";
 import { IndexedDbService } from "../indexedDbService";
-import { CollectionNotFoundError, InvalidPasswordError } from "../errors";
+import {
+  CollectionNotFoundError,
+  CorruptedDataError,
+  InvalidPasswordError,
+} from "../errors";
 import { openDB } from "idb";
 
 const DB_NAME = "mremote-keyval";
@@ -75,5 +80,14 @@ describe("CollectionManager", () => {
     await expect(
       manager.loadCollectionData(col.id, "wrong"),
     ).rejects.toBeInstanceOf(InvalidPasswordError);
+  });
+
+  it("throws CorruptedDataError when decrypted data is invalid", async () => {
+    const password = "secret";
+    const encrypted = CryptoJS.AES.encrypt("not-json", password).toString();
+    await IndexedDbService.setItem("mremote-collection-corrupt", encrypted);
+    await expect(
+      manager.loadCollectionData("corrupt", password),
+    ).rejects.toBeInstanceOf(CorruptedDataError);
   });
 });

--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -3,7 +3,11 @@ import { ConnectionCollection } from "../types/connection";
 import { StorageData } from "./storage";
 import { IndexedDbService } from "./indexedDbService";
 import { generateId } from "./id";
-import { CollectionNotFoundError, InvalidPasswordError } from "./errors";
+import {
+  CollectionNotFoundError,
+  CorruptedDataError,
+  InvalidPasswordError,
+} from "./errors";
 
 export class CollectionManager {
   private static instance: CollectionManager;
@@ -188,7 +192,10 @@ export class CollectionManager {
       if (error instanceof InvalidPasswordError) {
         throw error;
       }
-      throw new InvalidPasswordError();
+      if (error instanceof SyntaxError) {
+        throw new CorruptedDataError("Corrupted collection data");
+      }
+      throw error;
     }
   }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,3 +11,10 @@ export class InvalidPasswordError extends Error {
     this.name = "InvalidPasswordError";
   }
 }
+
+export class CorruptedDataError extends Error {
+  constructor(message: string = "Corrupted data") {
+    super(message);
+    this.name = "CorruptedDataError";
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `CorruptedDataError` to represent invalid or unparsable collection data
- Refine `loadCollectionData` to rethrow `InvalidPasswordError` only for empty decrypts and surface `CorruptedDataError` for malformed data
- Add unit test covering corrupted data scenario

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab93a3fad88325997546ad789ede66