### PR TITLE
docs: explain generateId fallback strategy

### DIFF
--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,5 +1,22 @@
+/**
+ * Generates a unique identifier.
+ *
+ * Prefers the host's `crypto.randomUUID` implementation for RFC 4122 v4
+ * identifiers when available. This provides strong entropy and collision
+ * resistance as long as the runtime exposes a compliant `crypto` API.
+ *
+ * When `crypto.randomUUID` is unavailable, falls back to combining a
+ * base36-encoded `Math.random` segment with the current timestamp. This
+ * fallback offers limited entropy and does not guarantee global uniqueness,
+ * especially across processes or machines.
+ *
+ * @returns {string} Best-effort unique identifier.
+ * @remarks Requires a standards-compliant `crypto.randomUUID` for strong
+ *          uniqueness guarantees; the fallback assumes a reasonably accurate
+ *          clock and non-broken `Math.random` implementation.
+ */
 export function generateId(): string {
-  if (typeof globalThis.crypto?.randomUUID === 'function') {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
   }
   const randomPart = Math.random().toString(36).slice(2);


### PR DESCRIPTION
## Summary
- document UUID-first ID generation with random/timestamp fallback

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b880bf0b5c8325a2c2d538498b9131