### PR TITLE
fix: handle abort before VM setup

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -464,6 +464,9 @@ export class ScriptEngine {
       signal?.addEventListener("abort", abortHandler, { once: true });
 
       worker.postMessage({ type: "execute", context, code, language });
+      if (signal?.aborted) {
+        abortHandler();
+      }
     });
   }
 

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -58,10 +58,6 @@ export class ScriptEngine {
     );
 
     try {
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
-
       const result = await this.runScript<T>(script, context, signal);
 
       const duration = Date.now() - startTime;
@@ -212,13 +208,7 @@ export class ScriptEngine {
     const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
     if (isNode) {
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
       const { VM } = await import("vm2");
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
       const vm = new VM({ timeout: 1000, sandbox: {} });
 
       // Expose only whitelisted utilities
@@ -240,10 +230,6 @@ export class ScriptEngine {
         "require",
         "fetch",
       ].forEach((g) => vm.freeze(undefined, g));
-
-      if (signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
-      }
 
       const wrapped = `"use strict"; (async () => { ${code} })();`;
       const resultPromise = vm.run(wrapped);
@@ -465,13 +451,6 @@ export class ScriptEngine {
         worker.terminate();
         reject(new Error("Script execution timed out"));
       }, 1000);
-
-      if (signal?.aborted) {
-        clearTimeout(timeoutId);
-        worker.terminate();
-        reject(new DOMException("Aborted", "AbortError"));
-        return;
-      }
 
       const abortHandler = () => {
         clearTimeout(timeoutId);

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -435,7 +435,10 @@ export class ScriptEngine {
         if (data.type === "result") {
           clearTimeout(timeoutId);
           worker.terminate();
-          if (data.error) {
+          signal?.removeEventListener("abort", abortHandler);
+          if (signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+          } else if (data.error) {
             reject(
               data.error.name
                 ? new DOMException(data.error.message, data.error.name)
@@ -459,10 +462,6 @@ export class ScriptEngine {
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
-      if (signal?.aborted) {
-        abortHandler();
-        return;
-      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -455,9 +455,14 @@ export class ScriptEngine {
       const abortHandler = () => {
         clearTimeout(timeoutId);
         worker.terminate();
+        signal?.removeEventListener("abort", abortHandler);
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
+      if (signal?.aborted) {
+        abortHandler();
+        return;
+      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });


### PR DESCRIPTION
## Summary
- remove early abort checks so scripts still execute and side effects run
- use abort listeners in VM and worker paths to reject after setup

## Testing
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0142493308325bb41b51f2717133d