### PR TITLE
feat: add HTTP probing fallback and IPv6 range tests

### DIFF
--- a/src/components/NetworkDiscovery.tsx
+++ b/src/components/NetworkDiscovery.tsx
@@ -46,6 +46,11 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
       ftp: [21],
       telnet: [23],
     },
+    probeStrategies: {
+      default: ["websocket"],
+      http: ["websocket", "http"],
+      https: ["websocket", "http"],
+    },
     cacheTTL: 300000,
     hostnameTtl: 300000,
     macTtl: 300000,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -172,6 +172,7 @@ export interface NetworkDiscoveryConfig {
   maxConcurrent: number;
   maxPortConcurrent: number;
   customPorts: Record<string, number[]>;
+  probeStrategies: Record<string, ("websocket" | "http")[]>;
   cacheTTL: number;
   hostnameTtl: number;
   macTtl: number;

--- a/src/utils/__tests__/networkScanner.test.ts
+++ b/src/utils/__tests__/networkScanner.test.ts
@@ -105,6 +105,7 @@ describe('NetworkScanner helper methods', () => {
       maxConcurrent: 10,
       maxPortConcurrent: 2,
       customPorts: {},
+      probeStrategies: { default: ['websocket'] },
       cacheTTL: 60000,
       hostnameTtl: 60000,
       macTtl: 60000,
@@ -143,6 +144,7 @@ describe('NetworkScanner helper methods', () => {
       maxConcurrent: 2,
       maxPortConcurrent: 1,
       customPorts: {},
+      probeStrategies: { default: ['websocket'] },
       cacheTTL: 60000,
       hostnameTtl: 60000,
       macTtl: 60000,
@@ -167,6 +169,7 @@ describe('NetworkScanner helper methods', () => {
       maxConcurrent: 2,
       maxPortConcurrent: 1,
       customPorts: {},
+      probeStrategies: { default: ['websocket'] },
       cacheTTL: 60000,
       hostnameTtl: 60000,
       macTtl: 60000,
@@ -179,7 +182,21 @@ describe('NetworkScanner helper methods', () => {
   });
 
   it('scanPort resolves false on invalid hostname without rejection', async () => {
-    const result = await scanner.scanPort('invalid host', 80, 50);
+    const config: NetworkDiscoveryConfig = {
+      enabled: true,
+      ipRange: '',
+      portRanges: [],
+      protocols: [],
+      timeout: 50,
+      maxConcurrent: 1,
+      maxPortConcurrent: 1,
+      customPorts: {},
+      probeStrategies: { default: ['websocket'] },
+      cacheTTL: 0,
+      hostnameTtl: 0,
+      macTtl: 0,
+    };
+    const result = await scanner.scanPort('invalid host', 80, config);
     expect(result.isOpen).toBe(false);
   });
 
@@ -196,7 +213,21 @@ describe('NetworkScanner helper methods', () => {
       close() {}
     }
     (global as any).WebSocket = MockWebSocket as any;
-    const result = await scanner.scanPort('2001:db8::1', 80, 50);
+    const config: NetworkDiscoveryConfig = {
+      enabled: true,
+      ipRange: '',
+      portRanges: [],
+      protocols: [],
+      timeout: 50,
+      maxConcurrent: 1,
+      maxPortConcurrent: 1,
+      customPorts: {},
+      probeStrategies: { default: ['websocket'] },
+      cacheTTL: 0,
+      hostnameTtl: 0,
+      macTtl: 0,
+    };
+    const result = await scanner.scanPort('2001:db8::1', 80, config);
     expect(capturedUrl).toBe('ws://[2001:db8::1]:80');
     expect(result.isOpen).toBe(false);
   });

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -216,7 +216,7 @@ export class NetworkScanner {
         if (signal?.aborted) {
           return { isOpen: false, elapsed: 0 };
         }
-        return await this.scanPort(ip, port, config.timeout, signal);
+        return await this.scanPort(ip, port, config, signal);
       } finally {
         portSemaphore.release();
       }
@@ -279,9 +279,45 @@ export class NetworkScanner {
   private async scanPort(
     ip: string,
     port: number,
-    timeout: number,
+    config: NetworkDiscoveryConfig,
     signal?: AbortSignal,
   ): Promise<{ isOpen: boolean; banner?: string; elapsed: number }> {
+    const protocol = serviceMap[port]?.protocol || "default";
+    const strategies =
+      config.probeStrategies[protocol] || config.probeStrategies.default || ["websocket"];
+
+    for (const strategy of strategies) {
+      if (signal?.aborted) {
+        return { isOpen: false, elapsed: 0 };
+      }
+
+      if (strategy === "websocket") {
+        const wsResult = await this.probeWebSocket(ip, port, config.timeout, signal);
+        if (wsResult !== null) {
+          if (wsResult.isOpen || strategies.length === 1) {
+            return wsResult;
+          }
+          // If websocket reported closed and other strategies remain, continue loop
+          continue;
+        }
+        // wsResult null means creation failed; fall through to next strategy
+      } else if (strategy === "http") {
+        const httpResult = await this.probeHttp(ip, port, config.timeout, signal);
+        if (httpResult !== null) {
+          return httpResult;
+        }
+      }
+    }
+
+    return { isOpen: false, elapsed: 0 };
+  }
+
+  private async probeWebSocket(
+    ip: string,
+    port: number,
+    timeout: number,
+    signal?: AbortSignal,
+  ): Promise<{ isOpen: boolean; elapsed: number } | null> {
     return new Promise((resolve) => {
       const startTime = Date.now();
       let resolved = false;
@@ -292,7 +328,6 @@ export class NetworkScanner {
         return;
       }
 
-      // Use WebSocket for port scanning (limited but works for many services)
       try {
         let host = ip;
         try {
@@ -306,8 +341,8 @@ export class NetworkScanner {
           // If the IP is malformed, fall back to the raw string.
         }
         ws = new WebSocket(`ws://${host}:${port}`);
-      } catch (error) {
-        resolve({ isOpen: false, elapsed: Date.now() - startTime });
+      } catch {
+        resolve(null); // Creation failed, try next strategy
         return;
       }
 
@@ -362,6 +397,50 @@ export class NetworkScanner {
         }
       };
     });
+  }
+
+  private async probeHttp(
+    ip: string,
+    port: number,
+    timeout: number,
+    signal?: AbortSignal,
+  ): Promise<{ isOpen: boolean; banner?: string; elapsed: number } | null> {
+    const startTime = Date.now();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      const url = `http://${ip}:${port}`;
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "HEAD",
+          signal: signal ? this.mergeSignals(signal, controller.signal) : controller.signal,
+        });
+      } catch {
+        response = await fetch(url, {
+          method: "GET",
+          signal: signal ? this.mergeSignals(signal, controller.signal) : controller.signal,
+        });
+      }
+      clearTimeout(timer);
+      const banner = response.headers.get("server") || undefined;
+      return { isOpen: true, banner, elapsed: Date.now() - startTime };
+    } catch {
+      clearTimeout(timer);
+      return { isOpen: false, elapsed: Date.now() - startTime };
+    }
+  }
+
+  private mergeSignals(signalA: AbortSignal, signalB: AbortSignal): AbortSignal {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    if (signalA.aborted || signalB.aborted) {
+      controller.abort();
+    } else {
+      signalA.addEventListener("abort", abort);
+      signalB.addEventListener("abort", abort);
+    }
+    return controller.signal;
   }
 
   private identifyService(

--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -409,7 +409,18 @@ export class NetworkScanner {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeout);
     try {
-      const url = `http://${ip}:${port}`;
+      let host = ip;
+      try {
+        if (ipaddr.isValid(ip)) {
+          const addr = ipaddr.parse(ip);
+          if (addr.kind() === "ipv6") {
+            host = `[${addr.toString()}]`;
+          }
+        }
+      } catch {
+        // If the IP is malformed, fall back to the raw string.
+      }
+      const url = `http://${host}:${port}`;
       let response: Response;
       try {
         response = await fetch(url, {

--- a/tests/networkScannerStrategies.test.ts
+++ b/tests/networkScannerStrategies.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { NetworkScanner } from '../src/utils/networkScanner';
+import type { NetworkDiscoveryConfig } from '../src/types/settings';
+
+const scanner = new NetworkScanner() as any;
+const originalFetch = global.fetch;
+const originalWebSocket = (global as any).WebSocket;
+
+afterEach(() => {
+  (global as any).fetch = originalFetch;
+  (global as any).WebSocket = originalWebSocket;
+  vi.restoreAllMocks();
+});
+
+describe('IPv6 range generation', () => {
+  it('generates addresses for IPv6 CIDR', async () => {
+    const ips: string[] = [];
+    for await (const ip of scanner.generateIPRange('2001:db8::/126')) {
+      ips.push(ip);
+    }
+    expect(ips).toEqual([
+      '2001:db8::',
+      '2001:db8::1',
+      '2001:db8::2',
+      '2001:db8::3',
+    ]);
+  });
+});
+
+describe('probe strategy selection', () => {
+  const baseConfig: NetworkDiscoveryConfig = {
+    enabled: true,
+    ipRange: '::/0',
+    portRanges: [],
+    protocols: [],
+    timeout: 200,
+    maxConcurrent: 1,
+    maxPortConcurrent: 1,
+    customPorts: {},
+    probeStrategies: { default: ['websocket'], http: ['websocket', 'http'] },
+    cacheTTL: 0,
+    hostnameTtl: 0,
+    macTtl: 0,
+  };
+
+  it('falls back to HTTP when WebSocket creation fails', async () => {
+    const wsCtor = vi.fn(() => {
+      throw new Error('no ws');
+    });
+    (global as any).WebSocket = wsCtor as any;
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { headers: { server: 'test' } }),
+    );
+    (global as any).fetch = fetchMock;
+
+    const result = await scanner.scanPort('127.0.0.1', 80, baseConfig);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result.isOpen).toBe(true);
+    expect(result.banner).toBe('test');
+  });
+
+  it('does not use HTTP when strategy excludes it', async () => {
+    const wsCtor = vi.fn(() => {
+      throw new Error('no ws');
+    });
+    (global as any).WebSocket = wsCtor as any;
+    const fetchMock = vi.fn();
+    (global as any).fetch = fetchMock;
+    const config = { ...baseConfig, probeStrategies: { default: ['websocket'] } };
+    const result = await scanner.scanPort('127.0.0.1', 80, config);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- allow per-protocol probe strategies with HTTP fallback
- capture HTTP banners when WebSocket creation fails
- add tests for IPv6 range generation and strategy selection

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b75c6735dc8325b282243cc3575bd1