### PR TITLE
feat: add custom theme management

### DIFF
--- a/src/components/SettingsDialog/sections/GeneralSettings.tsx
+++ b/src/components/SettingsDialog/sections/GeneralSettings.tsx
@@ -1,22 +1,36 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { GlobalSettings, Theme, ColorScheme } from '../../../types/settings';
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { GlobalSettings, Theme, ColorScheme } from "../../../types/settings";
+import { ThemeManager } from "../../../utils/themeManager";
 
 interface GeneralSettingsProps {
   settings: GlobalSettings;
   updateSettings: (updates: Partial<GlobalSettings>) => void;
 }
 
-export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, updateSettings }) => {
+export const GeneralSettings: React.FC<GeneralSettingsProps> = ({
+  settings,
+  updateSettings,
+}) => {
   const { t } = useTranslation();
+  const themeManager = ThemeManager.getInstance();
+  const [themes, setThemes] = useState<Theme[]>([]);
+  const [schemes, setSchemes] = useState<ColorScheme[]>([]);
+
+  useEffect(() => {
+    setThemes(themeManager.getAvailableThemes());
+    setSchemes(themeManager.getAvailableColorSchemes());
+  }, [themeManager]);
   return (
     <div className="space-y-6">
-      <h3 className="text-lg font-medium text-white">{t('settings.general')}</h3>
+      <h3 className="text-lg font-medium text-white">
+        {t("settings.general")}
+      </h3>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label className="block text-sm font-medium text-gray-300 mb-2">
-            {t('settings.language')}
+            {t("settings.language")}
           </label>
           <select
             value={settings.language}
@@ -30,19 +44,18 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
 
         <div>
           <label className="block text-sm font-medium text-gray-300 mb-2">
-            {t('settings.theme')}
+            {t("settings.theme")}
           </label>
           <select
             value={settings.theme}
             onChange={(e) => updateSettings({ theme: e.target.value as Theme })}
             className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
           >
-            <option value="dark">Dark</option>
-            <option value="light">Light</option>
-            <option value="darkest">Darkest</option>
-            <option value="oled">OLED Black</option>
-            <option value="semilight">Semi Light</option>
-            <option value="auto">Auto</option>
+            {themes.map((th) => (
+              <option key={th} value={th}>
+                {th}
+              </option>
+            ))}
           </select>
         </div>
 
@@ -52,16 +65,16 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
           </label>
           <select
             value={settings.colorScheme}
-            onChange={(e) => updateSettings({ colorScheme: e.target.value as ColorScheme })}
+            onChange={(e) =>
+              updateSettings({ colorScheme: e.target.value as ColorScheme })
+            }
             className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
           >
-            <option value="blue">Blue</option>
-            <option value="green">Green</option>
-            <option value="purple">Purple</option>
-            <option value="red">Red</option>
-            <option value="orange">Orange</option>
-            <option value="teal">Teal</option>
-            <option value="grey">Grey</option>
+            {schemes.map((sc) => (
+              <option key={sc} value={sc}>
+                {sc}
+              </option>
+            ))}
           </select>
         </div>
 
@@ -72,7 +85,9 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
           <input
             type="number"
             value={settings.connectionTimeout}
-            onChange={(e) => updateSettings({ connectionTimeout: parseInt(e.target.value) })}
+            onChange={(e) =>
+              updateSettings({ connectionTimeout: parseInt(e.target.value) })
+            }
             className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
             min="5"
             max="300"
@@ -86,7 +101,11 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
           <input
             type="number"
             value={settings.maxConcurrentConnections}
-            onChange={(e) => updateSettings({ maxConcurrentConnections: parseInt(e.target.value) })}
+            onChange={(e) =>
+              updateSettings({
+                maxConcurrentConnections: parseInt(e.target.value),
+              })
+            }
             className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
             min="1"
             max="50"
@@ -99,30 +118,40 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
           <input
             type="checkbox"
             checked={settings.singleWindowMode}
-            onChange={(e) => updateSettings({ singleWindowMode: e.target.checked })}
+            onChange={(e) =>
+              updateSettings({ singleWindowMode: e.target.checked })
+            }
             className="rounded border-gray-600 bg-gray-700 text-blue-600"
           />
-          <span className="text-gray-300">{t('connections.singleWindow')}</span>
+          <span className="text-gray-300">{t("connections.singleWindow")}</span>
         </label>
 
         <label className="flex items-center space-x-2">
           <input
             type="checkbox"
             checked={settings.singleConnectionMode}
-            onChange={(e) => updateSettings({ singleConnectionMode: e.target.checked })}
+            onChange={(e) =>
+              updateSettings({ singleConnectionMode: e.target.checked })
+            }
             className="rounded border-gray-600 bg-gray-700 text-blue-600"
           />
-          <span className="text-gray-300">{t('connections.singleConnection')}</span>
+          <span className="text-gray-300">
+            {t("connections.singleConnection")}
+          </span>
         </label>
 
         <label className="flex items-center space-x-2">
           <input
             type="checkbox"
             checked={settings.reconnectOnReload}
-            onChange={(e) => updateSettings({ reconnectOnReload: e.target.checked })}
+            onChange={(e) =>
+              updateSettings({ reconnectOnReload: e.target.checked })
+            }
             className="rounded border-gray-600 bg-gray-700 text-blue-600"
           />
-          <span className="text-gray-300">{t('connections.reconnectOnReload')}</span>
+          <span className="text-gray-300">
+            {t("connections.reconnectOnReload")}
+          </span>
         </label>
 
         <label className="flex items-center space-x-2">
@@ -132,7 +161,7 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
             onChange={(e) => updateSettings({ warnOnClose: e.target.checked })}
             className="rounded border-gray-600 bg-gray-700 text-blue-600"
           />
-          <span className="text-gray-300">{t('connections.warnOnClose')}</span>
+          <span className="text-gray-300">{t("connections.warnOnClose")}</span>
         </label>
 
         <label className="flex items-center space-x-2">
@@ -142,7 +171,7 @@ export const GeneralSettings: React.FC<GeneralSettingsProps> = ({ settings, upda
             onChange={(e) => updateSettings({ warnOnExit: e.target.checked })}
             className="rounded border-gray-600 bg-gray-700 text-blue-600"
           />
-          <span className="text-gray-300">{t('connections.warnOnExit')}</span>
+          <span className="text-gray-300">{t("connections.warnOnExit")}</span>
         </label>
       </div>
     </div>

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Palette, Sun, Moon, Monitor } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { Theme, ColorScheme } from '../types/settings';
+import React, { useEffect, useState } from "react";
+import { Palette, Sun, Moon, Monitor } from "lucide-react";
+import { Theme, ColorScheme, ThemeConfig } from "../types/settings";
+import { ThemeManager } from "../utils/themeManager";
 
 interface ThemeSelectorProps {
   theme: Theme;
@@ -10,48 +10,183 @@ interface ThemeSelectorProps {
   onColorSchemeChange: (scheme: ColorScheme) => void;
 }
 
+const themeManager = ThemeManager.getInstance();
+
 export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
   theme,
   colorScheme,
   onThemeChange,
   onColorSchemeChange,
 }) => {
-  const { t } = useTranslation();
+  const [themes, setThemes] = useState<Theme[]>([]);
+  const [schemes, setSchemes] = useState<ColorScheme[]>([]);
 
-  const colorSchemes = [
-    { name: 'blue', colors: ['#3b82f6', '#1d4ed8', '#1e40af'] },
-    { name: 'green', colors: ['#10b981', '#059669', '#047857'] },
-    { name: 'purple', colors: ['#8b5cf6', '#7c3aed', '#6d28d9'] },
-    { name: 'red', colors: ['#ef4444', '#dc2626', '#b91c1c'] },
-    { name: 'orange', colors: ['#f97316', '#ea580c', '#c2410c'] },
-    { name: 'teal', colors: ['#14b8a6', '#0d9488', '#0f766e'] },
-    { name: 'grey', colors: ['#9ca3af', '#6b7280', '#4b5563'] },
+  const refresh = () => {
+    setThemes(themeManager.getAvailableThemes());
+    setSchemes(themeManager.getAvailableColorSchemes());
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const builtinThemes = [
+    "light",
+    "dark",
+    "auto",
+    "darkest",
+    "oled",
+    "semilight",
   ];
+  const builtinSchemes = [
+    "blue",
+    "green",
+    "purple",
+    "red",
+    "orange",
+    "teal",
+    "grey",
+  ];
+
+  const themeOptions = themes.map((tName) => {
+    let Icon = Palette;
+    if (tName === "light") Icon = Sun;
+    else if (tName === "dark") Icon = Moon;
+    else if (tName === "auto") Icon = Monitor;
+    return { value: tName, icon: Icon };
+  });
+
+  const schemeOptions = schemes.map((name) => ({
+    name,
+    colors: themeManager.getColorSchemeConfig(name) || {
+      primary: "#000",
+      secondary: "#000",
+      accent: "#000",
+    },
+  }));
+
+  const handleAddTheme = async () => {
+    const name = prompt("Theme name?");
+    if (!name) return;
+    const existing: ThemeConfig = themeManager.getThemeConfig(name) || {
+      name,
+      colors: {
+        primary: "#000000",
+        secondary: "#000000",
+        accent: "#000000",
+        background: "#000000",
+        surface: "#000000",
+        text: "#ffffff",
+        textSecondary: "#cccccc",
+        border: "#000000",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+      },
+    };
+    const configStr = prompt(
+      "Theme config JSON",
+      JSON.stringify(existing, null, 2),
+    );
+    if (!configStr) return;
+    try {
+      const config = JSON.parse(configStr) as ThemeConfig;
+      config.name = config.name || name;
+      await themeManager.addCustomTheme(name, config);
+      refresh();
+    } catch {
+      alert("Invalid theme config");
+    }
+  };
+
+  const handleEditTheme = async (name: string) => {
+    const configStr = prompt(
+      "Theme config JSON",
+      JSON.stringify(themeManager.getThemeConfig(name), null, 2),
+    );
+    if (!configStr) return;
+    try {
+      const config = JSON.parse(configStr) as ThemeConfig;
+      config.name = config.name || name;
+      await themeManager.editCustomTheme(name, config);
+      refresh();
+    } catch {
+      alert("Invalid theme config");
+    }
+  };
+
+  const handleRemoveTheme = async (name: string) => {
+    if (!confirm("Delete theme?")) return;
+    await themeManager.removeCustomTheme(name);
+    refresh();
+    if (theme === name) onThemeChange("dark");
+  };
+
+  const handleAddScheme = async () => {
+    const name = prompt("Color scheme name?");
+    if (!name) return;
+    const configStr = prompt(
+      "Color scheme JSON",
+      JSON.stringify(
+        { primary: "#3b82f6", secondary: "#1d4ed8", accent: "#1e40af" },
+        null,
+        2,
+      ),
+    );
+    if (!configStr) return;
+    try {
+      const config = JSON.parse(configStr) as Record<string, string>;
+      await themeManager.addCustomColorScheme(name, config);
+      refresh();
+    } catch {
+      alert("Invalid color scheme");
+    }
+  };
+
+  const handleEditScheme = async (name: string) => {
+    const configStr = prompt(
+      "Color scheme JSON",
+      JSON.stringify(themeManager.getColorSchemeConfig(name), null, 2),
+    );
+    if (!configStr) return;
+    try {
+      const config = JSON.parse(configStr) as Record<string, string>;
+      await themeManager.editCustomColorScheme(name, config);
+      refresh();
+    } catch {
+      alert("Invalid color scheme");
+    }
+  };
+
+  const handleRemoveScheme = async (name: string) => {
+    if (!confirm("Delete color scheme?")) return;
+    await themeManager.removeCustomColorScheme(name);
+    refresh();
+    if (colorScheme === name) onColorSchemeChange("blue");
+  };
+
+  const selectedScheme = themeManager.getColorSchemeConfig(colorScheme);
 
   return (
     <div className="space-y-6">
       {/* Theme Mode */}
       <div>
         <label className="block text-sm font-medium text-gray-300 mb-3">
-          Theme Mode
+          Theme
         </label>
         <div className="grid grid-cols-3 gap-3">
-          {[
-            { value: 'light', label: 'Light', icon: Sun },
-            { value: 'dark', label: 'Dark', icon: Moon },
-            { value: 'auto', label: 'Auto', icon: Monitor },
-          ].map(({ value, label, icon: Icon }) => (
+          {themeOptions.map(({ value, icon: Icon }) => (
             <button
               key={value}
               onClick={() => onThemeChange(value as Theme)}
               className={`p-4 rounded-lg border-2 transition-colors flex flex-col items-center space-y-2 ${
                 theme === value
-                  ? 'border-blue-500 bg-blue-500/20'
-                  : 'border-gray-600 hover:border-gray-500'
+                  ? "border-blue-500 bg-blue-500/20"
+                  : "border-gray-600 hover:border-gray-500"
               }`}
             >
               <Icon size={24} className="text-gray-300" />
-              <span className="text-white font-medium">{label}</span>
+              <span className="text-white font-medium capitalize">{value}</span>
             </button>
           ))}
         </div>
@@ -63,26 +198,28 @@ export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
           Color Scheme
         </label>
         <div className="grid grid-cols-3 gap-3">
-          {colorSchemes.map(scheme => (
+          {schemeOptions.map((scheme) => (
             <button
               key={scheme.name}
               onClick={() => onColorSchemeChange(scheme.name as ColorScheme)}
               className={`p-4 rounded-lg border-2 transition-colors ${
                 colorScheme === scheme.name
-                  ? 'border-blue-500 bg-blue-500/20'
-                  : 'border-gray-600 hover:border-gray-500'
+                  ? "border-blue-500 bg-blue-500/20"
+                  : "border-gray-600 hover:border-gray-500"
               }`}
             >
               <div className="flex items-center space-x-2 mb-2">
                 <Palette size={16} className="text-gray-300" />
-                <span className="text-white font-medium capitalize">{scheme.name}</span>
+                <span className="text-white font-medium capitalize">
+                  {scheme.name}
+                </span>
               </div>
               <div className="flex space-x-1">
-                {scheme.colors.map((color, index) => (
+                {["primary", "secondary", "accent"].map((key) => (
                   <div
-                    key={index}
+                    key={key}
                     className="w-6 h-6 rounded"
-                    style={{ backgroundColor: color }}
+                    style={{ backgroundColor: scheme.colors[key] }}
                   />
                 ))}
               </div>
@@ -96,27 +233,104 @@ export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
         <h3 className="text-white font-medium mb-3">Preview</h3>
         <div className="space-y-2">
           <div className="flex items-center space-x-2">
-            <div 
+            <div
               className="w-4 h-4 rounded"
-              style={{ backgroundColor: colorSchemes.find(s => s.name === colorScheme)?.colors[0] }}
+              style={{ backgroundColor: selectedScheme?.primary }}
             />
             <span className="text-gray-300">Primary Color</span>
           </div>
           <div className="flex items-center space-x-2">
-            <div 
+            <div
               className="w-4 h-4 rounded"
-              style={{ backgroundColor: colorSchemes.find(s => s.name === colorScheme)?.colors[1] }}
+              style={{ backgroundColor: selectedScheme?.secondary }}
             />
             <span className="text-gray-300">Secondary Color</span>
           </div>
           <div className="flex items-center space-x-2">
-            <div 
+            <div
               className="w-4 h-4 rounded"
-              style={{ backgroundColor: colorSchemes.find(s => s.name === colorScheme)?.colors[2] }}
+              style={{ backgroundColor: selectedScheme?.accent }}
             />
             <span className="text-gray-300">Accent Color</span>
           </div>
         </div>
+      </div>
+
+      {/* Management for custom items */}
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">
+          Custom Themes
+        </label>
+        <ul className="space-y-2">
+          {themes
+            .filter((tName) => !builtinThemes.includes(tName))
+            .map((tName) => (
+              <li
+                key={tName}
+                className="flex items-center justify-between text-white"
+              >
+                <span className="capitalize">{tName}</span>
+                <div className="space-x-2 text-sm">
+                  <button
+                    className="text-blue-400 hover:underline"
+                    onClick={() => handleEditTheme(tName)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-400 hover:underline"
+                    onClick={() => handleRemoveTheme(tName)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+        </ul>
+        <button
+          className="mt-2 text-blue-400 text-sm hover:underline"
+          onClick={handleAddTheme}
+        >
+          Add Theme
+        </button>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">
+          Custom Color Schemes
+        </label>
+        <ul className="space-y-2">
+          {schemes
+            .filter((s) => !builtinSchemes.includes(s))
+            .map((s) => (
+              <li
+                key={s}
+                className="flex items-center justify-between text-white"
+              >
+                <span className="capitalize">{s}</span>
+                <div className="space-x-2 text-sm">
+                  <button
+                    className="text-blue-400 hover:underline"
+                    onClick={() => handleEditScheme(s)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-400 hover:underline"
+                    onClick={() => handleRemoveScheme(s)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+        </ul>
+        <button
+          className="mt-2 text-blue-400 text-sm hover:underline"
+          onClick={handleAddScheme}
+        >
+          Add Color Scheme
+        </button>
       </div>
     </div>
   );

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,26 +1,28 @@
 export const Themes = [
-  'dark',
-  'light',
-  'auto',
-  'darkest',
-  'oled',
-  'semilight',
+  "dark",
+  "light",
+  "auto",
+  "darkest",
+  "oled",
+  "semilight",
 ] as const;
-export type Theme = typeof Themes[number];
+// Allow custom theme names beyond the predefined list
+export type Theme = (typeof Themes)[number] | string;
 
 export const ColorSchemes = [
-  'blue',
-  'green',
-  'purple',
-  'red',
-  'orange',
-  'teal',
-  'grey',
+  "blue",
+  "green",
+  "purple",
+  "red",
+  "orange",
+  "teal",
+  "grey",
 ] as const;
-export type ColorScheme = typeof ColorSchemes[number];
+// Allow custom color scheme names beyond the predefined list
+export type ColorScheme = (typeof ColorSchemes)[number] | string;
 
-export const StatusCheckMethods = ['ping', 'socket', 'http'] as const;
-export type StatusCheckMethod = typeof StatusCheckMethods[number];
+export const StatusCheckMethods = ["ping", "socket", "http"] as const;
+export type StatusCheckMethod = (typeof StatusCheckMethods)[number];
 
 export interface GlobalSettings {
   // General Settings
@@ -32,41 +34,41 @@ export interface GlobalSettings {
   reconnectOnReload: boolean;
   warnOnClose: boolean;
   warnOnExit: boolean;
-  
+
   // Auto Lock
   autoLock: AutoLockConfig;
-  
+
   // Performance Settings
   maxConcurrentConnections: number;
   connectionTimeout: number;
   retryAttempts: number;
   retryDelay: number;
   enablePerformanceTracking: boolean;
-  
+
   // Security Settings
-  encryptionAlgorithm: 'AES-256-GCM' | 'AES-256-CBC' | 'ChaCha20-Poly1305';
-  blockCipherMode: 'GCM' | 'CBC' | 'CTR' | 'OFB' | 'CFB';
+  encryptionAlgorithm: "AES-256-GCM" | "AES-256-CBC" | "ChaCha20-Poly1305";
+  blockCipherMode: "GCM" | "CBC" | "CTR" | "OFB" | "CFB";
   keyDerivationIterations: number;
   autoBenchmarkIterations: boolean;
   benchmarkTimeSeconds: number;
-  
+
   // TOTP Settings
   totpEnabled: boolean;
   totpIssuer: string;
   totpDigits: number;
   totpPeriod: number;
-  
+
   // Proxy Settings
   globalProxy?: ProxyConfig;
-  
+
   // Tab Settings
-  tabGrouping: 'none' | 'protocol' | 'status' | 'hostname' | 'colorTag';
+  tabGrouping: "none" | "protocol" | "status" | "hostname" | "colorTag";
   hostnameOverride: boolean;
-  defaultTabLayout: 'tabs' | 'sideBySide' | 'mosaic' | 'miniMosaic';
+  defaultTabLayout: "tabs" | "sideBySide" | "mosaic" | "miniMosaic";
   enableTabDetachment: boolean;
   enableTabResize: boolean;
   enableZoom: boolean;
-  
+
   // Color Tags
   colorTags: {
     [key: string]: {
@@ -75,15 +77,15 @@ export interface GlobalSettings {
       global: boolean;
     };
   };
-  
+
   // Status Checking
   enableStatusChecking: boolean;
   statusCheckInterval: number;
   statusCheckMethod: StatusCheckMethod;
-  
+
   // Network Discovery
   networkDiscovery: NetworkDiscoveryConfig;
-  
+
   // REST API
   restApi: {
     enabled: boolean;
@@ -93,24 +95,24 @@ export interface GlobalSettings {
     corsEnabled: boolean;
     rateLimiting: boolean;
   };
-  
+
   // Wake on LAN
   wolEnabled: boolean;
   wolPort: number;
   wolBroadcastAddress: string;
-  
+
   // Logging
   enableActionLog: boolean;
-  logLevel: 'debug' | 'info' | 'warn' | 'error';
+  logLevel: "debug" | "info" | "warn" | "error";
   maxLogEntries: number;
-  
+
   // Export Settings
   exportEncryption: boolean;
   exportPassword?: string;
 }
 
 export interface ProxyConfig {
-  type: 'http' | 'https' | 'socks4' | 'socks5';
+  type: "http" | "https" | "socks4" | "socks5";
   host: string;
   port: number;
   username?: string;
@@ -141,7 +143,7 @@ export interface PerformanceMetrics {
 export interface ActionLogEntry {
   id: string;
   timestamp: Date;
-  level: 'debug' | 'info' | 'warn' | 'error';
+  level: "debug" | "info" | "warn" | "error";
   action: string;
   connectionId?: string;
   connectionName?: string;
@@ -152,9 +154,9 @@ export interface ActionLogEntry {
 export interface CustomScript {
   id: string;
   name: string;
-  type: 'javascript' | 'typescript';
+  type: "javascript" | "typescript";
   content: string;
-  trigger: 'onConnect' | 'onDisconnect' | 'manual';
+  trigger: "onConnect" | "onDisconnect" | "manual";
   protocol?: string;
   enabled: boolean;
   createdAt: Date;
@@ -181,7 +183,7 @@ export interface TOTPConfig {
   account: string;
   digits: number;
   period: number;
-  algorithm: 'SHA1' | 'SHA256' | 'SHA512';
+  algorithm: "SHA1" | "SHA256" | "SHA512";
 }
 
 export interface ThemeConfig {

--- a/src/utils/themeManager.ts
+++ b/src/utils/themeManager.ts
@@ -1,10 +1,10 @@
-import { ThemeConfig, Theme, ColorScheme } from '../types/settings';
-import { IndexedDbService } from './indexedDbService';
+import { ThemeConfig, Theme, ColorScheme } from "../types/settings";
+import { IndexedDbService } from "./indexedDbService";
 
 export class ThemeManager {
   private static instance: ThemeManager | null = null;
-  private currentTheme: Theme = 'dark';
-  private currentColorScheme: ColorScheme = 'blue';
+  private currentTheme: Theme = "dark";
+  private currentColorScheme: ColorScheme = "blue";
   private systemThemeStop?: () => void;
 
   static getInstance(): ThemeManager {
@@ -20,131 +20,154 @@ export class ThemeManager {
 
   private themes: Record<string, ThemeConfig> = {
     dark: {
-      name: 'Dark',
+      name: "Dark",
       colors: {
-        primary: '#3b82f6',
-        secondary: '#6b7280',
-        accent: '#10b981',
-        background: '#111827',
-        surface: '#1f2937',
-        text: '#f9fafb',
-        textSecondary: '#d1d5db',
-        border: '#374151',
-        success: '#10b981',
-        warning: '#f59e0b',
-        error: '#ef4444',
+        primary: "#3b82f6",
+        secondary: "#6b7280",
+        accent: "#10b981",
+        background: "#111827",
+        surface: "#1f2937",
+        text: "#f9fafb",
+        textSecondary: "#d1d5db",
+        border: "#374151",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
       },
     },
     light: {
-      name: 'Light',
+      name: "Light",
       colors: {
-        primary: '#3b82f6',
-        secondary: '#6b7280',
-        accent: '#10b981',
-        background: '#ffffff',
-        surface: '#f9fafb',
-        text: '#000000',
-        textSecondary: '#6b7280',
-        border: '#e5e7eb',
-        success: '#10b981',
-        warning: '#f59e0b',
-        error: '#ef4444',
+        primary: "#3b82f6",
+        secondary: "#6b7280",
+        accent: "#10b981",
+        background: "#ffffff",
+        surface: "#f9fafb",
+        text: "#000000",
+        textSecondary: "#6b7280",
+        border: "#e5e7eb",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
       },
     },
     darkest: {
-      name: 'Darkest',
+      name: "Darkest",
       colors: {
-        primary: '#3b82f6',
-        secondary: '#4b5563',
-        accent: '#10b981',
-        background: '#000000',
-        surface: '#0f0f0f',
-        text: '#ffffff',
-        textSecondary: '#9ca3af',
-        border: '#1f1f1f',
-        success: '#10b981',
-        warning: '#f59e0b',
-        error: '#ef4444',
+        primary: "#3b82f6",
+        secondary: "#4b5563",
+        accent: "#10b981",
+        background: "#000000",
+        surface: "#0f0f0f",
+        text: "#ffffff",
+        textSecondary: "#9ca3af",
+        border: "#1f1f1f",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
       },
     },
     oled: {
-      name: 'OLED Black',
+      name: "OLED Black",
       colors: {
-        primary: '#3b82f6',
-        secondary: '#374151',
-        accent: '#10b981',
-        background: '#000000',
-        surface: '#000000',
-        text: '#ffffff',
-        textSecondary: '#6b7280',
-        border: '#111111',
-        success: '#10b981',
-        warning: '#f59e0b',
-        error: '#ef4444',
+        primary: "#3b82f6",
+        secondary: "#374151",
+        accent: "#10b981",
+        background: "#000000",
+        surface: "#000000",
+        text: "#ffffff",
+        textSecondary: "#6b7280",
+        border: "#111111",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
       },
     },
     semilight: {
-      name: 'Semi Light',
+      name: "Semi Light",
       colors: {
-        primary: '#3b82f6',
-        secondary: '#6b7280',
-        accent: '#10b981',
-        background: '#f3f4f6',
-        surface: '#e5e7eb',
-        text: '#000000',
-        textSecondary: '#374151',
-        border: '#d1d5db',
-        success: '#10b981',
-        warning: '#f59e0b',
-        error: '#ef4444',
+        primary: "#3b82f6",
+        secondary: "#6b7280",
+        accent: "#10b981",
+        background: "#f3f4f6",
+        surface: "#e5e7eb",
+        text: "#000000",
+        textSecondary: "#374151",
+        border: "#d1d5db",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
       },
     },
   };
 
   private colorSchemes: Record<string, Record<string, string>> = {
     blue: {
-      primary: '#3b82f6',
-      secondary: '#1d4ed8',
-      accent: '#1e40af',
+      primary: "#3b82f6",
+      secondary: "#1d4ed8",
+      accent: "#1e40af",
     },
     green: {
-      primary: '#10b981',
-      secondary: '#059669',
-      accent: '#047857',
+      primary: "#10b981",
+      secondary: "#059669",
+      accent: "#047857",
     },
     purple: {
-      primary: '#8b5cf6',
-      secondary: '#7c3aed',
-      accent: '#6d28d9',
+      primary: "#8b5cf6",
+      secondary: "#7c3aed",
+      accent: "#6d28d9",
     },
     red: {
-      primary: '#ef4444',
-      secondary: '#dc2626',
-      accent: '#b91c1c',
+      primary: "#ef4444",
+      secondary: "#dc2626",
+      accent: "#b91c1c",
     },
     orange: {
-      primary: '#f97316',
-      secondary: '#ea580c',
-      accent: '#c2410c',
+      primary: "#f97316",
+      secondary: "#ea580c",
+      accent: "#c2410c",
     },
     teal: {
-      primary: '#14b8a6',
-      secondary: '#0d9488',
-      accent: '#0f766e',
+      primary: "#14b8a6",
+      secondary: "#0d9488",
+      accent: "#0f766e",
     },
     grey: {
-      primary: '#9ca3af',
-      secondary: '#6b7280',
-      accent: '#4b5563',
+      primary: "#9ca3af",
+      secondary: "#6b7280",
+      accent: "#4b5563",
     },
   };
 
+  // Containers for user-defined themes and color schemes
+  private customThemes: Record<string, ThemeConfig> = {};
+  private customColorSchemes: Record<string, Record<string, string>> = {};
+
+  private readonly customThemesKey = "mremote-custom-themes";
+  private readonly customSchemesKey = "mremote-custom-color-schemes";
+
+  private getAllThemes(): Record<string, ThemeConfig> {
+    return { ...this.themes, ...this.customThemes };
+  }
+
+  private getAllColorSchemes(): Record<string, Record<string, string>> {
+    return { ...this.colorSchemes, ...this.customColorSchemes };
+  }
+
+  getThemeConfig(name: string): ThemeConfig | undefined {
+    return this.getAllThemes()[name];
+  }
+
+  getColorSchemeConfig(name: string): Record<string, string> | undefined {
+    return this.getAllColorSchemes()[name];
+  }
+
   private applyResolvedTheme(themeName: string, colorScheme: string): void {
-    const theme = this.themes[themeName];
-    const colors = this.colorSchemes[colorScheme];
+    const theme = this.getAllThemes()[themeName];
+    const colors = this.getAllColorSchemes()[colorScheme];
 
     if (!theme || !colors) {
-      console.error('Invalid theme or color scheme');
+      console.error("Invalid theme or color scheme");
       return;
     }
 
@@ -154,13 +177,13 @@ export class ThemeManager {
       root.style.setProperty(`--color-${key}`, value);
     });
 
-    root.style.setProperty('--color-primary', colors.primary);
-    root.style.setProperty('--color-secondary', colors.secondary);
-    root.style.setProperty('--color-accent', colors.accent);
+    root.style.setProperty("--color-primary", colors.primary);
+    root.style.setProperty("--color-secondary", colors.secondary);
+    root.style.setProperty("--color-accent", colors.accent);
 
     document.body.className = document.body.className
-      .replace(/theme-\w+/g, '')
-      .replace(/scheme-\w+/g, '');
+      .replace(/theme-\w+/g, "")
+      .replace(/scheme-\w+/g, "");
 
     document.body.classList.add(`theme-${themeName}`, `scheme-${colorScheme}`);
   }
@@ -174,7 +197,7 @@ export class ThemeManager {
       this.systemThemeStop = undefined;
     }
 
-    if (themeName === 'auto') {
+    if (themeName === "auto") {
       const systemTheme = this.detectSystemTheme();
       this.applyResolvedTheme(systemTheme, colorScheme);
       this.systemThemeStop = this.watchSystemTheme((theme) => {
@@ -185,8 +208,8 @@ export class ThemeManager {
     }
 
     // Persist to IndexedDB
-    void IndexedDbService.setItem('mremote-theme', themeName);
-    void IndexedDbService.setItem('mremote-color-scheme', colorScheme);
+    void IndexedDbService.setItem("mremote-theme", themeName);
+    void IndexedDbService.setItem("mremote-color-scheme", colorScheme);
   }
 
   getCurrentTheme(): Theme {
@@ -198,65 +221,134 @@ export class ThemeManager {
   }
 
   getAvailableThemes(): Theme[] {
-    return Object.keys(this.themes) as Theme[];
+    return [...Object.keys(this.getAllThemes()), "auto"] as Theme[];
   }
 
   getAvailableColorSchemes(): ColorScheme[] {
-    return Object.keys(this.colorSchemes) as ColorScheme[];
+    return Object.keys(this.getAllColorSchemes()) as ColorScheme[];
   }
 
   async loadSavedTheme(): Promise<void> {
-    const savedTheme = (await IndexedDbService.getItem<Theme>('mremote-theme')) ?? 'dark';
-    const savedColorScheme = (await IndexedDbService.getItem<ColorScheme>('mremote-color-scheme')) ?? 'blue';
+    // Load persisted custom themes and color schemes
+    this.customThemes =
+      (await IndexedDbService.getItem<Record<string, ThemeConfig>>(
+        this.customThemesKey,
+      )) ?? {};
+    this.customColorSchemes =
+      (await IndexedDbService.getItem<Record<string, Record<string, string>>>(
+        this.customSchemesKey,
+      )) ?? {};
+
+    this.injectThemeCSS();
+
+    const savedTheme =
+      (await IndexedDbService.getItem<Theme>("mremote-theme")) ?? "dark";
+    const savedColorScheme =
+      (await IndexedDbService.getItem<ColorScheme>("mremote-color-scheme")) ??
+      "blue";
 
     this.applyTheme(savedTheme, savedColorScheme);
   }
 
+  private async saveCustomThemes(): Promise<void> {
+    await IndexedDbService.setItem(this.customThemesKey, this.customThemes);
+    this.injectThemeCSS();
+  }
+
+  private async saveCustomColorSchemes(): Promise<void> {
+    await IndexedDbService.setItem(
+      this.customSchemesKey,
+      this.customColorSchemes,
+    );
+    this.injectThemeCSS();
+  }
+
+  async addCustomTheme(name: string, config: ThemeConfig): Promise<void> {
+    this.customThemes[name] = config;
+    await this.saveCustomThemes();
+  }
+
+  async editCustomTheme(name: string, config: ThemeConfig): Promise<void> {
+    await this.addCustomTheme(name, config);
+  }
+
+  async removeCustomTheme(name: string): Promise<void> {
+    delete this.customThemes[name];
+    await this.saveCustomThemes();
+  }
+
+  async addCustomColorScheme(
+    name: string,
+    colors: Record<string, string>,
+  ): Promise<void> {
+    this.customColorSchemes[name] = colors;
+    await this.saveCustomColorSchemes();
+  }
+
+  async editCustomColorScheme(
+    name: string,
+    colors: Record<string, string>,
+  ): Promise<void> {
+    await this.addCustomColorScheme(name, colors);
+  }
+
+  async removeCustomColorScheme(name: string): Promise<void> {
+    delete this.customColorSchemes[name];
+    await this.saveCustomColorSchemes();
+  }
+
   // Auto theme detection
   detectSystemTheme(): string {
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark';
+    if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+      return "dark";
     }
-    return 'light';
+    return "light";
   }
 
   // Listen for system theme changes
-  watchSystemTheme(callback: (theme: 'dark' | 'light') => void): (() => void) | undefined {
+  watchSystemTheme(
+    callback: (theme: "dark" | "light") => void,
+  ): (() => void) | undefined {
     if (window.matchMedia) {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
       const handleChange = (e: MediaQueryListEvent) => {
-        callback(e.matches ? 'dark' : 'light');
+        callback(e.matches ? "dark" : "light");
       };
 
-      mediaQuery.addEventListener('change', handleChange);
-      
+      mediaQuery.addEventListener("change", handleChange);
+
       // Return cleanup function
       return () => {
-        mediaQuery.removeEventListener('change', handleChange);
+        mediaQuery.removeEventListener("change", handleChange);
       };
     }
   }
 
   // Generate CSS for themes
   generateThemeCSS(): string {
-    let css = '';
+    let css = "";
 
-    Object.entries(this.themes).forEach(([themeName, theme]) => {
+    Object.entries(this.getAllThemes()).forEach(([themeName, theme]) => {
       css += `.theme-${themeName} {\n`;
       Object.entries(theme.colors).forEach(([key, value]) => {
         css += `  --color-${key}: ${value};\n`;
       });
-      css += '}\n\n';
+      css += "}\n\n";
     });
 
-    Object.entries(this.colorSchemes).forEach(([schemeName, colors]) => {
-      css += `.scheme-${schemeName} {\n`;
-      Object.entries(colors).forEach(([key, value]) => {
-        css += `  --color-${key}: ${value};\n`;
-      });
-      css += '}\n\n';
-    });
+    Object.entries(this.getAllColorSchemes()).forEach(
+      ([schemeName, colors]) => {
+        css += `.scheme-${schemeName} {\n`;
+        Object.entries(colors).forEach(([key, value]) => {
+          css += `  --color-${key}: ${value};\n`;
+        });
+        css += "}\n\n";
+      },
+    );
 
     // Drop indicators for drag and drop
     css += `
@@ -312,13 +404,13 @@ export class ThemeManager {
 
   // Inject theme CSS into document
   injectThemeCSS(): void {
-    const existingStyle = document.getElementById('theme-styles');
+    const existingStyle = document.getElementById("theme-styles");
     if (existingStyle) {
       existingStyle.remove();
     }
 
-    const style = document.createElement('style');
-    style.id = 'theme-styles';
+    const style = document.createElement("style");
+    style.id = "theme-styles";
     style.textContent = this.generateThemeCSS();
     document.head.appendChild(style);
   }

--- a/tests/SettingsDialog.test.tsx
+++ b/tests/SettingsDialog.test.tsx
@@ -1,52 +1,61 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { SettingsDialog } from '../src/components/SettingsDialog';
-import { GlobalSettings } from '../src/types/settings';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { SettingsDialog } from "../src/components/SettingsDialog";
+import { GlobalSettings } from "../src/types/settings";
 
 // mock i18n
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } })
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: vi.fn() },
+  }),
 }));
 
 const mockSettings: GlobalSettings = {
-  language: 'en',
-  theme: 'dark',
-  colorScheme: 'blue',
+  language: "en",
+  theme: "dark",
+  colorScheme: "blue",
   singleWindowMode: false,
   singleConnectionMode: false,
   reconnectOnReload: false,
   warnOnClose: false,
   warnOnExit: false,
-  autoLock: { enabled: false, timeoutMinutes: 10, lockOnIdle: true, lockOnSuspend: true, requirePassword: true },
+  autoLock: {
+    enabled: false,
+    timeoutMinutes: 10,
+    lockOnIdle: true,
+    lockOnSuspend: true,
+    requirePassword: true,
+  },
   maxConcurrentConnections: 5,
   connectionTimeout: 30,
   retryAttempts: 0,
   retryDelay: 5000,
   enablePerformanceTracking: false,
-  encryptionAlgorithm: 'AES-256-GCM',
-  blockCipherMode: 'GCM',
+  encryptionAlgorithm: "AES-256-GCM",
+  blockCipherMode: "GCM",
   keyDerivationIterations: 1000,
   autoBenchmarkIterations: false,
   benchmarkTimeSeconds: 1,
   totpEnabled: false,
-  totpIssuer: '',
+  totpIssuer: "",
   totpDigits: 6,
   totpPeriod: 30,
-  globalProxy: { type: 'http', host: '', port: 8080, enabled: false },
-  tabGrouping: 'none',
+  globalProxy: { type: "http", host: "", port: 8080, enabled: false },
+  tabGrouping: "none",
   hostnameOverride: false,
-  defaultTabLayout: 'tabs',
+  defaultTabLayout: "tabs",
   enableTabDetachment: false,
   enableTabResize: true,
   enableZoom: true,
   colorTags: {},
   enableStatusChecking: false,
   statusCheckInterval: 30,
-  statusCheckMethod: 'socket',
+  statusCheckMethod: "socket",
   networkDiscovery: {
     enabled: false,
-    ipRange: '',
+    ipRange: "",
     portRanges: [],
     protocols: [],
     timeout: 5000,
@@ -57,18 +66,25 @@ const mockSettings: GlobalSettings = {
     hostnameTtl: 300000,
     macTtl: 300000,
   },
-  restApi: { enabled: false, port: 8080, authentication: false, apiKey: '', corsEnabled: true, rateLimiting: true },
+  restApi: {
+    enabled: false,
+    port: 8080,
+    authentication: false,
+    apiKey: "",
+    corsEnabled: true,
+    rateLimiting: true,
+  },
   wolEnabled: false,
   wolPort: 9,
-  wolBroadcastAddress: '255.255.255.255',
+  wolBroadcastAddress: "255.255.255.255",
   enableActionLog: false,
-  logLevel: 'info',
+  logLevel: "info",
   maxLogEntries: 1000,
   exportEncryption: false,
   exportPassword: undefined,
 };
 
-vi.mock('../src/utils/settingsManager', () => ({
+vi.mock("../src/utils/settingsManager", () => ({
   SettingsManager: {
     getInstance: () => ({
       loadSettings: vi.fn().mockResolvedValue(mockSettings),
@@ -77,15 +93,20 @@ vi.mock('../src/utils/settingsManager', () => ({
   },
 }));
 
-vi.mock('../src/utils/themeManager', () => ({
-  ThemeManager: { getInstance: () => ({ applyTheme: vi.fn() }) },
+vi.mock("../src/utils/themeManager", () => ({
+  ThemeManager: {
+    getInstance: () => ({
+      applyTheme: vi.fn(),
+      getAvailableThemes: () => ["dark", "light", "auto"],
+      getAvailableColorSchemes: () => ["blue"],
+    }),
+  },
 }));
 
-describe('SettingsDialog', () => {
-  it('renders general tab content', async () => {
+describe("SettingsDialog", () => {
+  it("renders general tab content", async () => {
     render(<SettingsDialog isOpen onClose={() => {}} />);
-    const items = await screen.findAllByText('settings.general');
+    const items = await screen.findAllByText("settings.general");
     expect(items.length).toBeGreaterThan(0);
   });
 });
-


### PR DESCRIPTION
## Summary
- persist user-defined themes and color schemes in ThemeManager using IndexedDB
- expose APIs to add, edit, and delete custom themes
- expand theme selector and settings UI to manage custom themes

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b61bd0b35083259f79b0d47e11fbe5