### PR TITLE
docs: document default port utilities

### DIFF
--- a/src/utils/defaultPorts.ts
+++ b/src/utils/defaultPorts.ts
@@ -1,3 +1,13 @@
+/**
+ * Utilities for working with default network ports. Provides a lookup table
+ * and helper to retrieve standard port numbers.
+ */
+
+/**
+ * Mapping of supported protocols to their default port numbers. When a
+ * protocol is not present in this map, {@link getDefaultPort} will fall back
+ * to port `22`.
+ */
 export const DEFAULT_PORTS: Record<string, number> = {
   rdp: 3389,
   ssh: 22,
@@ -8,6 +18,13 @@ export const DEFAULT_PORTS: Record<string, number> = {
   rlogin: 513,
 };
 
+/**
+ * Returns the default port for a given protocol name.
+ *
+ * @param protocol - Protocol identifier such as `ssh` or `http`.
+ * @returns The default port number. If the protocol is unknown, `22` is
+ * returned as a safe fallback.
+ */
 export const getDefaultPort = (protocol: string): number => {
   return DEFAULT_PORTS[protocol] ?? 22;
 };


### PR DESCRIPTION
## Summary
- document the default port mapping and lookup helper
- clarify fallback behavior when protocols aren't listed

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b5e44732d083259c17523cc130313a