### PR TITLE
ci: run workflow only on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["**"]
 
 jobs:
   format:


### PR DESCRIPTION
## Summary
- run GitHub Actions workflow only on push to avoid duplicate runs

## Testing
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run` *(fails: CollectionManager > throws InvalidPasswordError when password is incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ee14ff9c8325b638db1cb9e8f313