### PR TITLE
fix: skip vm execution when aborted

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -208,6 +208,9 @@ export class ScriptEngine {
     const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
     if (isNode) {
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
       const { VM } = await import("vm2");
       const vm = new VM({ timeout: 1000, sandbox: {} });
 

--- a/tests/scriptAbort.test.ts
+++ b/tests/scriptAbort.test.ts
@@ -52,4 +52,27 @@ describe("ScriptEngine abort handling", () => {
     await expect(promise).rejects.toMatchObject({ name: "AbortError" });
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it("does not run script when aborted before execution", async () => {
+    const engine = ScriptEngine.getInstance();
+    const script: CustomScript = {
+      id: "preabort",
+      name: "preabort",
+      type: "javascript",
+      content: "await http.get('https://example.com');",
+      trigger: "manual",
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const context: ScriptExecutionContext = { trigger: "manual" };
+    const fetchMock = vi.fn();
+    (global as any).fetch = fetchMock;
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      engine.executeScript<void>(script, context, ac.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- check abort signal before creating Node VM to avoid running canceled scripts
- add test ensuring pre-aborted scripts don't perform side effects

## Testing
- `npx prettier agents.md -w`
- `npm run lint` (warnings: react-hooks/exhaustive-deps, react-refresh/only-export-components)
- `npm test -- --run` (fails: 5 failed test files)

------
https://chatgpt.com/codex/tasks/task_e_68c1e4b0fdf08325a6fcdf86fe8dbb19