### PR TITLE
chore: improve dynamic imports for node modules

### DIFF
--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -211,7 +211,7 @@ export class ScriptEngine {
       if (signal?.aborted) {
         throw new DOMException("Aborted", "AbortError");
       }
-      const { VM } = await import("vm2");
+      const { VM } = await import(/* @vite-ignore */ "vm2");
       const vm = new VM({ timeout: 1000, sandbox: {} });
 
       // Expose only whitelisted utilities
@@ -540,11 +540,9 @@ export class ScriptEngine {
         if (sig.aborted) {
           controller.abort(sig.reason);
         } else {
-          sig.addEventListener(
-            "abort",
-            () => controller.abort(sig.reason),
-            { once: true },
-          );
+          sig.addEventListener("abort", () => controller.abort(sig.reason), {
+            once: true,
+          });
         }
       };
       forward(signal);

--- a/src/utils/statusChecker.ts
+++ b/src/utils/statusChecker.ts
@@ -149,7 +149,7 @@ export class StatusChecker {
     port: number,
     timeout: number,
   ): Promise<void> {
-    const net = await import("net");
+    const net = await import(/* @vite-ignore */ "node:net");
     return new Promise((resolve, reject) => {
       const socket = net.createConnection({ host: hostname, port });
 


### PR DESCRIPTION
## Summary
- avoid bundling Node-only modules by marking dynamic imports with `node:` prefix and `vite-ignore`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c304c3cff48325a2f9231c407e7b46