### PR TITLE
Add filtering and CSV export to network discovery

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Hosts filtern",
+    "exportCsv": "CSV exportieren",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Filtrer les hôtes",
+    "exportCsv": "Exporter CSV",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",

--- a/src/i18n/locales/pt-PT.json
+++ b/src/i18n/locales/pt-PT.json
@@ -163,6 +163,8 @@
     "startScan": "Start Scan",
     "createConnections": "Create {{count}} Connection(s)",
     "discoveredHosts": "Discovered Hosts ({{count}})",
+    "filterPlaceholder": "Filtrar hosts",
+    "exportCsv": "Exportar CSV",
     "responseTime": "Response: {{ms}}ms",
     "macAddress": "MAC: {{mac}}",
     "port": "Port {{port}}",


### PR DESCRIPTION
## Summary
- add text filter and CSV export to network discovery
- translate new filter and export labels
- cover host CSV export utility with tests

## Testing
- `npm run lint`
- `npm test -- --run`
- `npx vitest tests/discoveredHostsCsv.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb27182f98832594e8ade4f4f04a76