### PR TITLE
fix: handle IPv6 hostnames in HTTP probe

### DIFF
--- a/src/utils/networkScanner.ts
+++ b/src/utils/networkScanner.ts
@@ -409,7 +409,18 @@ export class NetworkScanner {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeout);
     try {
-      const url = `http://${ip}:${port}`;
+      let host = ip;
+      try {
+        if (ipaddr.isValid(ip)) {
+          const addr = ipaddr.parse(ip);
+          if (addr.kind() === "ipv6") {
+            host = `[${addr.toString()}]`;
+          }
+        }
+      } catch {
+        // If the IP is malformed, fall back to the raw string.
+      }
+      const url = `http://${host}:${port}`;
       let response: Response;
       try {
         response = await fetch(url, {


### PR DESCRIPTION
## Summary
- normalize IPv6 addresses before constructing HTTP fallback URLs

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b769759ba88325aac54eb0c02ba060