### PR TITLE
fix: normalize language codes for dynamic i18n loading

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -36,9 +36,14 @@ const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
 const changeLanguage = async (lng: string, ...args: any[]) => {
   if (typeof lng === "string") {
     const baseLng = getBaseLanguage(lng);
+    const hasLngBundle = i18n.hasResourceBundle(lng, "translation");
+    const hasBaseBundle = i18n.hasResourceBundle(baseLng, "translation");
+    const hasLngLoader = Boolean(languageLoaders[lng]);
+    const hasBaseLoader = Boolean(languageLoaders[baseLng]);
+
     if (
-      !i18n.hasResourceBundle(lng, "translation") &&
-      !i18n.hasResourceBundle(baseLng, "translation")
+      !hasLngBundle &&
+      (hasLngLoader || (!hasBaseBundle && hasBaseLoader))
     ) {
       await loadLanguage(lng);
     }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -15,18 +15,33 @@ const languageLoaders: Record<string, () => Promise<any>> = {
   "pt-PT": () => import("./locales/pt-PT.json"),
 };
 
+const getBaseLanguage = (lng: string) => lng.split("-")[0];
+
 const loadLanguage = async (lng: string) => {
-  const loader = languageLoaders[lng];
+  let language = lng;
+  let loader = languageLoaders[language];
+
+  if (!loader) {
+    language = getBaseLanguage(language);
+    loader = languageLoaders[language];
+  }
+
   if (loader) {
     const { default: translations } = await loader();
-    i18n.addResourceBundle(lng, "translation", translations, true, true);
+    i18n.addResourceBundle(language, "translation", translations, true, true);
   }
 };
 
 const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
 const changeLanguage = async (lng: string, ...args: any[]) => {
-  if (typeof lng === "string" && !i18n.hasResourceBundle(lng, "translation")) {
-    await loadLanguage(lng);
+  if (typeof lng === "string") {
+    const baseLng = getBaseLanguage(lng);
+    if (
+      !i18n.hasResourceBundle(lng, "translation") &&
+      !i18n.hasResourceBundle(baseLng, "translation")
+    ) {
+      await loadLanguage(lng);
+    }
   }
   return originalChangeLanguage(lng, ...args);
 };


### PR DESCRIPTION
## Summary
- normalize locale code before lazily loading translations
- skip duplicate loads when base resources already exist

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9d8d5582c83258a4bbec30cb36ac0