### PR TITLE
fix: preserve multiple wake schedules

### DIFF
--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -126,20 +126,24 @@ export class WakeOnLanService {
         while (nextTime.getTime() <= now.getTime()) {
           nextTime = this.getNextWakeTime(nextTime, s.recurrence);
         }
-        if (nextTime.toISOString() !== s.wakeTime) {
-          this.removeSchedule(s);
-        }
-      } else if (nextTime.getTime() <= now.getTime()) {
         this.removeSchedule(s);
-        continue;
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+          s.recurrence,
+        );
+      } else if (nextTime.getTime() > now.getTime()) {
+        this.scheduleWakeUp(
+          s.macAddress,
+          nextTime,
+          s.broadcastAddress,
+          s.port,
+        );
+      } else {
+        this.removeSchedule(s);
       }
-      this.scheduleWakeUp(
-        s.macAddress,
-        nextTime,
-        s.broadcastAddress,
-        s.port,
-        s.recurrence,
-      );
     }
   }
 


### PR DESCRIPTION
## Summary
- always remove processed recurring schedules before rescheduling and skip past entries when restoring wake timers

## Testing
- ✅ `npx prettier AGENTS.md -w`
- ✅ `npx prettier agents.md -w`
- ✅ `npm run lint`
- ✅ `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1466efc8325bbcd90cfecaab6c1