### PR TITLE
fix: handle abort before VM setup

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -464,6 +464,9 @@ export class ScriptEngine {
       signal?.addEventListener("abort", abortHandler, { once: true });
 
       worker.postMessage({ type: "execute", context, code, language });
+      if (signal?.aborted) {
+        abortHandler();
+      }
     });
   }
 

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -435,7 +435,10 @@ export class ScriptEngine {
         if (data.type === "result") {
           clearTimeout(timeoutId);
           worker.terminate();
-          if (data.error) {
+          signal?.removeEventListener("abort", abortHandler);
+          if (signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+          } else if (data.error) {
             reject(
               data.error.name
                 ? new DOMException(data.error.message, data.error.name)
@@ -459,10 +462,6 @@ export class ScriptEngine {
         reject(new DOMException("Aborted", "AbortError"));
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
-      if (signal?.aborted) {
-        abortHandler();
-        return;
-      }
 
       worker.postMessage({ type: "execute", context, code, language });
     });


### PR DESCRIPTION
## Summary
- ensure worker-based script execution posts code before aborting so side effects run
- reject worker execution when the signal is already aborted after setup

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0585c7d108325abb37f736f1cab0b