### PR TITLE
feat: allow aborting script execution

### DIFF
--- a/tests/scriptAbort.test.ts
+++ b/tests/scriptAbort.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   ScriptEngine,
   ScriptExecutionContext,
@@ -6,6 +6,11 @@ import {
 import { CustomScript } from "../src/types/settings";
 
 describe("ScriptEngine abort handling", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
   it("aborts a sleeping script", async () => {
     const engine = ScriptEngine.getInstance();
     const script: CustomScript = {


### PR DESCRIPTION
## Summary
- restore original `fetch` after abort tests to prevent leaking mocks

## Testing
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c2ac5509408325b3bea5eea67abe50