### PR TITLE
fix: preserve script abort signal

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -510,7 +510,7 @@ export class ScriptEngine {
     options: RequestInit = {},
     signal?: AbortSignal,
   ): Promise<T> {
-    const { headers: optHeaders, ...restOptions } = options;
+    const { headers: optHeaders, signal: optSignal, ...restOptions } = options;
     let headers: Record<string, string> = {};
 
     if (optHeaders instanceof Headers) {
@@ -533,11 +533,16 @@ export class ScriptEngine {
       headers["Content-Type"] = "application/json";
     }
 
+    const combinedSignal =
+      signal && optSignal
+        ? AbortSignal.any([signal, optSignal])
+        : signal || optSignal;
+
     const response = await fetch(url, {
       method,
       headers,
-      signal,
       ...restOptions,
+      signal: combinedSignal,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- combine script abort signal with per-request signal so script cancellation can't be overridden

## Testing
- `npx prettier agents.md -w`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c2f29d117483258f065c106d2a9529