### PR TITLE
fix: load variant locale when base translations present

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -36,9 +36,14 @@ const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
 const changeLanguage = async (lng: string, ...args: any[]) => {
   if (typeof lng === "string") {
     const baseLng = getBaseLanguage(lng);
+    const hasLngBundle = i18n.hasResourceBundle(lng, "translation");
+    const hasBaseBundle = i18n.hasResourceBundle(baseLng, "translation");
+    const hasLngLoader = Boolean(languageLoaders[lng]);
+    const hasBaseLoader = Boolean(languageLoaders[baseLng]);
+
     if (
-      !i18n.hasResourceBundle(lng, "translation") &&
-      !i18n.hasResourceBundle(baseLng, "translation")
+      !hasLngBundle &&
+      (hasLngLoader || (!hasBaseBundle && hasBaseLoader))
     ) {
       await loadLanguage(lng);
     }


### PR DESCRIPTION
## Summary
- ensure changeLanguage loads variant bundles when available, even if base language already has resources

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9db6543d48325a35b97ba37c20285