### PR TITLE
fix: normalise broadcast input

### DIFF
--- a/src/components/WakeScheduleManager.tsx
+++ b/src/components/WakeScheduleManager.tsx
@@ -47,9 +47,7 @@ export const WakeScheduleManager: React.FC<Props> = ({ isOpen, onClose }) => {
     if (editing) {
       wolService.cancelSchedule(editing);
     }
-    const broadcast = form.broadcastAddress?.trim()
-      ? form.broadcastAddress
-      : undefined;
+    const broadcast = form.broadcastAddress?.trim() || undefined;
     wolService.scheduleWakeUp(
       form.macAddress,
       date,


### PR DESCRIPTION
## Summary
- trim broadcast address before scheduling and map blanks to `undefined`
- keep schedule list keys unique across device, time, broadcast, port and recurrence

## Testing
- ⚠️ `npx prettier AGENTS.md -w` (No files matching the pattern were found: "AGENTS.md")
- ✅ `npx prettier agents.md -w`
- ✅ `npm run lint`
- ✅ `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcc106504c8325b7a68d9dba29ede3