### PR TITLE
feat: expand auth service with user management

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -117,7 +117,8 @@ export class AuthService {
    */
   async removeUser(username: string): Promise<boolean> {
     await this.ready();
-    if (!(username in this.users)) {
+    const hash = this.users[username];
+    if (!hash) {
       return false;
     }
     delete this.users[username];
@@ -125,7 +126,8 @@ export class AuthService {
       await this.persist();
     } catch (error) {
       console.error("Failed to persist user removal", error);
-      return false;
+      this.users[username] = hash;
+      throw error;
     }
     return true;
   }
@@ -142,7 +144,8 @@ export class AuthService {
     newPassword: string,
   ): Promise<boolean> {
     await this.ready();
-    if (!(username in this.users)) {
+    const currentHash = this.users[username];
+    if (!currentHash) {
       return false;
     }
     const hash = await bcrypt.hash(newPassword, 10);
@@ -151,7 +154,8 @@ export class AuthService {
       await this.persist();
     } catch (error) {
       console.error("Failed to persist password update", error);
-      return false;
+      this.users[username] = currentHash;
+      throw error;
     }
     return true;
   }

--- a/src/utils/restApiServer.ts
+++ b/src/utils/restApiServer.ts
@@ -324,11 +324,16 @@ export class RestApiServer {
     });
 
     this.app.delete("/api/users/:username", async (req, res) => {
-      const removed = await this.authService.removeUser(req.params.username);
-      if (!removed) {
-        return res.status(404).json({ error: "User not found" });
+      try {
+        const removed = await this.authService.removeUser(req.params.username);
+        if (!removed) {
+          return res.status(404).json({ error: "User not found" });
+        }
+        res.status(204).send();
+      } catch (error) {
+        console.error("Failed to remove user", error);
+        res.status(500).json({ error: "Failed to remove user" });
       }
-      res.status(204).send();
     });
 
     this.app.put("/api/users/:username/password", async (req, res) => {
@@ -336,14 +341,19 @@ export class RestApiServer {
       if (!result.success) {
         return res.status(400).json({ error: "Invalid request" });
       }
-      const updated = await this.authService.updatePassword(
-        req.params.username,
-        result.data.password,
-      );
-      if (!updated) {
-        return res.status(404).json({ error: "User not found" });
+      try {
+        const updated = await this.authService.updatePassword(
+          req.params.username,
+          result.data.password,
+        );
+        if (!updated) {
+          return res.status(404).json({ error: "User not found" });
+        }
+        res.status(204).send();
+      } catch (error) {
+        console.error("Failed to update password", error);
+        res.status(500).json({ error: "Failed to update password" });
       }
-      res.status(204).send();
     });
 
     // Connections API

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,17 +1,19 @@
-import fs from 'fs/promises';
-import path from 'path';
-import os from 'os';
-import { AuthService } from '../src/utils/authService';
+import fs from "fs/promises";
+import * as fsSync from "fs";
+import path from "path";
+import os from "os";
+import { vi } from "vitest";
+import { AuthService } from "../src/utils/authService";
 
 // Utility to create temp directory for user store
 async function createStore(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'auth-'));
-  const file = path.join(dir, 'users.json');
-  await fs.writeFile(file, '[]');
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "auth-"));
+  const file = path.join(dir, "users.json");
+  await fs.writeFile(file, "[]");
   return file;
 }
 
-describe('AuthService', () => {
+describe("AuthService", () => {
   let storePath: string;
   let service: AuthService;
 
@@ -21,29 +23,51 @@ describe('AuthService', () => {
     await service.ready();
   });
 
-  test('addUser and listUsers', async () => {
-    await service.addUser('alice', 'password1');
-    await service.addUser('bob', 'password2');
+  test("addUser and listUsers", async () => {
+    await service.addUser("alice", "password1");
+    await service.addUser("bob", "password2");
     const users = await service.listUsers();
-    expect(users.sort()).toEqual(['alice', 'bob']);
-    const contents = await fs.readFile(storePath, 'utf8');
-    expect(contents).toContain('alice');
-    expect(contents).toContain('bob');
+    expect(users.sort()).toEqual(["alice", "bob"]);
+    const contents = await fs.readFile(storePath, "utf8");
+    expect(contents).toContain("alice");
+    expect(contents).toContain("bob");
   });
 
-  test('removeUser', async () => {
-    await service.addUser('charlie', 'secret');
-    const removed = await service.removeUser('charlie');
+  test("removeUser", async () => {
+    await service.addUser("charlie", "secret");
+    const removed = await service.removeUser("charlie");
     expect(removed).toBe(true);
     expect(await service.listUsers()).toEqual([]);
-    const contents = await fs.readFile(storePath, 'utf8');
-    expect(contents).not.toContain('charlie');
+    const contents = await fs.readFile(storePath, "utf8");
+    expect(contents).not.toContain("charlie");
   });
 
-  test('updatePassword', async () => {
-    await service.addUser('dave', 'old');
-    const updated = await service.updatePassword('dave', 'new');
+  test("updatePassword", async () => {
+    await service.addUser("dave", "old");
+    const updated = await service.updatePassword("dave", "new");
     expect(updated).toBe(true);
-    expect(await service.verifyUser('dave', 'new')).toBe(true);
+    expect(await service.verifyUser("dave", "new")).toBe(true);
+  });
+
+  test("removeUser propagates persist errors", async () => {
+    await service.addUser("eve", "secret");
+    const spy = vi
+      .spyOn(fsSync.promises, "writeFile")
+      .mockRejectedValue(new Error("disk full"));
+    await expect(service.removeUser("eve")).rejects.toThrow("disk full");
+    expect(await service.listUsers()).toContain("eve");
+    spy.mockRestore();
+  });
+
+  test("updatePassword propagates persist errors", async () => {
+    await service.addUser("frank", "old");
+    const spy = vi
+      .spyOn(fsSync.promises, "writeFile")
+      .mockRejectedValue(new Error("disk full"));
+    await expect(service.updatePassword("frank", "new")).rejects.toThrow(
+      "disk full",
+    );
+    expect(await service.verifyUser("frank", "old")).toBe(true);
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- propagate persistence errors from `removeUser` and `updatePassword`
- handle auth service errors in REST API
- add tests for persistence error handling in auth service

## Testing
- `npx prettier agents.md src/utils/authService.ts src/utils/restApiServer.ts tests/authService.test.ts -w`
- `npx prettier AGENTS.md -w` *(fails: No files matching the pattern were found: "AGENTS.md".)*
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6affa04908325b5ed0b4271173708