### PR TITLE
feat: allow aborting script execution

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -439,9 +439,7 @@ export class ScriptEngine {
           clearTimeout(timeoutId);
           worker.terminate();
           signal?.removeEventListener("abort", abortHandler);
-          if (signal?.aborted) {
-            reject(new DOMException("Aborted", "AbortError"));
-          } else if (data.error) {
+          if (data.error) {
             reject(
               data.error.name
                 ? new DOMException(data.error.message, data.error.name)


### PR DESCRIPTION
## Summary
- allow completed workers to resolve even if abort signal fires afterwards

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c2b3dc85548325a1ddba813bc3d835