### PR TITLE
feat: persist and resume file transfers

### DIFF
--- a/src/components/FileTransferManager.tsx
+++ b/src/components/FileTransferManager.tsx
@@ -54,8 +54,8 @@ export const FileTransferManager: React.FC<FileTransferManagerProps> = ({
     }
   };
 
-  const loadTransfers = () => {
-    const activeTransfers = fileServiceRef.current.getActiveTransfers(connectionId);
+  const loadTransfers = async () => {
+    const activeTransfers = await fileServiceRef.current.getActiveTransfers(connectionId);
     setTransfers(activeTransfers);
   };
 
@@ -93,7 +93,7 @@ export const FileTransferManager: React.FC<FileTransferManagerProps> = ({
       try {
         await fileServiceRef.current.uploadFile(connectionId, file, remotePath);
         loadDirectory(currentPath);
-        loadTransfers();
+        await loadTransfers();
       } catch (error) {
         console.error('Upload failed:', error);
       }
@@ -107,7 +107,7 @@ export const FileTransferManager: React.FC<FileTransferManagerProps> = ({
       
       try {
         await fileServiceRef.current.downloadFile(connectionId, remotePath, fileName);
-        loadTransfers();
+        await loadTransfers();
       } catch (error) {
         console.error('Download failed:', error);
       }
@@ -368,6 +368,20 @@ export const FileTransferManager: React.FC<FileTransferManagerProps> = ({
                     {transfer.error && (
                       <p className="text-red-400 text-xs mt-1">{transfer.error}</p>
                     )}
+
+                    {transfer.status !== 'active' &&
+                      transfer.status !== 'completed' &&
+                      transfer.type === 'download' && (
+                        <button
+                          onClick={async () => {
+                            await fileServiceRef.current.resumeTransfer(transfer.id);
+                            await loadTransfers();
+                          }}
+                          className="mt-2 text-blue-400 text-xs hover:underline"
+                        >
+                          Resume
+                        </button>
+                      )}
                   </div>
                 ))
               )}

--- a/tests/fileTransferResume.test.ts
+++ b/tests/fileTransferResume.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FileTransferService, FileTransferAdapter, FileItem } from '../src/utils/fileTransferService';
+import { IndexedDbService } from '../src/utils/indexedDbService';
+import { openDB } from 'idb';
+
+const DB_NAME = 'mremote-keyval';
+const STORE_NAME = 'keyval';
+
+class StubAdapter implements FileTransferAdapter {
+  async list(_path: string): Promise<FileItem[]> { return []; }
+  async upload(
+    file: any,
+    _remotePath: string,
+    onProgress?: (transferred: number, total: number) => void,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const total = file.size ?? 100;
+    let transferred = 0;
+    while (transferred < total) {
+      if (signal?.aborted) throw new Error('aborted');
+      await new Promise(res => setTimeout(res, 10));
+      transferred += 20;
+      onProgress?.(transferred, total);
+    }
+  }
+  async download(
+    _remotePath: string,
+    _localPath: string,
+    _onProgress?: (transferred: number, total: number) => void,
+    _signal?: AbortSignal
+  ): Promise<void> {
+    // not needed for this test
+  }
+}
+
+describe('FileTransferService resumeTransfer', () => {
+  beforeEach(async () => {
+    await IndexedDbService.init();
+    const db = await openDB(DB_NAME, 1);
+    await db.clear(STORE_NAME);
+  });
+
+  it('persists and resumes an interrupted upload', async () => {
+    const adapter = new StubAdapter();
+    const service = new FileTransferService();
+    service.registerAdapter('c1', adapter);
+    const file: any = { name: 'test.txt', size: 100 };
+
+    let transferId = '';
+    service.on('start', session => { transferId = session.id; });
+
+    const promise = service.uploadFile('c1', file, '/remote');
+    await new Promise(res => setTimeout(res, 25));
+    service.cancelTransfer(transferId);
+    await promise;
+
+    let sessions = await service.getActiveTransfers('c1');
+    let stored = sessions.find(s => s.id === transferId)!;
+    expect(stored.status).toBe('cancelled');
+    expect(stored.transferredSize).toBeLessThan(stored.totalSize);
+
+    const service2 = new FileTransferService();
+    service2.registerAdapter('c1', adapter);
+    await service2.resumeTransfer(transferId, file);
+    sessions = await service2.getActiveTransfers('c1');
+    stored = sessions.find(s => s.id === transferId)!;
+    expect(stored.status).toBe('completed');
+    expect(stored.transferredSize).toBe(stored.totalSize);
+  });
+});


### PR DESCRIPTION
## Summary
- persist file transfer sessions using IndexedDbService
- add resume capability and UI hook for download transfers
- cover interruption/resumption with integration tests

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc39b7945483258358976898e90bb0