### PR TITLE
fix: propagate user store load failures

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -41,9 +41,20 @@ export class AuthService {
    * @throws {Error} If the user store cannot be read or parsed.
    */
   private async load(): Promise<void> {
+    const fullPath = path.resolve(this.storePath);
+    let data: string;
     try {
-      const fullPath = path.resolve(this.storePath);
-      const data = await fs.promises.readFile(fullPath, "utf8");
+      data = await fs.promises.readFile(fullPath, "utf8");
+    } catch (err: any) {
+      if (err.code === "ENOENT") {
+        this.users = {};
+        return;
+      }
+      console.error("Failed to read user store", err);
+      throw err;
+    }
+
+    try {
       const parsed = JSON.parse(data);
       if (Array.isArray(parsed)) {
         // Plaintext store
@@ -89,8 +100,9 @@ export class AuthService {
       } else {
         this.users = {};
       }
-    } catch {
-      this.users = {};
+    } catch (err) {
+      console.error("Failed to load user store", err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- surface read/decryption failures when loading the user store instead of resetting users

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b72ebfc93c8325853d4f85678db100