### PR TITLE
fix: persist WakeOnLanService instance

### DIFF
--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -3,6 +3,8 @@ import { WakeOnLanService, type WakeSchedule, type WakeRecurrence } from '../uti
 import { Trash2, Pencil, Save, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+const wolService = new WakeOnLanService();
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -10,7 +12,6 @@ interface Props {
 
 export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
   const { t } = useTranslation();
-  const wolService = new WakeOnLanService();
   const [schedules, setSchedules] = useState<WakeSchedule[]>([]);
   const [editing, setEditing] = useState<WakeSchedule | null>(null);
   const [form, setForm] = useState<WakeSchedule>({


### PR DESCRIPTION
## Summary
- reuse a single WakeOnLanService instance across WakeScheduleManager renders

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc429141b48325b42c2f52fd76e9a4