### PR TITLE
Fix lint warning and failing test

### DIFF
--- a/src/utils/collectionManager.ts
+++ b/src/utils/collectionManager.ts
@@ -213,6 +213,9 @@ export class CollectionManager {
       if (error instanceof SyntaxError) {
         throw new CorruptedDataError("Corrupted collection data");
       }
+      if (error instanceof Error && error.message === "Malformed UTF-8 data") {
+        throw new InvalidPasswordError();
+      }
       throw error;
     }
   }

--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -1,9 +1,8 @@
-import { SettingsManager } from './settingsManager';
+import { SettingsManager } from "./settingsManager";
 
 export function debugLog(...args: unknown[]): void {
   const settings = SettingsManager.getInstance().getSettings();
-  if (settings.logLevel === 'debug') {
-    // eslint-disable-next-line no-console
+  if (settings.logLevel === "debug") {
     console.log(...args);
   }
 }

--- a/tests/NetworkDiscovery.i18n.test.tsx
+++ b/tests/NetworkDiscovery.i18n.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../src/i18n";
@@ -20,7 +20,9 @@ describe("NetworkDiscovery i18n", () => {
     const { rerender } = renderWithProviders();
     expect(screen.getByText("Network Discovery")).toBeInTheDocument();
 
-    await i18n.changeLanguage("es");
+    await act(async () => {
+      await i18n.changeLanguage("es");
+    });
     rerender(
       <I18nextProvider i18n={i18n}>
         <ConnectionProvider>


### PR DESCRIPTION
## Summary
- remove unused eslint-disable in debugLogger
- wrap i18n language switch in `act` to avoid React state update warning
- translate malformed CryptoJS decryption errors into `InvalidPasswordError`

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b1ec514c108325b3acc68418eb5ca4