### PR TITLE
feat: expand network scanner for ipv6 and async ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "i18next": "^23.7.6",
         "i18next-browser-languagedetector": "^7.2.0",
         "idb": "^8.0.3",
+        "ipaddr.js": "^2.2.0",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",
         "lucide-react": "^0.344.0",
@@ -5279,12 +5280,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arguments": {
@@ -7121,6 +7122,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "i18next": "^23.7.6",
     "i18next-browser-languagedetector": "^7.2.0",
     "idb": "^8.0.3",
+    "ipaddr.js": "^2.2.0",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "lucide-react": "^0.344.0",

--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -14,21 +14,43 @@ afterEach(() => {
 });
 
 describe('NetworkScanner helper methods', () => {
-  it('generateIPRange("192.168.0.0/30") returns two host IPs', () => {
-    const ips = scanner.generateIPRange('192.168.0.0/30');
+  it('generateIPRange("192.168.0.0/30") returns two host IPs', async () => {
+    const ips: string[] = [];
+    for await (const ip of scanner.generateIPRange('192.168.0.0/30')) {
+      ips.push(ip);
+    }
     expect(ips).toEqual(['192.168.0.1', '192.168.0.2']);
   });
 
-  it('masks non-network-base addresses before generating hosts', () => {
-    const ips = scanner.generateIPRange('192.168.0.5/30');
+  it('masks non-network-base addresses before generating hosts', async () => {
+    const ips: string[] = [];
+    for await (const ip of scanner.generateIPRange('192.168.0.5/30')) {
+      ips.push(ip);
+    }
     expect(ips).toEqual(['192.168.0.5', '192.168.0.6']);
   });
 
-  it('handles edge prefix /24', () => {
-    const ips = scanner.generateIPRange('10.0.0.42/24');
+  it('handles edge prefix /24', async () => {
+    const ips: string[] = [];
+    for await (const ip of scanner.generateIPRange('10.0.0.42/24')) {
+      ips.push(ip);
+    }
     expect(ips.length).toBe(254);
     expect(ips[0]).toBe('10.0.0.1');
     expect(ips[253]).toBe('10.0.0.254');
+  });
+
+  it('supports IPv6 ranges', async () => {
+    const ips: string[] = [];
+    for await (const ip of scanner.generateIPRange('2001:db8::/126')) {
+      ips.push(ip);
+    }
+    expect(ips).toEqual([
+      '2001:db8::',
+      '2001:db8::1',
+      '2001:db8::2',
+      '2001:db8::3',
+    ]);
   });
 
   it('compareIPs sorts numerically', () => {
@@ -41,18 +63,19 @@ describe('NetworkScanner helper methods', () => {
     expect(version).toBe('8.6');
   });
 
-  it('throws on malformed CIDR strings', () => {
-    expect(() => scanner.generateIPRange('192.168.0.0')).toThrow();
-    expect(() => scanner.generateIPRange('192.168.0.0/abc')).toThrow();
+  it('throws on malformed CIDR strings', async () => {
+    await expect(scanner.generateIPRange('192.168.0.0').next()).rejects.toThrow();
+    await expect(scanner.generateIPRange('192.168.0.0/abc').next()).rejects.toThrow();
   });
 
-  it('throws when IP does not have four octets', () => {
-    expect(() => scanner.generateIPRange('192.168.0/24')).toThrow();
+  it('throws when IP does not have four octets', async () => {
+    await expect(scanner.generateIPRange('192.168.0/24').next()).rejects.toThrow();
   });
 
-  it('throws when prefix is outside supported range', () => {
-    expect(() => scanner.generateIPRange('192.168.0.0/23')).toThrow();
-    expect(() => scanner.generateIPRange('192.168.0.0/31')).toThrow();
+  it('throws when prefix is outside supported range', async () => {
+    await expect(scanner.generateIPRange('192.168.0.0/23').next()).rejects.toThrow();
+    await expect(scanner.generateIPRange('192.168.0.0/31').next()).rejects.toThrow();
+    await expect(scanner.generateIPRange('2001:db8::/111').next()).rejects.toThrow();
   });
 
   it('identifyService returns mapped values', () => {
@@ -101,6 +124,50 @@ describe('NetworkScanner helper methods', () => {
     await promise;
     expect(maxActive).toBe(config.maxPortConcurrent);
     vi.useRealTimers();
+  });
+
+  it('scanNetwork processes IPv4 ranges', async () => {
+    const testScanner = new NetworkScanner() as any;
+    testScanner.scanHost = vi.fn(async () => null);
+
+    const config: NetworkDiscoveryConfig = {
+      enabled: true,
+      ipRange: '192.168.0.0/30',
+      portRanges: [],
+      protocols: [],
+      timeout: 1000,
+      maxConcurrent: 2,
+      maxPortConcurrent: 1,
+      customPorts: {},
+      cacheTTL: 60000,
+    };
+
+    const progress: number[] = [];
+    await testScanner.scanNetwork(config, (p: number) => progress.push(p));
+    expect(testScanner.scanHost).toHaveBeenCalledTimes(2);
+    expect(progress.at(-1)).toBe(100);
+  });
+
+  it('scanNetwork processes IPv6 ranges', async () => {
+    const testScanner = new NetworkScanner() as any;
+    testScanner.scanHost = vi.fn(async () => null);
+
+    const config: NetworkDiscoveryConfig = {
+      enabled: true,
+      ipRange: '2001:db8::/126',
+      portRanges: [],
+      protocols: [],
+      timeout: 1000,
+      maxConcurrent: 2,
+      maxPortConcurrent: 1,
+      customPorts: {},
+      cacheTTL: 60000,
+    };
+
+    const progress: number[] = [];
+    await testScanner.scanNetwork(config, (p: number) => progress.push(p));
+    expect(testScanner.scanHost).toHaveBeenCalledTimes(4);
+    expect(progress.at(-1)).toBe(100);
   });
 
   it('scanPort resolves false on invalid hostname without rejection', async () => {

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -84,6 +84,17 @@ export class NetworkScanner {
   private async *generateIPRange(cidr: string): AsyncGenerator<string> {
     let addr: ipaddr.IPv4 | ipaddr.IPv6;
     let prefix: number;
+
+    const [ipPart] = cidr.split("/");
+    // ipaddr.js accepts IPv4 addresses with fewer than four octets.
+    // Reject such shorthand forms to keep input validation strict.
+    if (ipPart && !ipPart.includes(":")) {
+      const octetCount = ipPart.split(".").length;
+      if (octetCount !== 4) {
+        throw new Error(`IPv4 address must contain four octets: ${ipPart}`);
+      }
+    }
+
     try {
       [addr, prefix] = ipaddr.parseCIDR(cidr);
     } catch {
@@ -100,7 +111,10 @@ export class NetworkScanner {
       const hostBits = 32 - prefix;
       const mask = (0xffffffff << hostBits) >>> 0;
       const ipNum =
-        ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>>
+        ((octets[0] << 24) |
+          (octets[1] << 16) |
+          (octets[2] << 8) |
+          octets[3]) >>>
         0;
       const networkNum = ipNum & mask;
       const hostCount = Math.pow(2, hostBits) - 2;
@@ -144,6 +158,15 @@ export class NetworkScanner {
   private getHostCount(cidr: string): number {
     let addr: ipaddr.IPv4 | ipaddr.IPv6;
     let prefix: number;
+
+    const [ipPart] = cidr.split("/");
+    if (ipPart && !ipPart.includes(":")) {
+      const octetCount = ipPart.split(".").length;
+      if (octetCount !== 4) {
+        throw new Error(`IPv4 address must contain four octets: ${ipPart}`);
+      }
+    }
+
     try {
       [addr, prefix] = ipaddr.parseCIDR(cidr);
     } catch {

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -271,7 +271,18 @@ export class NetworkScanner {
 
       // Use WebSocket for port scanning (limited but works for many services)
       try {
-        ws = new WebSocket(`ws://${ip}:${port}`);
+        let host = ip;
+        try {
+          if (ipaddr.isValid(ip)) {
+            const addr = ipaddr.parse(ip);
+            if (addr.kind() === "ipv6") {
+              host = `[${addr.toString()}]`;
+            }
+          }
+        } catch {
+          // If the IP is malformed, fall back to the raw string.
+        }
+        ws = new WebSocket(`ws://${host}:${port}`);
       } catch (error) {
         resolve({ isOpen: false, elapsed: Date.now() - startTime });
         return;


### PR DESCRIPTION
## Summary
- stream IPs from CIDR ranges with async generator and IPv6 support
- scan networks without precomputing hosts and track progress incrementally
- test IPv4/IPv6 address generation and scanning

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: CollectionManager throws InvalidPasswordError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1eb073ea88325932e9b298ba73783