### PR TITLE
fix: abort already-aborted signals after posting

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -464,6 +464,9 @@ export class ScriptEngine {
       signal?.addEventListener("abort", abortHandler, { once: true });
 
       worker.postMessage({ type: "execute", context, code, language });
+      if (signal?.aborted) {
+        abortHandler();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- recheck `signal.aborted` after posting worker message and invoke abort handler

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0736da3808325837b4d2bf70bf3cb