### PR TITLE
Add filtering and CSV export to network discovery

### DIFF
--- a/src/components/NetworkDiscovery.tsx
+++ b/src/components/NetworkDiscovery.tsx
@@ -9,6 +9,7 @@ import {
   Globe,
   Plus,
   Settings,
+  Download,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { DiscoveredHost, DiscoveredService } from "../types/connection";
@@ -16,6 +17,7 @@ import { NetworkDiscoveryConfig } from "../types/settings";
 import { NetworkScanner } from "../utils/networkScanner";
 import { useConnections } from "../contexts/ConnectionContext";
 import { generateId } from "../utils/id";
+import { discoveredHostsToCsv } from "../utils/discoveredHostsCsv";
 
 interface NetworkDiscoveryProps {
   isOpen: boolean;
@@ -60,6 +62,7 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
   const [scanProgress, setScanProgress] = useState(0);
   const [selectedHosts, setSelectedHosts] = useState<Set<string>>(new Set());
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [filterText, setFilterText] = useState("");
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const scanner = new NetworkScanner();
@@ -150,6 +153,27 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
       newSelection.add(hostIp);
     }
     setSelectedHosts(newSelection);
+  };
+
+  const filteredHosts = discoveredHosts.filter((host) => {
+    const query = filterText.toLowerCase();
+    return (
+      host.ip.toLowerCase().includes(query) ||
+      host.hostname?.toLowerCase().includes(query)
+    );
+  });
+
+  const handleExportCSV = () => {
+    const csv = discoveredHostsToCsv(filteredHosts);
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "discovered_hosts.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   };
 
   if (!isOpen) return null;
@@ -364,14 +388,34 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
           {/* Discovered Hosts */}
           {discoveredHosts.length > 0 && (
             <div>
-              <h3 className="text-lg font-medium text-white mb-4">
-                {t("networkDiscovery.discoveredHosts", {
-                  count: discoveredHosts.length,
-                })}
-              </h3>
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-medium text-white">
+                  {t("networkDiscovery.discoveredHosts", {
+                    count: filteredHosts.length,
+                  })}
+                </h3>
+                <div className="flex items-center space-x-2">
+                  <input
+                    type="text"
+                    value={filterText}
+                    onChange={(e) => setFilterText(e.target.value)}
+                    placeholder={t(
+                      "networkDiscovery.filterPlaceholder",
+                    )}
+                    className="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+                  />
+                  <button
+                    onClick={handleExportCSV}
+                    className="px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors flex items-center space-x-2"
+                  >
+                    <Download size={14} />
+                    <span>{t("networkDiscovery.exportCsv")}</span>
+                  </button>
+                </div>
+              </div>
 
               <div className="space-y-4">
-                {discoveredHosts.map((host) => (
+                {filteredHosts.map((host) => (
                   <div
                     key={host.ip}
                     className={`bg-gray-700 rounded-lg p-4 border-2 transition-colors cursor-pointer ${

--- a/src/components/NetworkDiscovery.tsx
+++ b/src/components/NetworkDiscovery.tsx
@@ -159,7 +159,7 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
     const query = filterText.toLowerCase();
     return (
       host.ip.toLowerCase().includes(query) ||
-      host.hostname?.toLowerCase().includes(query)
+      (host.hostname?.toLowerCase()?.includes(query) ?? false)
     );
   });
 
@@ -399,9 +399,7 @@ export const NetworkDiscovery: React.FC<NetworkDiscoveryProps> = ({
                     type="text"
                     value={filterText}
                     onChange={(e) => setFilterText(e.target.value)}
-                    placeholder={t(
-                      "networkDiscovery.filterPlaceholder",
-                    )}
+                    placeholder={t("networkDiscovery.filterPlaceholder")}
                     className="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
                   />
                   <button

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Hosts filtern",
+    "exportCsv": "CSV exportieren",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Filter hosts",
+    "exportCsv": "Export CSV",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -163,6 +163,8 @@
     "startScan": "Iniciar Escaneo",
     "createConnections": "Crear {{count}} Conexión(es)",
     "discoveredHosts": "Hosts Descubiertos ({{count}})",
+    "filterPlaceholder": "Filtrar hosts",
+    "exportCsv": "Exportar CSV",
     "responseTime": "Respuesta: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Puerto {{port}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Filtrer les hôtes",
+    "exportCsv": "Exporter CSV",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/i18n/locales/pt-PT.json
+++ b/src/i18n/locales/pt-PT.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Filtrar hosts",
+    "exportCsv": "Exportar CSV",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/utils/discoveredHostsCsv.ts
+++ b/src/utils/discoveredHostsCsv.ts
@@ -1,0 +1,30 @@
+import { DiscoveredHost } from "../types/connection";
+
+const escapeCsv = (str: string): string => {
+  if (str.includes(",") || str.includes("\"") || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+export const discoveredHostsToCsv = (hosts: DiscoveredHost[]): string => {
+  const headers = [
+    "IP",
+    "Hostname",
+    "ResponseTime",
+    "MAC",
+    "OpenPorts",
+    "Services",
+  ];
+
+  const rows = hosts.map((host) => [
+    host.ip,
+    host.hostname || "",
+    host.responseTime.toString(),
+    host.macAddress || "",
+    host.openPorts.join(";"),
+    host.services.map((s) => `${s.service}:${s.port}`).join(";"),
+  ]);
+
+  return [headers.join(","), ...rows.map((r) => r.map(escapeCsv).join(","))].join("\n");
+};

--- a/tests/discoveredHostsCsv.test.ts
+++ b/tests/discoveredHostsCsv.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { discoveredHostsToCsv } from "../src/utils/discoveredHostsCsv";
+import { DiscoveredHost } from "../src/types/connection";
+
+describe("discoveredHostsToCsv", () => {
+  it("converts hosts to CSV", () => {
+    const hosts: DiscoveredHost[] = [
+      {
+        ip: "192.168.1.10",
+        hostname: "server",
+        openPorts: [22, 80],
+        services: [
+          { port: 22, protocol: "tcp", service: "ssh" },
+          { port: 80, protocol: "tcp", service: "http" },
+        ],
+        responseTime: 42,
+        macAddress: "AA:BB:CC:DD:EE:FF",
+      },
+    ];
+
+    const csv = discoveredHostsToCsv(hosts);
+
+    expect(csv).toBe(
+      "IP,Hostname,ResponseTime,MAC,OpenPorts,Services\n" +
+        "192.168.1.10,server,42,AA:BB:CC:DD:EE:FF,22;80,ssh:22;http:80",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add text filter and CSV export to network discovery
- translate new filter and export labels
- cover host CSV export utility with tests

## Testing
- `npm run lint`
- `npm test -- --run`
- `npx vitest tests/discoveredHostsCsv.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9ff29ccf48325a64359bcd7dece89