### PR TITLE
fix: preserve local wake time across recurrence and normalize wake schedules

### DIFF
--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -47,10 +47,13 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
     if (editing) {
       wolService.cancelSchedule(editing);
     }
+    const broadcast = form.broadcastAddress?.trim()
+      ? form.broadcastAddress
+      : undefined;
     wolService.scheduleWakeUp(
       form.macAddress,
       date,
-      form.broadcastAddress,
+      broadcast,
       form.port,
       form.recurrence as WakeRecurrence | undefined,
     );
@@ -83,7 +86,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
         <div className="space-y-2 max-h-60 overflow-y-auto mb-4">
           {schedules.map((s) => (
             <div
-              key={s.wakeTime + s.macAddress}
+              key={`${s.macAddress}-${s.wakeTime}-${s.broadcastAddress ?? ""}-${s.port}-${s.recurrence ?? ""}`}
               className="flex justify-between items-center bg-gray-700 px-2 py-1 rounded"
             >
               <div className="text-sm">

--- a/src/utils/wakeOnLan.ts
+++ b/src/utils/wakeOnLan.ts
@@ -218,13 +218,16 @@ export class WakeOnLanService {
   }
 
   private getNextWakeTime(current: Date, recurrence: WakeRecurrence): Date {
-    const next = new Date(current);
-    if (recurrence === "daily") {
-      next.setDate(next.getDate() + 1);
-    } else if (recurrence === "weekly") {
-      next.setDate(next.getDate() + 7);
-    }
-    return next;
+    const days = recurrence === "daily" ? 1 : 7;
+    return new Date(
+      current.getFullYear(),
+      current.getMonth(),
+      current.getDate() + days,
+      current.getHours(),
+      current.getMinutes(),
+      current.getSeconds(),
+      current.getMilliseconds(),
+    );
   }
 
   listSchedules(): WakeSchedule[] {


### PR DESCRIPTION
## Summary
- derive next recurring wake from local date components to retain wall-clock time
- treat blank broadcast address as undefined and supply unique schedule keys

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcbc5d55ec832588169449087dbe68