### PR TITLE
fix: load auto-detected locale resources

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -23,6 +23,14 @@ const loadLanguage = async (lng: string) => {
   }
 };
 
+const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
+(i18n as any).changeLanguage = async (lng: string, ...args: any[]) => {
+  if (typeof lng === "string" && !i18n.hasResourceBundle(lng, "translation")) {
+    await loadLanguage(lng);
+  }
+  return originalChangeLanguage(lng, ...args);
+};
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
@@ -38,13 +46,5 @@ i18n
       caches: [],
     },
   });
-
-const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
-(i18n as any).changeLanguage = async (lng: string, ...args: any[]) => {
-  if (!i18n.hasResourceBundle(lng, "translation")) {
-    await loadLanguage(lng);
-  }
-  return originalChangeLanguage(lng, ...args);
-};
 
 export default i18n;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -24,7 +24,7 @@ const loadLanguage = async (lng: string) => {
 };
 
 const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
-(i18n as any).changeLanguage = async (lng: string, ...args: any[]) => {
+const changeLanguage = async (lng: string, ...args: any[]) => {
   if (typeof lng === "string" && !i18n.hasResourceBundle(lng, "translation")) {
     await loadLanguage(lng);
   }
@@ -45,6 +45,10 @@ i18n
       order: ["navigator", "htmlTag"],
       caches: [],
     },
+  })
+  .then(async () => {
+    (i18n as any).changeLanguage = changeLanguage;
+    await changeLanguage(i18n.language);
   });
 
 export default i18n;


### PR DESCRIPTION
## Summary
- ensure detected locales load translations during initialization

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9c28f60ac8325bdf9bde750e6a770