### PR TITLE
Add password validation for short passwords

### DIFF
--- a/src/components/PasswordDialog.tsx
+++ b/src/components/PasswordDialog.tsx
@@ -20,6 +20,7 @@ export const PasswordDialog: React.FC<PasswordDialogProps> = ({
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -29,9 +30,11 @@ export const PasswordDialog: React.FC<PasswordDialogProps> = ({
     }
     
     if (password.length < 4) {
+      setPasswordError('Password must be at least 4 characters');
       return;
     }
 
+    setPasswordError('');
     onSubmit(password);
     setPassword('');
     setConfirmPassword('');
@@ -40,6 +43,7 @@ export const PasswordDialog: React.FC<PasswordDialogProps> = ({
   const handleCancel = () => {
     setPassword('');
     setConfirmPassword('');
+    setPasswordError('');
     onCancel();
   };
 
@@ -110,6 +114,9 @@ export const PasswordDialog: React.FC<PasswordDialogProps> = ({
                 {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
               </button>
             </div>
+            {passwordError && (
+              <p className="text-red-400 text-sm mt-1">{passwordError}</p>
+            )}
           </div>
 
           {mode === 'setup' && (

--- a/tests/PasswordDialog.test.tsx
+++ b/tests/PasswordDialog.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PasswordDialog } from '../src/components/PasswordDialog';
+
+describe('PasswordDialog', () => {
+  it('shows validation message for short passwords', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <PasswordDialog isOpen mode="unlock" onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+
+    const input = screen.getByPlaceholderText('Enter password');
+    fireEvent.change(input, { target: { value: 'abc' } });
+    const form = input.closest('form')!;
+    fireEvent.submit(form);
+
+    expect(
+      screen.getByText('Password must be at least 4 characters'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add local password error state to PasswordDialog
- show validation message when password is too short
- test that short password triggers validation

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b6dbb02f8483258dabf4aa7b2bb23d