### PR TITLE
docs: add auth service jsdoc

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -1,12 +1,17 @@
-import fs from 'fs';
-import path from 'path';
-import bcrypt from 'bcryptjs';
+import fs from "fs";
+import path from "path";
+import bcrypt from "bcryptjs";
 
 export interface StoredUser {
   username: string;
   passwordHash: string;
 }
 
+/**
+ * Service for managing user credentials persisted as bcrypt hashes in a JSON
+ * file on disk. Credentials are loaded into memory and can be updated or
+ * verified against provided passwords.
+ */
 export class AuthService {
   private users: Record<string, string> = {};
   private storePath: string;
@@ -17,13 +22,19 @@ export class AuthService {
     this.loadPromise = this.load();
   }
 
+  /**
+   * Loads the stored users from disk into memory.
+   *
+   * @returns {Promise<void>} Resolves when the user list is loaded.
+   * @throws {Error} If the user store cannot be read or parsed.
+   */
   private async load(): Promise<void> {
     try {
       const fullPath = path.resolve(this.storePath);
-      const data = await fs.promises.readFile(fullPath, 'utf8');
+      const data = await fs.promises.readFile(fullPath, "utf8");
       const parsed: StoredUser[] = JSON.parse(data);
       this.users = {};
-      parsed.forEach(u => {
+      parsed.forEach((u) => {
         this.users[u.username] = u.passwordHash;
       });
     } catch {
@@ -31,16 +42,30 @@ export class AuthService {
     }
   }
 
+  /**
+   * Persists the in-memory users to the JSON storage file.
+   *
+   * @returns {Promise<void>} Resolves when all users are written to disk.
+   * @throws {Error} If writing to the storage file fails.
+   */
   private async persist(): Promise<void> {
     const arr: StoredUser[] = Object.entries(this.users).map(
-      ([username, passwordHash]) => ({ username, passwordHash })
+      ([username, passwordHash]) => ({ username, passwordHash }),
     );
     await fs.promises.writeFile(
       path.resolve(this.storePath),
-      JSON.stringify(arr, null, 2)
+      JSON.stringify(arr, null, 2),
     );
   }
 
+  /**
+   * Adds a new user with a bcrypt-hashed password and persists the update.
+   *
+   * @param {string} username - The username to store.
+   * @param {string} password - The plain-text password for the user.
+   * @returns {Promise<void>} Resolves when the user is added and persisted.
+   * @throws {Error} If hashing or persisting the user fails.
+   */
   async addUser(username: string, password: string): Promise<void> {
     const hash = await bcrypt.hash(password, 10);
     await this.loadPromise;
@@ -48,10 +73,19 @@ export class AuthService {
     try {
       await this.persist();
     } catch (error) {
-      console.error('Failed to persist user', error);
+      console.error("Failed to persist user", error);
     }
   }
 
+  /**
+   * Verifies that a provided password matches the stored hash for the given
+   * username.
+   *
+   * @param {string} username - The username to verify.
+   * @param {string} password - The plain-text password to compare.
+   * @returns {Promise<boolean>} True if the credentials are valid, otherwise false.
+   * @throws {Error} If the password comparison fails.
+   */
   async verifyUser(username: string, password: string): Promise<boolean> {
     await this.loadPromise;
     const hash = this.users[username];


### PR DESCRIPTION
## Summary
- document AuthService class and methods with JSDoc

## Testing
- `npx prettier AGENTS.md -w` *(fails: No files matching the pattern were found)*
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run` *(fails: src/utils/__tests__/collectionManager.test.ts > CollectionManager > throws InvalidPasswordError when password is incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ea10d624832596aa125dc37f7a0b