### PR TITLE
feat: allow aborting script execution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,3 +78,19 @@ starts, it checks for any `mremote-` keys in `localStorage` and moves them into
 IndexedDB. After migration these keys are removed from `localStorage`.
 Ensure your browser supports IndexedDB so settings and collections can be
 preserved across sessions.
+
+## Aborting Scripts
+
+Custom scripts executed through the `ScriptEngine` can be cancelled using an
+`AbortSignal`. Create an `AbortController` and pass its signal to
+`executeScript`. Any pending `http`, `ssh`, or `sleep` calls will reject with an
+`AbortError` when the signal is triggered:
+
+```ts
+const controller = new AbortController();
+const promise = engine.executeScript(script, context, controller.signal);
+controller.abort(); // script stops immediately
+```
+
+This allows external callers to stop long running scripts and network requests
+cleanly.

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -464,6 +464,9 @@ export class ScriptEngine {
       signal?.addEventListener("abort", abortHandler, { once: true });
 
       worker.postMessage({ type: "execute", context, code, language });
+      if (signal?.aborted) {
+        abortHandler();
+      }
     });
   }
 

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -208,6 +208,9 @@ export class ScriptEngine {
     const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
     if (isNode) {
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
       const { VM } = await import("vm2");
       const vm = new VM({ timeout: 1000, sandbox: {} });
 

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -58,10 +58,6 @@ export class ScriptEngine {
     );
 
     try {
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
-
       const result = await this.runScript<T>(script, context, signal);
 
       const duration = Date.now() - startTime;
@@ -212,13 +208,7 @@ export class ScriptEngine {
     const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
     if (isNode) {
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
       const { VM } = await import("vm2");
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
       const vm = new VM({ timeout: 1000, sandbox: {} });
 
       // Expose only whitelisted utilities
@@ -240,10 +230,6 @@ export class ScriptEngine {
         "require",
         "fetch",
       ].forEach((g) => vm.freeze(undefined, g));
-
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
 
       const wrapped = `"use strict"; (async () => { ${code} })();`;
       const resultPromise = vm.run(wrapped);
@@ -465,13 +451,6 @@ export class ScriptEngine {
         worker.terminate();
         reject(new Error("Script execution timed out"));
       }, 1000);
-
-      if (signal?.aborted) {
-        clearTimeout(timeoutId);
-        worker.terminate();
-        reject(new DOMException("Aborted", "AbortError"));
-        return;
-      }
 
       const abortHandler = () => {
         clearTimeout(timeoutId);

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -466,10 +466,12 @@ export class ScriptEngine {
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
 
-      worker.postMessage({ type: "execute", context, code, language });
       if (signal?.aborted) {
         abortHandler();
+        return;
       }
+
+      worker.postMessage({ type: "execute", context, code, language });
     });
   }
 

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -435,7 +435,10 @@ export class ScriptEngine {
         if (data.type === "result") {
           clearTimeout(timeoutId);
           worker.terminate();
-          if (data.error) {
+          signal?.removeEventListener("abort", abortHandler);
+          if (signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+          } else if (data.error) {
             reject(
               data.error.name
                 ? new DOMException(data.error.message, data.error.name)
@@ -459,10 +462,6 @@ export class ScriptEngine {
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
-      if (signal?.aborted) {
-        abortHandler();
-        return;
-      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -439,9 +439,7 @@ export class ScriptEngine {
           clearTimeout(timeoutId);
           worker.terminate();
           signal?.removeEventListener("abort", abortHandler);
-          if (signal?.aborted) {
-            reject(new DOMException("Aborted", "AbortError"));
-          } else if (data.error) {
+          if (data.error) {
             reject(
               data.error.name
                 ? new DOMException(data.error.message, data.error.name)

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -455,9 +455,14 @@ export class ScriptEngine {
       const abortHandler = () => {
         clearTimeout(timeoutId);
         worker.terminate();
+        signal?.removeEventListener("abort", abortHandler);
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
+      if (signal?.aborted) {
+        abortHandler();
+        return;
+      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -510,7 +510,7 @@ export class ScriptEngine {
     options: RequestInit = {},
     signal?: AbortSignal,
   ): Promise<T> {
-    const { headers: optHeaders, ...restOptions } = options;
+    const { headers: optHeaders, signal: optSignal, ...restOptions } = options;
     let headers: Record<string, string> = {};
 
     if (optHeaders instanceof Headers) {
@@ -533,11 +533,16 @@ export class ScriptEngine {
       headers["Content-Type"] = "application/json";
     }
 
+    const combinedSignal =
+      signal && optSignal
+        ? AbortSignal.any([signal, optSignal])
+        : signal || optSignal;
+
     const response = await fetch(url, {
       method,
       headers,
-      signal,
       ...restOptions,
+      signal: combinedSignal,
     });
 
     if (!response.ok) {

--- a/tests/scriptAbort.test.ts
+++ b/tests/scriptAbort.test.ts
@@ -52,4 +52,27 @@ describe("ScriptEngine abort handling", () => {
     await expect(promise).rejects.toMatchObject({ name: "AbortError" });
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it("does not run script when aborted before execution", async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: "preabort",
+      name: "preabort",
+      type: "javascript",
+      content: "await http.get('https://example.com');",
+      trigger: "manual",
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const context: ScriptExecutionContext = { trigger: "manual" };
+    const fetchMock = vi.fn();
+    (global as any).fetch = fetchMock;
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      engine.executeScript<void>(script, context, ac.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/scriptAbort.test.ts
+++ b/tests/scriptAbort.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ScriptEngine,
+  ScriptExecutionContext,
+} from "../src/utils/scriptEngine";
+import { CustomScript } from "../src/types/settings";
+
+describe("ScriptEngine abort handling", () => {
+  it("aborts a sleeping script", async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: "sleep",
+      name: "sleep",
+      type: "javascript",
+      content: "await sleep(1000); return 1;",
+      trigger: "manual",
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const context: ScriptExecutionContext = { trigger: "manual" };
+    const ac = new AbortController();
+    const promise = engine.executeScript<number>(script, context, ac.signal);
+    ac.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("aborts in-flight http request", async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: "http",
+      name: "http",
+      type: "javascript",
+      content: "await http.get('https://example.com');",
+      trigger: "manual",
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const context: ScriptExecutionContext = { trigger: "manual" };
+    const fetchMock = vi.fn((_: string, opts: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    });
+    (global as any).fetch = fetchMock;
+    const ac = new AbortController();
+    const promise = engine.executeScript<void>(script, context, ac.signal);
+    ac.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/tests/scriptAbort.test.ts
+++ b/tests/scriptAbort.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   ScriptEngine,
   ScriptExecutionContext,
@@ -6,6 +6,11 @@ import {
 import { CustomScript } from "../src/types/settings";
 
 describe("ScriptEngine abort handling", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
   it("aborts a sleeping script", async () => {
     const engine = ScriptEngine.getInstance();
     const script: CustomScript = {


### PR DESCRIPTION
## Summary
- add optional AbortSignal to ScriptEngine and helpers for cancellation
- cancel in-flight http/ssh requests and sleep when aborted
- document and test abortable script execution

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: Cannot read properties of undefined (reading 'importKey'))*

------
https://chatgpt.com/codex/tasks/task_e_68bf26921d288325927740f49066087f