### PR TITLE
Handle root-level drop in dragDropManager

### DIFF
--- a/src/utils/__tests__/dragDropManager.test.ts
+++ b/src/utils/__tests__/dragDropManager.test.ts
@@ -46,4 +46,12 @@ describe('DragDropManager.processDropResult', () => {
     expect(item.parentId).toBeUndefined();
     expect(updated.map(c => c.id)).toEqual(['group1', 'item1', 'group2']);
   });
+
+  it('moves connection to root when dropped on root level', () => {
+    const result: DragDropResult = { draggedId: 'item1', targetId: null, position: 'after' };
+    const updated = manager.processDropResult(result, connections);
+    const item = updated.find(c => c.id === 'item1')!;
+    expect(item.parentId).toBeUndefined();
+    expect(updated.map(c => c.id)).toEqual(['group1', 'group2', 'item1']);
+  });
 });


### PR DESCRIPTION
## Summary
- handle `null` targetId in drag-drop manager to allow root-level drops
- add unit test for dragging a connection to the root

## Testing
- `npx vitest run src/utils/__tests__/dragDropManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aba952ff2883258d60046f25d0b2d5