### PR TITLE
fix: preserve multiple wake schedules

### DIFF
--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -126,20 +126,24 @@ export class WakeOnLanService {
         while (nextTime.getTime() <= now.getTime()) {
           nextTime = this.getNextWakeTime(nextTime, s.recurrence);
         }
-        if (nextTime.toISOString() !== s.wakeTime) {
-          this.removeSchedule(s);
-        }
-      } else if (nextTime.getTime() <= now.getTime()) {
         this.removeSchedule(s);
-        continue;
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+          s.recurrence,
+        );
+      } else if (nextTime.getTime() > now.getTime()) {
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+        );
+      } else {
+        this.removeSchedule(s);
       }
-      this.scheduleWakeUp(
-        s.macAddress,
-        nextTime,
-        s.broadcastAddress,
-        s.port,
-        s.recurrence,
-      );
     }
   }
 


### PR DESCRIPTION
## Summary
- prune outdated wake schedules and reschedule only future entries
- remove completed schedules before scheduling recurrences and include wake time in storage key so multiple wake times per device persist
- test that the service retains multiple schedules for a single host

## Testing
- ⚠️ `npx prettier AGENTS.md -w` *(No files matching the pattern were found: "AGENTS.md")*
- ✅ `npx prettier agents.md -w`
- ✅ `npm run lint`
- ✅ `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcaea497ac8325afcf848f62d5f471