### PR TITLE
fix: handle abort before VM setup

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -455,9 +455,14 @@ export class ScriptEngine {
       const abortHandler = () => {
         clearTimeout(timeoutId);
         worker.terminate();
+        signal?.removeEventListener("abort", abortHandler);
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
+      if (signal?.aborted) {
+        abortHandler();
+        return;
+      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });


### PR DESCRIPTION
## Summary
- ensure worker execution rejects when provided an already-aborted signal

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0410f880c83259addf33431e3fc27