### PR TITLE
fix: handle abort before VM setup

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -466,10 +466,12 @@ export class ScriptEngine {
       };
       signal?.addEventListener("abort", abortHandler, { once: true });
 
-      worker.postMessage({ type: "execute", context, code, language });
       if (signal?.aborted) {
         abortHandler();
+        return;
       }
+
+      worker.postMessage({ type: "execute", context, code, language });
     });
   }
 


### PR DESCRIPTION
## Summary
- check abort signal before dispatching work to the worker to avoid running cancelled scripts

## Testing
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9cedddc83259ac4faa4cc9f303d