### PR TITLE
feat: add recurring wake schedules

### DIFF
--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -47,10 +47,13 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
     if (editing) {
       wolService.cancelSchedule(editing);
     }
+    const broadcast = form.broadcastAddress?.trim()
+      ? form.broadcastAddress
+      : undefined;
     wolService.scheduleWakeUp(
       form.macAddress,
       date,
-      form.broadcastAddress,
+      broadcast,
       form.port,
       form.recurrence as WakeRecurrence | undefined,
     );
@@ -83,7 +86,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
         <div className="space-y-2 max-h-60 overflow-y-auto mb-4">
           {schedules.map((s) => (
             <div
-              key={s.wakeTime + s.macAddress}
+              key={`${s.macAddress}-${s.wakeTime}-${s.broadcastAddress ?? ""}-${s.port}-${s.recurrence ?? ""}`}
               className="flex justify-between items-center bg-gray-700 px-2 py-1 rounded"
             >
               <div className="text-sm">

--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -1,9 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { WakeOnLanService, type WakeSchedule, type WakeRecurrence } from '../utils/wakeOnLan';
-import { Trash2, Pencil, Save, X } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from "react";
+import {
+  WakeOnLanService,
+  type WakeSchedule,
+  type WakeRecurrence,
+} from "../utils/wakeOnLan";
+import { Trash2, Pencil, Save, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 const wolService = new WakeOnLanService();
+
+const toLocalInput = (date: Date) =>
+  new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16);
 
 interface Props {
   isOpen: boolean;
@@ -15,8 +24,8 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
   const [schedules, setSchedules] = useState<WakeSchedule[]>([]);
   const [editing, setEditing] = useState<WakeSchedule | null>(null);
   const [form, setForm] = useState<WakeSchedule>({
-    macAddress: '',
-    wakeTime: new Date().toISOString().slice(0, 16),
+    macAddress: "",
+    wakeTime: toLocalInput(new Date()),
     port: 9,
   });
 
@@ -29,7 +38,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   const resetForm = () => {
-    setForm({ macAddress: '', wakeTime: new Date().toISOString().slice(0, 16), port: 9 });
+    setForm({ macAddress: "", wakeTime: toLocalInput(new Date()), port: 9 });
     setEditing(null);
   };
 
@@ -51,7 +60,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const handleEdit = (s: WakeSchedule) => {
     setEditing(s);
-    setForm({ ...s, wakeTime: s.wakeTime.slice(0, 16) });
+    setForm({ ...s, wakeTime: toLocalInput(new Date(s.wakeTime)) });
   };
 
   const handleDelete = (s: WakeSchedule) => {
@@ -60,27 +69,50 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={(e) => e.target === e.currentTarget && onClose()}>
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
       <div className="bg-gray-800 rounded-lg p-4 w-full max-w-xl">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-bold">{t('wake.scheduleManager')}</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white"><X size={20} /></button>
+          <h2 className="text-xl font-bold">{t("wake.scheduleManager")}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">
+            <X size={20} />
+          </button>
         </div>
         <div className="space-y-2 max-h-60 overflow-y-auto mb-4">
           {schedules.map((s) => (
-            <div key={s.wakeTime + s.macAddress} className="flex justify-between items-center bg-gray-700 px-2 py-1 rounded">
+            <div
+              key={s.wakeTime + s.macAddress}
+              className="flex justify-between items-center bg-gray-700 px-2 py-1 rounded"
+            >
               <div className="text-sm">
                 <div>{s.macAddress}</div>
-                <div className="text-gray-300">{new Date(s.wakeTime).toLocaleString()} {s.recurrence && `(${s.recurrence})`}</div>
+                <div className="text-gray-300">
+                  {new Date(s.wakeTime).toLocaleString()}{" "}
+                  {s.recurrence && `(${s.recurrence})`}
+                </div>
               </div>
               <div className="space-x-2">
-                <button onClick={() => handleEdit(s)} className="text-blue-400 hover:text-blue-200"><Pencil size={16} /></button>
-                <button onClick={() => handleDelete(s)} className="text-red-400 hover:text-red-200"><Trash2 size={16} /></button>
+                <button
+                  onClick={() => handleEdit(s)}
+                  className="text-blue-400 hover:text-blue-200"
+                >
+                  <Pencil size={16} />
+                </button>
+                <button
+                  onClick={() => handleDelete(s)}
+                  className="text-red-400 hover:text-red-200"
+                >
+                  <Trash2 size={16} />
+                </button>
               </div>
             </div>
           ))}
           {schedules.length === 0 && (
-            <div className="text-center text-gray-400">{t('wake.noSchedules')}</div>
+            <div className="text-center text-gray-400">
+              {t("wake.noSchedules")}
+            </div>
           )}
         </div>
         <div className="space-y-2">
@@ -101,27 +133,36 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
             type="text"
             placeholder="Broadcast Address"
             className="w-full px-2 py-1 rounded bg-gray-700 text-white"
-            value={form.broadcastAddress ?? ''}
-            onChange={(e) => setForm({ ...form, broadcastAddress: e.target.value })}
+            value={form.broadcastAddress ?? ""}
+            onChange={(e) =>
+              setForm({ ...form, broadcastAddress: e.target.value })
+            }
           />
           <input
             type="number"
             className="w-full px-2 py-1 rounded bg-gray-700 text-white"
             value={form.port}
-            onChange={(e) => setForm({ ...form, port: parseInt(e.target.value, 10) })}
+            onChange={(e) =>
+              setForm({ ...form, port: parseInt(e.target.value, 10) })
+            }
           />
           <select
             className="w-full px-2 py-1 rounded bg-gray-700 text-white"
-            value={form.recurrence ?? ''}
-            onChange={(e) => setForm({ ...form, recurrence: e.target.value as WakeRecurrence })}
+            value={form.recurrence ?? ""}
+            onChange={(e) =>
+              setForm({ ...form, recurrence: e.target.value as WakeRecurrence })
+            }
           >
-            <option value="">{t('wake.once')}</option>
-            <option value="daily">{t('wake.daily')}</option>
-            <option value="weekly">{t('wake.weekly')}</option>
+            <option value="">{t("wake.once")}</option>
+            <option value="daily">{t("wake.daily")}</option>
+            <option value="weekly">{t("wake.weekly")}</option>
           </select>
-          <button onClick={handleSubmit} className="w-full flex items-center justify-center space-x-1 bg-blue-600 hover:bg-blue-500 text-white py-1 rounded">
+          <button
+            onClick={handleSubmit}
+            className="w-full flex items-center justify-center space-x-1 bg-blue-600 hover:bg-blue-500 text-white py-1 rounded"
+          >
             <Save size={16} />
-            <span>{editing ? t('common.save') : t('common.add')}</span>
+            <span>{editing ? t("common.save") : t("common.add")}</span>
           </button>
         </div>
       </div>

--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from 'react';
+import { WakeOnLanService, type WakeSchedule, type WakeRecurrence } from '../utils/wakeOnLan';
+import { Trash2, Pencil, Save, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
+  const wolService = new WakeOnLanService();
+  const [schedules, setSchedules] = useState<WakeSchedule[]>([]);
+  const [editing, setEditing] = useState<WakeSchedule | null>(null);
+  const [form, setForm] = useState<WakeSchedule>({
+    macAddress: '',
+    wakeTime: new Date().toISOString().slice(0, 16),
+    port: 9,
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      setSchedules(wolService.listSchedules());
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const resetForm = () => {
+    setForm({ macAddress: '', wakeTime: new Date().toISOString().slice(0, 16), port: 9 });
+    setEditing(null);
+  };
+
+  const handleSubmit = () => {
+    const date = new Date(form.wakeTime);
+    if (editing) {
+      wolService.cancelSchedule(editing);
+    }
+    wolService.scheduleWakeUp(
+      form.macAddress,
+      date,
+      form.broadcastAddress,
+      form.port,
+      form.recurrence as WakeRecurrence | undefined,
+    );
+    setSchedules(wolService.listSchedules());
+    resetForm();
+  };
+
+  const handleEdit = (s: WakeSchedule) => {
+    setEditing(s);
+    setForm({ ...s, wakeTime: s.wakeTime.slice(0, 16) });
+  };
+
+  const handleDelete = (s: WakeSchedule) => {
+    wolService.cancelSchedule(s);
+    setSchedules(wolService.listSchedules());
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="bg-gray-800 rounded-lg p-4 w-full max-w-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">{t('wake.scheduleManager')}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white"><X size={20} /></button>
+        </div>
+        <div className="space-y-2 max-h-60 overflow-y-auto mb-4">
+          {schedules.map((s) => (
+            <div key={s.wakeTime + s.macAddress} className="flex justify-between items-center bg-gray-700 px-2 py-1 rounded">
+              <div className="text-sm">
+                <div>{s.macAddress}</div>
+                <div className="text-gray-300">{new Date(s.wakeTime).toLocaleString()} {s.recurrence && `(${s.recurrence})`}</div>
+              </div>
+              <div className="space-x-2">
+                <button onClick={() => handleEdit(s)} className="text-blue-400 hover:text-blue-200"><Pencil size={16} /></button>
+                <button onClick={() => handleDelete(s)} className="text-red-400 hover:text-red-200"><Trash2 size={16} /></button>
+              </div>
+            </div>
+          ))}
+          {schedules.length === 0 && (
+            <div className="text-center text-gray-400">{t('wake.noSchedules')}</div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <input
+            type="text"
+            placeholder="MAC Address"
+            className="w-full px-2 py-1 rounded bg-gray-700 text-white"
+            value={form.macAddress}
+            onChange={(e) => setForm({ ...form, macAddress: e.target.value })}
+          />
+          <input
+            type="datetime-local"
+            className="w-full px-2 py-1 rounded bg-gray-700 text-white"
+            value={form.wakeTime}
+            onChange={(e) => setForm({ ...form, wakeTime: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Broadcast Address"
+            className="w-full px-2 py-1 rounded bg-gray-700 text-white"
+            value={form.broadcastAddress ?? ''}
+            onChange={(e) => setForm({ ...form, broadcastAddress: e.target.value })}
+          />
+          <input
+            type="number"
+            className="w-full px-2 py-1 rounded bg-gray-700 text-white"
+            value={form.port}
+            onChange={(e) => setForm({ ...form, port: parseInt(e.target.value, 10) })}
+          />
+          <select
+            className="w-full px-2 py-1 rounded bg-gray-700 text-white"
+            value={form.recurrence ?? ''}
+            onChange={(e) => setForm({ ...form, recurrence: e.target.value as WakeRecurrence })}
+          >
+            <option value="">{t('wake.once')}</option>
+            <option value="daily">{t('wake.daily')}</option>
+            <option value="weekly">{t('wake.weekly')}</option>
+          </select>
+          <button onClick={handleSubmit} className="w-full flex items-center justify-center space-x-1 bg-blue-600 hover:bg-blue-500 text-white py-1 rounded">
+            <Save size={16} />
+            <span>{editing ? t('common.save') : t('common.add')}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WakeScheduleManager;

--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -47,9 +47,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
     if (editing) {
       wolService.cancelSchedule(editing);
     }
-    const broadcast = form.broadcastAddress?.trim()
-      ? form.broadcastAddress
-      : undefined;
+    const broadcast = form.broadcastAddress?.trim() || undefined;
     wolService.scheduleWakeUp(
       form.macAddress,
       date,

--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -3,6 +3,8 @@ import { WakeOnLanService, type WakeSchedule, type WakeRecurrence } from '../uti
 import { Trash2, Pencil, Save, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+const wolService = new WakeOnLanService();
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -10,7 +12,6 @@ interface Props {
 
 export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
   const { t } = useTranslation();
-  const wolService = new WakeOnLanService();
   const [schedules, setSchedules] = useState<WakeSchedule[]>([]);
   const [editing, setEditing] = useState<WakeSchedule | null>(null);
   const [form, setForm] = useState<WakeSchedule>({

--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -126,20 +126,24 @@ export class WakeOnLanService {
         while (nextTime.getTime() <= now.getTime()) {
           nextTime = this.getNextWakeTime(nextTime, s.recurrence);
         }
-        if (nextTime.toISOString() !== s.wakeTime) {
-          this.removeSchedule(s);
-        }
-      } else if (nextTime.getTime() <= now.getTime()) {
         this.removeSchedule(s);
-        continue;
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+          s.recurrence,
+        );
+      } else if (nextTime.getTime() > now.getTime()) {
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+        );
+      } else {
+        this.removeSchedule(s);
       }
-      this.scheduleWakeUp(
-        s.macAddress,
-        nextTime,
-        s.broadcastAddress,
-        s.port,
-        s.recurrence,
-      );
     }
   }
 

--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -218,13 +218,16 @@ export class WakeOnLanService {
   }
 
   private getNextWakeTime(current: Date, recurrence: WakeRecurrence): Date {
-    const next = new Date(current);
-    if (recurrence === "daily") {
-      next.setDate(next.getDate() + 1);
-    } else if (recurrence === "weekly") {
-      next.setDate(next.getDate() + 7);
-    }
-    return next;
+    const days = recurrence === "daily" ? 1 : 7;
+    return new Date(
+      current.getFullYear(),
+      current.getMonth(),
+      current.getDate() + days,
+      current.getHours(),
+      current.getMinutes(),
+      current.getSeconds(),
+      current.getMilliseconds(),
+    );
   }
 
   listSchedules(): WakeSchedule[] {

--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -135,12 +135,7 @@ export class WakeOnLanService {
           s.recurrence,
         );
       } else if (nextTime.getTime() > now.getTime()) {
-        this.scheduleWakeUp(
-          s.macAddress,
-          nextTime,
-          s.broadcastAddress,
-          s.port,
-        );
+        this.scheduleWakeUp(s.macAddress, nextTime, s.broadcastAddress, s.port);
       } else {
         this.removeSchedule(s);
       }
@@ -220,9 +215,13 @@ export class WakeOnLanService {
   private getNextWakeTime(current: Date, recurrence: WakeRecurrence): Date {
     const next = new Date(current);
     if (recurrence === "daily") {
-      next.setDate(next.getDate() + 1);
+      next.setUTCDate(next.getUTCDate() + 1);
     } else if (recurrence === "weekly") {
-      next.setDate(next.getDate() + 7);
+      next.setUTCDate(next.getUTCDate() + 7);
+    }
+    const offsetDiff = next.getTimezoneOffset() - current.getTimezoneOffset();
+    if (offsetDiff !== 0) {
+      next.setMinutes(next.getMinutes() + offsetDiff);
     }
     return next;
   }

--- a/tests/wakeOnLanService.test.ts
+++ b/tests/wakeOnLanService.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WakeOnLanService } from '../src/utils/wakeOnLan';
+
+const MAC = '00:11:22:33:44:55';
+
+describe('WakeOnLanService scheduling', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.spyOn(WakeOnLanService.prototype, 'sendWakePacket').mockResolvedValue();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('persists schedules', () => {
+    const service = new WakeOnLanService();
+    const wakeTime = new Date(Date.now() + 3600000);
+    service.scheduleWakeUp(MAC, wakeTime);
+    const schedules = service.listSchedules();
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].macAddress).toBe(MAC);
+  });
+
+  it('handles daily recurrence', () => {
+    const service = new WakeOnLanService();
+    const wakeTime = new Date(Date.now() + 60000);
+    service.scheduleWakeUp(MAC, wakeTime, undefined, 9, 'daily');
+    vi.advanceTimersByTime(60000);
+    const schedules = service.listSchedules();
+    expect(schedules).toHaveLength(1);
+    const next = new Date(schedules[0].wakeTime).getTime();
+    expect(next).toBe(wakeTime.getTime() + 24 * 60 * 60 * 1000);
+  });
+
+  it('restores past schedules to next occurrence', () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    localStorage.setItem('wol-schedules', JSON.stringify([{ macAddress: MAC, wakeTime: past.toISOString(), port: 9, recurrence: 'daily' }]));
+    const service = new WakeOnLanService();
+    const spy = vi.spyOn(service, 'scheduleWakeUp');
+    service.restoreScheduledWakeUps();
+    expect(spy).toHaveBeenCalled();
+    const stored = service.listSchedules()[0];
+    expect(new Date(stored.wakeTime).getTime()).toBeGreaterThan(Date.now());
+  });
+});


### PR DESCRIPTION
## Summary
- add recurrence support to WakeOnLan service
- introduce WakeSchedule manager dialog for managing wake times
- test persistence and recurrence of wake schedules

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc3fb3610c83258e9dacf122271a44