### PR TITLE
docs: document ActionLogViewer

### DIFF
--- a/src/components/ActionLogViewer.tsx
+++ b/src/components/ActionLogViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   X,
   Download,
@@ -10,10 +10,10 @@ import {
   Info,
   AlertTriangle,
   Bug,
-} from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { ActionLogEntry } from '../types/settings';
-import { SettingsManager } from '../utils/settingsManager';
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { ActionLogEntry } from "../types/settings";
+import { SettingsManager } from "../utils/settingsManager";
 
 const LEVEL_ICONS: Record<string, JSX.Element> = {
   debug: <Bug className="text-gray-400" size={14} />,
@@ -25,28 +25,40 @@ const LEVEL_ICONS: Record<string, JSX.Element> = {
 const DEFAULT_ICON = <Info className="text-gray-400" size={14} />;
 
 const LEVEL_COLORS: Record<string, string> = {
-  debug: 'text-gray-400',
-  info: 'text-blue-400',
-  warn: 'text-yellow-400',
-  error: 'text-red-400',
+  debug: "text-gray-400",
+  info: "text-blue-400",
+  warn: "text-yellow-400",
+  error: "text-red-400",
 };
 
+/**
+ * Props for the {@link ActionLogViewer} component.
+ * @property isOpen - Whether the log viewer modal is visible.
+ * @property onClose - Callback fired when the modal should close.
+ */
 interface ActionLogViewerProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClose }) => {
+/**
+ * Displays a modal table of recorded actions with tools for filtering and exporting.
+ */
+export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({
+  isOpen,
+  onClose,
+}) => {
   const { t } = useTranslation();
   const [logs, setLogs] = useState<ActionLogEntry[]>([]);
   const [filteredLogs, setFilteredLogs] = useState<ActionLogEntry[]>([]);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [levelFilter, setLevelFilter] = useState<string>('all');
+  const [searchTerm, setSearchTerm] = useState("");
+  const [levelFilter, setLevelFilter] = useState<string>("all");
   const settingsManager = SettingsManager.getInstance();
 
   useEffect(() => {
     if (isOpen) {
       loadLogs();
+      // Periodically refresh logs while the viewer is open
       const interval = setInterval(loadLogs, 5000); // Refresh every 5 seconds
       return () => clearInterval(interval);
     }
@@ -62,18 +74,22 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
   };
 
   const filterLogs = () => {
+    // Start with the full log list
     let filtered = logs;
 
-    if (levelFilter !== 'all') {
-      filtered = filtered.filter(log => log.level === levelFilter);
+    // Apply level filter if a specific level is selected
+    if (levelFilter !== "all") {
+      filtered = filtered.filter((log) => log.level === levelFilter);
     }
 
+    // Apply text search across relevant fields
     if (searchTerm) {
       const term = searchTerm.toLowerCase();
-      filtered = filtered.filter(log =>
-        log.action.toLowerCase().includes(term) ||
-        log.details.toLowerCase().includes(term) ||
-        log.connectionName?.toLowerCase().includes(term)
+      filtered = filtered.filter(
+        (log) =>
+          log.action.toLowerCase().includes(term) ||
+          log.details.toLowerCase().includes(term) ||
+          log.connectionName?.toLowerCase().includes(term),
       );
     }
 
@@ -81,25 +97,28 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
   };
 
   const clearLogs = () => {
-    if (confirm('Are you sure you want to clear all logs?')) {
+    if (confirm("Are you sure you want to clear all logs?")) {
       settingsManager.clearActionLog();
       setLogs([]);
     }
   };
 
   const exportLogs = () => {
+    // Build CSV rows including a header
     const csvContent = [
-      'Timestamp,Level,Action,Connection,Details,Duration',
-      ...filteredLogs.map(log =>
-        `"${log.timestamp.toISOString()}","${log.level}","${log.action}","${log.connectionName || ''}","${log.details.replace(/"/g, '""')}","${log.duration || ''}"`
-      )
-    ].join('\n');
+      "Timestamp,Level,Action,Connection,Details,Duration",
+      ...filteredLogs.map(
+        (log) =>
+          `"${log.timestamp.toISOString()}","${log.level}","${log.action}","${log.connectionName || ""}","${log.details.replace(/"/g, '""')}","${log.duration || ""}"`,
+      ),
+    ].join("\n");
 
-    const blob = new Blob([csvContent], { type: 'text/csv' });
+    // Create a downloadable Blob and trigger browser download
+    const blob = new Blob([csvContent], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
-    link.download = `action-log-${new Date().toISOString().split('T')[0]}.csv`;
+    link.download = `action-log-${new Date().toISOString().split("T")[0]}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -109,7 +128,7 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
   const getLevelIcon = (level: string) => LEVEL_ICONS[level] ?? DEFAULT_ICON;
 
   const getLevelColor = (level: string) => {
-    return LEVEL_COLORS[level] ?? 'text-gray-400';
+    return LEVEL_COLORS[level] ?? "text-gray-400";
   };
 
   if (!isOpen) return null;
@@ -123,23 +142,28 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
     >
       <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-6xl mx-4 max-h-[90vh] overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b border-gray-700">
-          <h2 className="text-xl font-semibold text-white">{t('logs.title')}</h2>
+          <h2 className="text-xl font-semibold text-white">
+            {t("logs.title")}
+          </h2>
           <div className="flex items-center space-x-2">
             <button
               onClick={exportLogs}
               className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors flex items-center space-x-2"
             >
               <Download size={14} />
-              <span>{t('logs.export')}</span>
+              <span>{t("logs.export")}</span>
             </button>
             <button
               onClick={clearLogs}
               className="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded-md transition-colors flex items-center space-x-2"
             >
               <Trash2 size={14} />
-              <span>{t('logs.clear')}</span>
+              <span>{t("logs.clear")}</span>
             </button>
-            <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-white transition-colors"
+            >
               <X size={20} />
             </button>
           </div>
@@ -149,7 +173,10 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
         <div className="p-4 border-b border-gray-700 bg-gray-750">
           <div className="flex items-center space-x-4">
             <div className="flex-1 relative">
-              <Search size={16} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+              <Search
+                size={16}
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+              />
               <input
                 type="text"
                 placeholder="Search logs..."
@@ -158,7 +185,7 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
                 className="w-full pl-9 pr-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
               />
             </div>
-            
+
             <div className="flex items-center space-x-2">
               <Filter size={16} className="text-gray-400" />
               <select
@@ -188,20 +215,20 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
                   <div className="flex items-center space-x-1">
                     <Clock size={12} />
-                    <span>{t('logs.timestamp')}</span>
+                    <span>{t("logs.timestamp")}</span>
                   </div>
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                  {t('logs.level')}
+                  {t("logs.level")}
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                  {t('logs.action')}
+                  {t("logs.action")}
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                  {t('logs.connection')}
+                  {t("logs.connection")}
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                  {t('logs.details')}
+                  {t("logs.details")}
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
                   Duration
@@ -220,7 +247,9 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
                     </div>
                   </td>
                   <td className="px-4 py-3 text-sm">
-                    <div className={`flex items-center space-x-2 ${getLevelColor(log.level)}`}>
+                    <div
+                      className={`flex items-center space-x-2 ${getLevelColor(log.level)}`}
+                    >
                       {getLevelIcon(log.level)}
                       <span className="capitalize">{log.level}</span>
                     </div>
@@ -229,7 +258,7 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
                     {log.action}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-300">
-                    {log.connectionName || '-'}
+                    {log.connectionName || "-"}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-300 max-w-md">
                     <div className="truncate" title={log.details}>
@@ -237,7 +266,7 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
                     </div>
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-300">
-                    {log.duration ? `${log.duration}ms` : '-'}
+                    {log.duration ? `${log.duration}ms` : "-"}
                   </td>
                 </tr>
               ))}
@@ -248,7 +277,9 @@ export const ActionLogViewer: React.FC<ActionLogViewerProps> = ({ isOpen, onClos
             <div className="flex flex-col items-center justify-center py-12 text-gray-400">
               <AlertCircle size={48} className="mb-4" />
               <p className="text-lg font-medium mb-2">No log entries found</p>
-              <p className="text-sm">Try adjusting your search or filter criteria</p>
+              <p className="text-sm">
+                Try adjusting your search or filter criteria
+              </p>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- document ActionLogViewer props and component with JSDoc
- clarify log filtering, export, and refresh logic with inline comments

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ace2926a008325bf50ac40c8f5107d