### PR TITLE
feat: expand auth service with user management

### DIFF
--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { AuthService } from '../src/utils/authService';
+
+// Utility to create temp directory for user store
+async function createStore(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'auth-'));
+  const file = path.join(dir, 'users.json');
+  await fs.writeFile(file, '[]');
+  return file;
+}
+
+describe('AuthService', () => {
+  let storePath: string;
+  let service: AuthService;
+
+  beforeEach(async () => {
+    storePath = await createStore();
+    service = new AuthService(storePath);
+    await service.ready();
+  });
+
+  test('addUser and listUsers', async () => {
+    await service.addUser('alice', 'password1');
+    await service.addUser('bob', 'password2');
+    const users = await service.listUsers();
+    expect(users.sort()).toEqual(['alice', 'bob']);
+    const contents = await fs.readFile(storePath, 'utf8');
+    expect(contents).toContain('alice');
+    expect(contents).toContain('bob');
+  });
+
+  test('removeUser', async () => {
+    await service.addUser('charlie', 'secret');
+    const removed = await service.removeUser('charlie');
+    expect(removed).toBe(true);
+    expect(await service.listUsers()).toEqual([]);
+    const contents = await fs.readFile(storePath, 'utf8');
+    expect(contents).not.toContain('charlie');
+  });
+
+  test('updatePassword', async () => {
+    await service.addUser('dave', 'old');
+    const updated = await service.updatePassword('dave', 'new');
+    expect(updated).toBe(true);
+    expect(await service.verifyUser('dave', 'new')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add ready(), listUsers, removeUser, updatePassword in auth service
- expose REST endpoints for managing users
- add unit tests for user CRUD operations

## Testing
- `npx prettier AGENTS.md -w` *(file not found; formatted agents.md instead)*
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b628e684a08325bce91b4df3c4a941