### PR TITLE
fix(ssh): require fingerprint confirmation for ProxyCommand

### DIFF
--- a/src-tauri/crates/sorng-ssh/src/ssh/proxy_command.rs
+++ b/src-tauri/crates/sorng-ssh/src/ssh/proxy_command.rs
@@ -82,18 +82,16 @@ lazy_static::lazy_static! {
     pub static ref PROXY_COMMANDS: StdMutex<HashMap<String, ProxyCommandState>> = StdMutex::new(HashMap::new());
 
     /// Fingerprints of ProxyCommand strings the user has explicitly confirmed
-    /// at runtime via [`confirm_proxy_command`]. This complements the
-    /// `command_confirmed` config flag: a confirmed flag (set by the in-app
-    /// editor for user-typed commands) bypasses the gate, and so does a runtime
-    /// confirmation recorded here (used by the Wave-2 review-and-confirm UI for
-    /// imported commands without rewriting persisted config).
+    /// at runtime via [`confirm_proxy_command`]. The gate is intentionally keyed
+    /// only by the expanded command fingerprint so imported or persisted boolean
+    /// flags cannot bless different command contents.
     static ref CONFIRMED_PROXY_COMMANDS: StdMutex<std::collections::HashSet<String>> =
         StdMutex::new(std::collections::HashSet::new());
 }
 
 /// Record that the user has reviewed and confirmed a specific expanded
 /// ProxyCommand string. After this, [`spawn_proxy_command`] will execute that
-/// exact command even when its config carries `command_confirmed == false`.
+/// exact command.
 pub fn mark_proxy_command_confirmed(expanded_cmd: &str) {
     if let Ok(mut set) = CONFIRMED_PROXY_COMMANDS.lock() {
         set.insert(command_fingerprint(expanded_cmd));
@@ -305,14 +303,11 @@ pub fn spawn_proxy_command(
     let cmd_string = build_command_string(config, host, port, username)?;
 
     // ── Import-confirmation gate ──────────────────────────────────────
-    // ProxyCommand stays fully free-form, but a command from an untrusted
-    // origin (import/sync) must be confirmed once before it is ever spawned.
-    // It is allowed iff the config carries `command_confirmed == true` (set by
-    // the in-app editor for user-typed commands) OR the exact expanded command
-    // was confirmed at runtime via `confirm_proxy_command`. Otherwise we refuse
-    // — loudly and distinctly — rather than silently running or silently
-    // skipping it.
-    if !config.command_confirmed && !is_proxy_command_confirmed(&cmd_string) {
+    // ProxyCommand stays fully free-form, but the exact expanded command must
+    // be confirmed once before it is ever spawned. Persisted/imported
+    // `command_confirmed` booleans are deliberately ignored here because they
+    // are not bound to the expanded command fingerprint.
+    if !is_proxy_command_confirmed(&cmd_string) {
         log::warn!(
             "[{}] Refusing unconfirmed ProxyCommand (import/sync origin): {}",
             session_id,
@@ -593,23 +588,16 @@ mod tests {
     }
 
     #[test]
-    fn confirmed_flag_passes_the_gate() {
-        // command_confirmed=true (set by the in-app editor) bypasses the gate;
-        // we only need to prove it gets PAST the gate, so we hit a guaranteed
-        // failure AFTER the gate (a non-existent command still spawns the shell,
-        // so instead assert the error is NOT the confirmation-required one).
+    fn confirmed_flag_does_not_bypass_fingerprint_gate() {
+        // command_confirmed may arrive from persisted/imported config, so it
+        // must not bypass the fingerprint-scoped runtime confirmation gate.
         let cfg = free_form_config(true);
-        let result =
-            spawn_proxy_command("sess-confirmed-flag", &cfg, "host.example.com", 22, "user", 1);
-        // Regardless of whether the relay ultimately connects on this host, the
-        // gate must NOT be the thing that stopped it.
-        if let Err(e) = &result {
-            assert!(
-                !e.starts_with(PROXY_COMMAND_CONFIRMATION_REQUIRED_CODE),
-                "confirmed-flag command must clear the gate, got: {e}"
-            );
-        }
-        let _ = stop_proxy_command("sess-confirmed-flag");
+        let err = spawn_proxy_command("sess-confirmed-flag", &cfg, "host.example.com", 22, "user", 1)
+            .expect_err("confirmed flag alone must be refused, not spawned");
+        assert!(
+            err.starts_with(PROXY_COMMAND_CONFIRMATION_REQUIRED_CODE),
+            "confirmed flag alone must still require confirmation, got: {err}"
+        );
     }
 
     #[test]

--- a/src/components/ImportExport/utils.ts
+++ b/src/components/ImportExport/utils.ts
@@ -1,9 +1,13 @@
-import { Connection, type TunnelChainLayer, type TunnelType } from '../../types/connection/connection';
-import { generateId } from '../../utils/core/id';
+import {
+  Connection,
+  type TunnelChainLayer,
+  type TunnelType,
+} from "../../types/connection/connection";
+import { generateId } from "../../utils/core/id";
 
 export const parseCSVLine = (line: string): string[] => {
   const values: string[] = [];
-  let current = '';
+  let current = "";
   let inQuotes = false;
 
   for (let i = 0; i < line.length; i++) {
@@ -16,15 +20,15 @@ export const parseCSVLine = (line: string): string[] => {
       } else {
         inQuotes = !inQuotes;
       }
-    } else if (char === ',' && !inQuotes) {
-      values.push(current.trim().replace(/\r$/, ''));
-      current = '';
+    } else if (char === "," && !inQuotes) {
+      values.push(current.trim().replace(/\r$/, ""));
+      current = "";
     } else {
       current += char;
     }
   }
 
-  values.push(current.trim().replace(/\r$/, ''));
+  values.push(current.trim().replace(/\r$/, ""));
   return values;
 };
 
@@ -47,13 +51,13 @@ const getDefaultPort = (protocol: string): number => {
 };
 
 const parsePortOrDefault = (portValue: unknown, protocol: string): number => {
-  if (typeof portValue === 'number') {
+  if (typeof portValue === "number") {
     return Number.isFinite(portValue) && portValue > 0
       ? portValue
       : getDefaultPort(protocol);
   }
 
-  const normalizedPort = String(portValue ?? '').trim();
+  const normalizedPort = String(portValue ?? "").trim();
   if (!normalizedPort) return getDefaultPort(protocol);
 
   const parsedPort = Number.parseInt(normalizedPort, 10);
@@ -63,10 +67,11 @@ const parsePortOrDefault = (portValue: unknown, protocol: string): number => {
 };
 
 export const importFromCSV = async (content: string): Promise<Connection[]> => {
-  const lines = content.split(/\r?\n/).filter(line => line.trim());
-  if (lines.length < 2) throw new Error('CSV file must have headers and at least one data row');
+  const lines = content.split(/\r?\n/).filter((line) => line.trim());
+  if (lines.length < 2)
+    throw new Error("CSV file must have headers and at least one data row");
 
-  const headers = lines[0].split(',').map(h => h.trim().replace(/"/g, ''));
+  const headers = lines[0].split(",").map((h) => h.trim().replace(/"/g, ""));
   const connections: Connection[] = [];
 
   for (let i = 1; i < lines.length; i++) {
@@ -78,22 +83,23 @@ export const importFromCSV = async (content: string): Promise<Connection[]> => {
       conn[header] = values[index];
     });
 
-    const protocol = (conn.Protocol?.toLowerCase() || 'rdp') as Connection['protocol'];
+    const protocol = (conn.Protocol?.toLowerCase() ||
+      "rdp") as Connection["protocol"];
 
     connections.push({
       id: conn.ID || generateId(),
-      name: conn.Name || 'Imported Connection',
+      name: conn.Name || "Imported Connection",
       protocol,
-      hostname: conn.Hostname || '',
+      hostname: conn.Hostname || "",
       port: parsePortOrDefault(conn.Port, protocol),
       username: conn.Username || undefined,
       domain: conn.Domain || undefined,
       description: conn.Description || undefined,
       parentId: conn.ParentId || undefined,
-      isGroup: conn.IsGroup === 'true',
-      tags: conn.Tags?.split(';').filter((t: string) => t.trim()) || [],
+      isGroup: conn.IsGroup === "true",
+      tags: conn.Tags?.split(";").filter((t: string) => t.trim()) || [],
       createdAt: new Date(conn.CreatedAt || Date.now()).toISOString(),
-      updatedAt: new Date(conn.UpdatedAt || Date.now()).toISOString()
+      updatedAt: new Date(conn.UpdatedAt || Date.now()).toISOString(),
     });
   }
 
@@ -101,7 +107,9 @@ export const importFromCSV = async (content: string): Promise<Connection[]> => {
 };
 
 const parseBooleanAttribute = (value: string | null): boolean =>
-  String(value ?? '').trim().toLowerCase() === 'true';
+  String(value ?? "")
+    .trim()
+    .toLowerCase() === "true";
 
 const parseIsoOrNow = (value: string | null): string => {
   const parsed = new Date(value || Date.now());
@@ -115,44 +123,49 @@ const parseIsoOrNow = (value: string | null): string => {
  */
 export const importFromXML = async (content: string): Promise<Connection[]> => {
   const parser = new DOMParser();
-  const doc = parser.parseFromString(content, 'text/xml');
-  const parseError = doc.querySelector('parsererror');
+  const doc = parser.parseFromString(content, "text/xml");
+  const parseError = doc.querySelector("parsererror");
   if (parseError) {
-    throw new Error('Invalid XML format: ' + parseError.textContent);
+    throw new Error("Invalid XML format: " + parseError.textContent);
   }
 
   const root = doc.documentElement;
-  if (!root || root.tagName !== 'sortOfRemoteNG') {
-    throw new Error('Invalid sortOfRemoteNG XML: expected <sortOfRemoteNG> root');
+  if (!root || root.tagName !== "sortOfRemoteNG") {
+    throw new Error(
+      "Invalid sortOfRemoteNG XML: expected <sortOfRemoteNG> root",
+    );
   }
 
-  const nodes = Array.from(root.querySelectorAll('Connection'));
+  const nodes = Array.from(root.querySelectorAll("Connection"));
   if (nodes.length === 0) {
-    throw new Error('Invalid sortOfRemoteNG XML: no Connection nodes found');
+    throw new Error("Invalid sortOfRemoteNG XML: no Connection nodes found");
   }
 
   return nodes.map((node) => {
-    const protocol = (node.getAttribute('Type') || 'rdp').toLowerCase() as Connection['protocol'];
-    const isGroup = parseBooleanAttribute(node.getAttribute('IsGroup'));
-    const tags = (node.getAttribute('Tags') || '')
+    const protocol = (
+      node.getAttribute("Type") || "rdp"
+    ).toLowerCase() as Connection["protocol"];
+    const isGroup = parseBooleanAttribute(node.getAttribute("IsGroup"));
+    const tags = (node.getAttribute("Tags") || "")
       .split(/[;,]/)
       .map((tag) => tag.trim())
       .filter(Boolean);
 
     return {
-      id: node.getAttribute('Id') || generateId(),
-      name: node.getAttribute('Name') || 'Imported Connection',
+      id: node.getAttribute("Id") || generateId(),
+      name: node.getAttribute("Name") || "Imported Connection",
       protocol,
-      hostname: node.getAttribute('Server') || node.getAttribute('Hostname') || '',
-      port: parsePortOrDefault(node.getAttribute('Port'), protocol),
-      username: node.getAttribute('Username') || undefined,
-      domain: node.getAttribute('Domain') || undefined,
-      description: node.getAttribute('Description') || undefined,
-      parentId: node.getAttribute('ParentId') || undefined,
+      hostname:
+        node.getAttribute("Server") || node.getAttribute("Hostname") || "",
+      port: parsePortOrDefault(node.getAttribute("Port"), protocol),
+      username: node.getAttribute("Username") || undefined,
+      domain: node.getAttribute("Domain") || undefined,
+      description: node.getAttribute("Description") || undefined,
+      parentId: node.getAttribute("ParentId") || undefined,
       isGroup,
       tags,
-      createdAt: parseIsoOrNow(node.getAttribute('CreatedAt')),
-      updatedAt: parseIsoOrNow(node.getAttribute('UpdatedAt')),
+      createdAt: parseIsoOrNow(node.getAttribute("CreatedAt")),
+      updatedAt: parseIsoOrNow(node.getAttribute("UpdatedAt")),
     };
   });
 };
@@ -160,19 +173,19 @@ export const importFromXML = async (content: string): Promise<Connection[]> => {
 /**
  * Supported import formats
  */
-export type ImportFormat = 
-  | 'json'           // Native sortOfRemoteNG JSON
-  | 'xml'            // Native sortOfRemoteNG XML
-  | 'csv'            // Native sortOfRemoteNG CSV
-  | 'mremoteng'      // mRemoteNG XML format
-  | 'rdcman'         // Remote Desktop Connection Manager
-  | 'royalts'        // Royal TS/TSX JSON format
-  | 'mobaxterm'      // MobaXterm INI format
-  | 'putty'          // PuTTY registry export
-  | 'securecrt'      // SecureCRT XML sessions
-  | 'termius';       // Termius JSON export
+export type ImportFormat =
+  | "json" // Native sortOfRemoteNG JSON
+  | "xml" // Native sortOfRemoteNG XML
+  | "csv" // Native sortOfRemoteNG CSV
+  | "mremoteng" // mRemoteNG XML format
+  | "rdcman" // Remote Desktop Connection Manager
+  | "royalts" // Royal TS/TSX JSON format
+  | "mobaxterm" // MobaXterm INI format
+  | "putty" // PuTTY registry export
+  | "securecrt" // SecureCRT XML sessions
+  | "termius"; // Termius JSON export
 
-export type ImportFormatGroup = 'native' | 'vendor';
+export type ImportFormatGroup = "native" | "vendor";
 
 export interface ImportFormatCompatibility {
   value: ImportFormat;
@@ -181,125 +194,140 @@ export interface ImportFormatCompatibility {
   extensions: string[];
   signatures: string[];
   dataClasses: string[];
-  credentialSupport: 'full' | 'partial' | 'none';
+  credentialSupport: "full" | "partial" | "none";
   description: string;
   warning?: string;
 }
 
 export const IMPORT_FORMAT_ORDER: ImportFormat[] = [
-  'json',
-  'xml',
-  'csv',
-  'mremoteng',
-  'rdcman',
-  'termius',
-  'royalts',
-  'mobaxterm',
-  'putty',
-  'securecrt',
+  "json",
+  "xml",
+  "csv",
+  "mremoteng",
+  "rdcman",
+  "termius",
+  "royalts",
+  "mobaxterm",
+  "putty",
+  "securecrt",
 ];
 
-export const IMPORT_FORMAT_COMPATIBILITY: Record<ImportFormat, ImportFormatCompatibility> = {
+export const IMPORT_FORMAT_COMPATIBILITY: Record<
+  ImportFormat,
+  ImportFormatCompatibility
+> = {
   json: {
-    value: 'json',
-    label: 'JSON',
-    group: 'native',
-    extensions: ['.json', '.encrypted'],
-    signatures: ['{ "connections": [...] }', '{ "databases": [...] }', '[{ ... }]'],
-    dataClasses: ['connections', 'folders', 'settings sidecars', 'VPN', 'tunnel chains'],
-    credentialSupport: 'full',
-    description: 'Native sortOfRemoteNG JSON exports and connection arrays.',
+    value: "json",
+    label: "JSON",
+    group: "native",
+    extensions: [".json", ".encrypted"],
+    signatures: [
+      '{ "connections": [...] }',
+      '{ "databases": [...] }',
+      "[{ ... }]",
+    ],
+    dataClasses: [
+      "connections",
+      "folders",
+      "settings sidecars",
+      "VPN",
+      "tunnel chains",
+    ],
+    credentialSupport: "full",
+    description: "Native sortOfRemoteNG JSON exports and connection arrays.",
   },
   xml: {
-    value: 'xml',
-    label: 'XML',
-    group: 'native',
-    extensions: ['.xml', '.encrypted'],
-    signatures: ['<sortOfRemoteNG>', '<Connection ... />'],
-    dataClasses: ['connections', 'folders'],
-    credentialSupport: 'partial',
-    description: 'Native sortOfRemoteNG XML connection exports.',
+    value: "xml",
+    label: "XML",
+    group: "native",
+    extensions: [".xml", ".encrypted"],
+    signatures: ["<sortOfRemoteNG>", "<Connection ... />"],
+    dataClasses: ["connections", "folders"],
+    credentialSupport: "partial",
+    description: "Native sortOfRemoteNG XML connection exports.",
   },
   csv: {
-    value: 'csv',
-    label: 'CSV',
-    group: 'native',
-    extensions: ['.csv', '.encrypted'],
-    signatures: ['Name,Protocol,Hostname,Port', 'ID,Name,Protocol,Hostname'],
-    dataClasses: ['connections', 'folders'],
-    credentialSupport: 'partial',
-    description: 'Native sortOfRemoteNG CSV exports and templates.',
+    value: "csv",
+    label: "CSV",
+    group: "native",
+    extensions: [".csv", ".encrypted"],
+    signatures: ["Name,Protocol,Hostname,Port", "ID,Name,Protocol,Hostname"],
+    dataClasses: ["connections", "folders"],
+    credentialSupport: "partial",
+    description: "Native sortOfRemoteNG CSV exports and templates.",
   },
   mremoteng: {
-    value: 'mremoteng',
-    label: 'mRemoteNG',
-    group: 'vendor',
-    extensions: ['.xml'],
-    signatures: ['<Connections ConfVersion=...>', '<Node Protocol=...>'],
-    dataClasses: ['connections', 'folders', 'SSH tunnels'],
-    credentialSupport: 'partial',
-    description: 'mRemoteNG connection XML, including supported encrypted AES-GCM files.',
-    warning: 'Only common connection, folder, protocol, and credential fields can be mapped.',
+    value: "mremoteng",
+    label: "mRemoteNG",
+    group: "vendor",
+    extensions: [".xml"],
+    signatures: ["<Connections ConfVersion=...>", "<Node Protocol=...>"],
+    dataClasses: ["connections", "folders", "SSH tunnels"],
+    credentialSupport: "partial",
+    description:
+      "mRemoteNG connection XML, including supported encrypted AES-GCM files.",
+    warning:
+      "Only common connection, folder, protocol, and credential fields can be mapped.",
   },
   rdcman: {
-    value: 'rdcman',
-    label: 'RDCMan',
-    group: 'vendor',
-    extensions: ['.rdg', '.xml'],
-    signatures: ['<RDCMan>', '<file><group>'],
-    dataClasses: ['RDP connections', 'groups'],
-    credentialSupport: 'partial',
-    description: 'Remote Desktop Connection Manager server groups.',
+    value: "rdcman",
+    label: "RDCMan",
+    group: "vendor",
+    extensions: [".rdg", ".xml"],
+    signatures: ["<RDCMan>", "<file><group>"],
+    dataClasses: ["RDP connections", "groups"],
+    credentialSupport: "partial",
+    description: "Remote Desktop Connection Manager server groups.",
   },
   termius: {
-    value: 'termius',
-    label: 'Termius',
-    group: 'vendor',
-    extensions: ['.json'],
+    value: "termius",
+    label: "Termius",
+    group: "vendor",
+    extensions: [".json"],
     signatures: ['{ "hosts": [...] }'],
-    dataClasses: ['SSH hosts', 'groups'],
-    credentialSupport: 'partial',
-    description: 'Termius JSON host exports.',
+    dataClasses: ["SSH hosts", "groups"],
+    credentialSupport: "partial",
+    description: "Termius JSON host exports.",
   },
   royalts: {
-    value: 'royalts',
-    label: 'Royal TS/TSX',
-    group: 'vendor',
-    extensions: ['.rtsz', '.rtsx', '.json'],
-    signatures: ['{ "Objects": [...] }', 'RoyalFolder'],
-    dataClasses: ['connections', 'folders'],
-    credentialSupport: 'partial',
-    description: 'Royal TS/TSX object exports.',
+    value: "royalts",
+    label: "Royal TS/TSX",
+    group: "vendor",
+    extensions: [".rtsz", ".rtsx", ".json"],
+    signatures: ['{ "Objects": [...] }', "RoyalFolder"],
+    dataClasses: ["connections", "folders"],
+    credentialSupport: "partial",
+    description: "Royal TS/TSX object exports.",
   },
   mobaxterm: {
-    value: 'mobaxterm',
-    label: 'MobaXterm',
-    group: 'vendor',
-    extensions: ['.ini'],
-    signatures: ['[Bookmarks]', 'SubRep='],
-    dataClasses: ['sessions', 'folders'],
-    credentialSupport: 'none',
-    description: 'MobaXterm bookmark INI files.',
+    value: "mobaxterm",
+    label: "MobaXterm",
+    group: "vendor",
+    extensions: [".ini"],
+    signatures: ["[Bookmarks]", "SubRep="],
+    dataClasses: ["sessions", "folders"],
+    credentialSupport: "none",
+    description: "MobaXterm bookmark INI files.",
   },
   putty: {
-    value: 'putty',
-    label: 'PuTTY',
-    group: 'vendor',
-    extensions: ['.reg'],
-    signatures: ['REGEDIT4', 'SimonTatham\\PuTTY\\Sessions'],
-    dataClasses: ['sessions'],
-    credentialSupport: 'none',
-    description: 'PuTTY registry session exports.',
+    value: "putty",
+    label: "PuTTY",
+    group: "vendor",
+    extensions: [".reg"],
+    signatures: ["REGEDIT4", "SimonTatham\\PuTTY\\Sessions"],
+    dataClasses: ["sessions"],
+    credentialSupport: "none",
+    description: "PuTTY registry session exports.",
   },
   securecrt: {
-    value: 'securecrt',
-    label: 'SecureCRT',
-    group: 'vendor',
-    extensions: ['.xml'],
-    signatures: ['<VanDyke>', 'S:"Protocol Name"'],
-    dataClasses: ['sessions'],
-    credentialSupport: 'partial',
-    description: 'SecureCRT XML session exports.',
+    value: "securecrt",
+    label: "SecureCRT",
+    group: "vendor",
+    extensions: [".xml"],
+    signatures: ["<VanDyke>", 'S:"Protocol Name"'],
+    dataClasses: ["sessions"],
+    credentialSupport: "partial",
+    description: "SecureCRT XML session exports.",
   },
 };
 
@@ -310,117 +338,133 @@ export const getImportFormatCompatibility = (
 /**
  * Detect import format from file content
  */
-export const detectImportFormat = (content: string, filename?: string): ImportFormat => {
+export const detectImportFormat = (
+  content: string,
+  filename?: string,
+): ImportFormat => {
   // Strip BOM and whitespace.
-  const trimmed = content.replace(/^\uFEFF/, '').trim();
+  const trimmed = content.replace(/^\uFEFF/, "").trim();
   let extIsXml = false;
 
   // Check filename extension first when an extension is unambiguous.
   if (filename) {
     const lower = filename.toLowerCase();
-    const ext = lower.split('.').pop();
-    if (ext === 'csv') return 'csv';
-    if (ext === 'rtsz' || ext === 'rtsx' || lower.includes('royalts')) return 'royalts';
-    if (lower.includes('termius')) return 'termius';
-    if (ext === 'rdg') return 'rdcman';
-    if (ext === 'reg') return 'putty';
-    if (ext === 'ini' && lower.includes('moba')) return 'mobaxterm';
-    if (ext === 'xml') extIsXml = true;
+    const ext = lower.split(".").pop();
+    if (ext === "csv") return "csv";
+    if (ext === "rtsz" || ext === "rtsx" || lower.includes("royalts"))
+      return "royalts";
+    if (lower.includes("termius")) return "termius";
+    if (ext === "rdg") return "rdcman";
+    if (ext === "reg") return "putty";
+    if (ext === "ini" && lower.includes("moba")) return "mobaxterm";
+    if (ext === "xml") extIsXml = true;
   }
 
   // Native sortOfRemoteNG XML.
-  if (trimmed.includes('<sortOfRemoteNG') || trimmed.includes('<Connection ')) {
-    return 'xml';
+  if (trimmed.includes("<sortOfRemoteNG") || trimmed.includes("<Connection ")) {
+    return "xml";
   }
 
   // mRemoteNG detection - the <Connections> root tag is distinctive.
   // ConfVersion is usually present but absent in some encrypted exports,
   // so we accept either marker.
   if (
-    trimmed.includes('<Connections') &&
-    (trimmed.includes('ConfVersion') ||
-      trimmed.includes('FullFileEncryption') ||
-      trimmed.includes('Protected='))
+    trimmed.includes("<Connections") &&
+    (trimmed.includes("ConfVersion") ||
+      trimmed.includes("FullFileEncryption") ||
+      trimmed.includes("Protected="))
   ) {
-    return 'mremoteng';
+    return "mremoteng";
   }
-  
+
   // RDCMan detection
-  if (trimmed.includes('<RDCMan') || (trimmed.includes('<file') && trimmed.includes('<group'))) {
-    return 'rdcman';
+  if (
+    trimmed.includes("<RDCMan") ||
+    (trimmed.includes("<file") && trimmed.includes("<group"))
+  ) {
+    return "rdcman";
   }
-  
+
   // Royal TS JSON format
-  if (trimmed.startsWith('{') && (trimmed.includes('"Objects"') || trimmed.includes('"RoyalFolder"'))) {
-    return 'royalts';
+  if (
+    trimmed.startsWith("{") &&
+    (trimmed.includes('"Objects"') || trimmed.includes('"RoyalFolder"'))
+  ) {
+    return "royalts";
   }
-  
+
   // MobaXterm INI format
-  if (trimmed.includes('[Bookmarks') || trimmed.includes('SubRep=')) {
-    return 'mobaxterm';
+  if (trimmed.includes("[Bookmarks") || trimmed.includes("SubRep=")) {
+    return "mobaxterm";
   }
-  
+
   // PuTTY registry format
-  if (trimmed.includes('REGEDIT') || trimmed.includes('[HKEY_CURRENT_USER\\Software\\SimonTatham\\PuTTY')) {
-    return 'putty';
+  if (
+    trimmed.includes("REGEDIT") ||
+    trimmed.includes("[HKEY_CURRENT_USER\\Software\\SimonTatham\\PuTTY")
+  ) {
+    return "putty";
   }
-  
+
   // SecureCRT XML sessions
-  if (trimmed.includes('<VanDyke') || trimmed.includes('S:"Protocol Name"')) {
-    return 'securecrt';
+  if (trimmed.includes("<VanDyke") || trimmed.includes('S:"Protocol Name"')) {
+    return "securecrt";
   }
-  
+
   // Termius JSON
-  if (trimmed.startsWith('{') && trimmed.includes('"hosts"')) {
-    return 'termius';
+  if (trimmed.startsWith("{") && trimmed.includes('"hosts"')) {
+    return "termius";
   }
 
   // Generic XML check
-  if (trimmed.startsWith('<?xml') || trimmed.startsWith('<')) {
+  if (trimmed.startsWith("<?xml") || trimmed.startsWith("<")) {
     // Could be mRemoteNG without the standard header
-    if (trimmed.includes('Node') && (trimmed.includes('Protocol=') || trimmed.includes('Hostname='))) {
-      return 'mremoteng';
+    if (
+      trimmed.includes("Node") &&
+      (trimmed.includes("Protocol=") || trimmed.includes("Hostname="))
+    ) {
+      return "mremoteng";
     }
     // A bare <Connections>…</Connections> wrapper (e.g. fully-encrypted body
     // with no plaintext ConfVersion) is still mRemoteNG.
-    if (trimmed.includes('<Connections')) {
-      return 'mremoteng';
+    if (trimmed.includes("<Connections")) {
+      return "mremoteng";
     }
   }
 
   // Generic JSON check
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    return 'json';
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return "json";
   }
 
   // .xml filename without a matched signature: assume mRemoteNG rather than
   // falling through to CSV (which would otherwise eat encrypted XML blobs).
-  if (extIsXml) return 'mremoteng';
+  if (extIsXml) return "mremoteng";
 
   // Default to CSV
-  return 'csv';
+  return "csv";
 };
 
 /**
  * Map mRemoteNG protocol names to our format
  */
-const mapMRemoteNGProtocol = (protocol: string): Connection['protocol'] => {
-  const protocolMap: Record<string, Connection['protocol']> = {
-    'RDP': 'rdp',
-    'SSH1': 'ssh',
-    'SSH2': 'ssh',
-    'Telnet': 'telnet',
-    'Rlogin': 'rlogin',
-    'VNC': 'vnc',
-    'HTTP': 'http',
-    'HTTPS': 'https',
-    'ICA': 'rdp',           // Citrix ICA mapped to RDP
-    'RAW': 'telnet',
-    'IntApp': 'rdp',
-    'PowerShell': 'ssh',    // mRemoteNG PowerShell remoting → ssh
-    'Winbox': 'rdp',        // MikroTik Winbox → rdp
+const mapMRemoteNGProtocol = (protocol: string): Connection["protocol"] => {
+  const protocolMap: Record<string, Connection["protocol"]> = {
+    RDP: "rdp",
+    SSH1: "ssh",
+    SSH2: "ssh",
+    Telnet: "telnet",
+    Rlogin: "rlogin",
+    VNC: "vnc",
+    HTTP: "http",
+    HTTPS: "https",
+    ICA: "rdp", // Citrix ICA mapped to RDP
+    RAW: "telnet",
+    IntApp: "rdp",
+    PowerShell: "ssh", // mRemoteNG PowerShell remoting → ssh
+    Winbox: "rdp", // MikroTik Winbox → rdp
   };
-  return protocolMap[protocol] || 'rdp';
+  return protocolMap[protocol] || "rdp";
 };
 
 const getMRemoteNGAttribute = (
@@ -437,8 +481,8 @@ const getMRemoteNGAttribute = (
 const parseMRemoteNGBool = (value: string | undefined): boolean | undefined => {
   if (value === undefined) return undefined;
   const normalized = value.trim().toLowerCase();
-  if (['true', 'yes', '1'].includes(normalized)) return true;
-  if (['false', 'no', '0'].includes(normalized)) return false;
+  if (["true", "yes", "1"].includes(normalized)) return true;
+  if (["false", "no", "0"].includes(normalized)) return false;
   return undefined;
 };
 
@@ -446,7 +490,10 @@ const resolveMRemoteNGSshTunnelName = (
   node: Element,
   inheritedTunnelName?: string,
 ): string | undefined => {
-  const explicit = getMRemoteNGAttribute(node, 'SSHTunnelConnectionName')?.trim();
+  const explicit = getMRemoteNGAttribute(
+    node,
+    "SSHTunnelConnectionName",
+  )?.trim();
   if (explicit) return explicit;
 
   // mRemoteNG defaults every `Inherit*` flag to FALSE. Only inherit the
@@ -456,7 +503,7 @@ const resolveMRemoteNGSshTunnelName = (
   // `inheritedTunnelName`, attaching tunnels to connections that should not
   // have them, especially in trimmed/older confCons files).
   const inherit = parseMRemoteNGBool(
-    getMRemoteNGAttribute(node, 'InheritSSHTunnelConnectionName'),
+    getMRemoteNGAttribute(node, "InheritSSHTunnelConnectionName"),
   );
   if (inherit === true) return inheritedTunnelName;
   return undefined;
@@ -490,10 +537,16 @@ const resolveMRemoteNGInheritedProp = (
   inheritedValue: string | undefined,
 ): string | undefined => {
   const direct = node.getAttribute(attrName);
-  if (direct !== null && direct !== '') return direct;
+  if (direct !== null && direct !== "") return direct;
 
-  const inherit = parseMRemoteNGBool(getMRemoteNGAttribute(node, inheritFlagName));
-  if (inherit === true && inheritedValue !== undefined && inheritedValue !== '') {
+  const inherit = parseMRemoteNGBool(
+    getMRemoteNGAttribute(node, inheritFlagName),
+  );
+  if (
+    inherit === true &&
+    inheritedValue !== undefined &&
+    inheritedValue !== ""
+  ) {
     return inheritedValue;
   }
   // Preserve a present-but-empty direct attribute as empty (explicit clear).
@@ -518,14 +571,14 @@ export interface MRemoteNGEncryptionInfo {
 
 // mRemoteNG's hardcoded master password used when the user never sets one.
 // See upstream `Runtime.EncryptionKey` / cryptography provider.
-export const MREMOTENG_DEFAULT_MASTER_PASSWORD = 'mR3m';
+export const MREMOTENG_DEFAULT_MASTER_PASSWORD = "mR3m";
 
 // Plaintext stored in the `Protected` attribute. Decrypts to one of these
 // strings depending on whether a custom master password was set:
 //   - "ThisIsNotProtected"  → no master password set; default `mR3m` works
 //   - "ThisIsProtected"     → user set a custom master password
-const PROTECTED_PLAINTEXT_NO_PASSWORD = 'ThisIsNotProtected';
-const PROTECTED_PLAINTEXT_PASSWORD = 'ThisIsProtected';
+const PROTECTED_PLAINTEXT_NO_PASSWORD = "ThisIsNotProtected";
+const PROTECTED_PLAINTEXT_PASSWORD = "ThisIsProtected";
 
 // Wire format constants for AES-256-GCM (the only cipher implemented here).
 // Layout per upstream `AeadCryptographyProvider.cs`:
@@ -539,7 +592,7 @@ const asBufferSource = (bytes: Uint8Array): BufferSource =>
   bytes as Uint8Array<ArrayBuffer>;
 
 const decodeBase64 = (b64: string): Uint8Array => {
-  const clean = b64.replace(/\s+/g, '');
+  const clean = b64.replace(/\s+/g, "");
   const bin = atob(clean);
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
@@ -547,7 +600,7 @@ const decodeBase64 = (b64: string): Uint8Array => {
 };
 
 const encodeBase64 = (bytes: Uint8Array): string => {
-  let bin = '';
+  let bin = "";
   for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
   return btoa(bin);
 };
@@ -575,19 +628,19 @@ async function deriveMRemoteNGKey(
   password: string,
   salt: Uint8Array,
   iterations: number,
-  usages: KeyUsage[] = ['decrypt'],
+  usages: KeyUsage[] = ["decrypt"],
 ): Promise<CryptoKey> {
   const passKey = await crypto.subtle.importKey(
-    'raw',
+    "raw",
     asBufferSource(pkcs5PasswordToBytes(password)),
-    { name: 'PBKDF2' },
+    { name: "PBKDF2" },
     false,
-    ['deriveKey'],
+    ["deriveKey"],
   );
   return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', hash: 'SHA-1', salt: asBufferSource(salt), iterations },
+    { name: "PBKDF2", hash: "SHA-1", salt: asBufferSource(salt), iterations },
     passKey,
-    { name: 'AES-GCM', length: 256 },
+    { name: "AES-GCM", length: 256 },
     false,
     usages,
   );
@@ -615,21 +668,29 @@ async function decryptMRemoteNGBlob(
   const ciphertext = data.slice(MRNG_SALT_SIZE + MRNG_NONCE_SIZE);
   const key = await deriveMRemoteNGKey(password, salt, iterations);
   const params: AesGcmParams = {
-    name: 'AES-GCM',
+    name: "AES-GCM",
     iv: asBufferSource(nonce),
     additionalData: asBufferSource(salt),
     tagLength: MRNG_TAG_SIZE * 8,
   };
   let plain: ArrayBuffer;
   try {
-    plain = await crypto.subtle.decrypt(params, key, asBufferSource(ciphertext));
+    plain = await crypto.subtle.decrypt(
+      params,
+      key,
+      asBufferSource(ciphertext),
+    );
   } catch (primaryError) {
     // sortOfRemoteNG builds before this interop fix wrote AES-GCM blobs with
     // empty AAD. Keep that recovery path so existing exports can still import,
     // but prefer the upstream mRemoteNG salt-AAD format above.
     try {
       plain = await crypto.subtle.decrypt(
-        { name: 'AES-GCM', iv: asBufferSource(nonce), tagLength: MRNG_TAG_SIZE * 8 },
+        {
+          name: "AES-GCM",
+          iv: asBufferSource(nonce),
+          tagLength: MRNG_TAG_SIZE * 8,
+        },
         key,
         asBufferSource(ciphertext),
       );
@@ -650,16 +711,16 @@ export async function encryptMRemoteNGBlob(
   iterations: number,
 ): Promise<string> {
   const bytes =
-    typeof plaintext === 'string'
+    typeof plaintext === "string"
       ? new TextEncoder().encode(plaintext)
       : plaintext;
   const salt = crypto.getRandomValues(new Uint8Array(MRNG_SALT_SIZE));
   const nonce = crypto.getRandomValues(new Uint8Array(MRNG_NONCE_SIZE));
-  const key = await deriveMRemoteNGKey(password, salt, iterations, ['encrypt']);
+  const key = await deriveMRemoteNGKey(password, salt, iterations, ["encrypt"]);
   const ct = new Uint8Array(
     await crypto.subtle.encrypt(
       {
-        name: 'AES-GCM',
+        name: "AES-GCM",
         iv: asBufferSource(nonce),
         additionalData: asBufferSource(salt),
         tagLength: MRNG_TAG_SIZE * 8,
@@ -683,10 +744,10 @@ export async function encryptMRemoteNGBlob(
  * Throws with a descriptive error on anything other than AES/GCM.
  */
 function assertSupportedMRemoteNGCipher(root: Element): void {
-  const engine = (root.getAttribute('EncryptionEngine') || 'AES').toUpperCase();
-  const mode = (root.getAttribute('BlockCipherMode') || 'GCM').toUpperCase();
-  if (engine === 'AES' && mode === 'GCM') return;
-  if (engine !== 'AES') {
+  const engine = (root.getAttribute("EncryptionEngine") || "AES").toUpperCase();
+  const mode = (root.getAttribute("BlockCipherMode") || "GCM").toUpperCase();
+  if (engine === "AES" && mode === "GCM") return;
+  if (engine !== "AES") {
     throw new Error(
       `Unsupported mRemoteNG block cipher "${engine}". Only AES is implemented in this build (Serpent and Twofish would require a JS polyfill).`,
     );
@@ -718,31 +779,60 @@ export async function verifyMRemoteNGPassword(
   content: string,
   password: string,
 ): Promise<MRemoteNGPasswordCheck> {
-  const doc = new DOMParser().parseFromString(content, 'text/xml');
-  const root = doc.querySelector('Connections');
-  if (!root) throw new Error('Not an mRemoteNG file (no <Connections> root)');
+  const doc = new DOMParser().parseFromString(content, "text/xml");
+  const root = doc.querySelector("Connections");
+  if (!root) throw new Error("Not an mRemoteNG file (no <Connections> root)");
   const iterations = Math.max(
     1,
-    parseInt(root.getAttribute('KdfIterations') || '1000', 10),
+    parseInt(root.getAttribute("KdfIterations") || "1000", 10),
   );
-  const protectedB64 = (root.getAttribute('Protected') || '').trim();
+  const protectedB64 = (root.getAttribute("Protected") || "").trim();
   if (!protectedB64) {
-    return { valid: true, isDefaultMaster: true, iterations, hasProtected: false };
+    return {
+      valid: true,
+      isDefaultMaster: true,
+      iterations,
+      hasProtected: false,
+    };
   }
   try {
-    const plain = await decryptMRemoteNGBlob(protectedB64, password, iterations);
+    const plain = await decryptMRemoteNGBlob(
+      protectedB64,
+      password,
+      iterations,
+    );
     const text = new TextDecoder().decode(plain);
     if (text === PROTECTED_PLAINTEXT_NO_PASSWORD) {
-      return { valid: true, isDefaultMaster: true, iterations, hasProtected: true };
+      return {
+        valid: true,
+        isDefaultMaster: true,
+        iterations,
+        hasProtected: true,
+      };
     }
     if (text === PROTECTED_PLAINTEXT_PASSWORD) {
-      return { valid: true, isDefaultMaster: false, iterations, hasProtected: true };
+      return {
+        valid: true,
+        isDefaultMaster: false,
+        iterations,
+        hasProtected: true,
+      };
     }
     // Decryption succeeded but plaintext is unrecognised — that's still a
     // wrong password unless the sentinel changes upstream.
-    return { valid: false, isDefaultMaster: false, iterations, hasProtected: true };
+    return {
+      valid: false,
+      isDefaultMaster: false,
+      iterations,
+      hasProtected: true,
+    };
   } catch {
-    return { valid: false, isDefaultMaster: false, iterations, hasProtected: true };
+    return {
+      valid: false,
+      isDefaultMaster: false,
+      iterations,
+      hasProtected: true,
+    };
   }
 }
 
@@ -752,9 +842,9 @@ export async function verifyMRemoteNGPassword(
 //   - `VNCProxyPassword`   — added in ConfVersion ≥ 1.7
 //   - `RDGatewayPassword`  — added in ConfVersion ≥ 2.2
 const MRNG_PER_FIELD_PASSWORD_ATTRS = [
-  'Password',
-  'VNCProxyPassword',
-  'RDGatewayPassword',
+  "Password",
+  "VNCProxyPassword",
+  "RDGatewayPassword",
 ];
 
 /**
@@ -768,7 +858,7 @@ async function decryptPerFieldPasswords(
   password: string,
   iterations: number,
 ): Promise<void> {
-  const nodes = Array.from(doc.querySelectorAll('Node'));
+  const nodes = Array.from(doc.querySelectorAll("Node"));
   for (const node of nodes) {
     for (const attr of MRNG_PER_FIELD_PASSWORD_ATTRS) {
       const enc = node.getAttribute(attr);
@@ -799,40 +889,42 @@ export async function decryptMRemoteNGXml(
   content: string,
   password: string,
 ): Promise<string> {
-  const doc = new DOMParser().parseFromString(content, 'text/xml');
-  const root = doc.querySelector('Connections');
-  if (!root) throw new Error('Not an mRemoteNG file (no <Connections> root)');
+  const doc = new DOMParser().parseFromString(content, "text/xml");
+  const root = doc.querySelector("Connections");
+  if (!root) throw new Error("Not an mRemoteNG file (no <Connections> root)");
 
   assertSupportedMRemoteNGCipher(root);
   const iterations = Math.max(
     1,
-    parseInt(root.getAttribute('KdfIterations') || '1000', 10),
+    parseInt(root.getAttribute("KdfIterations") || "1000", 10),
   );
-  const fullFileAttr = (root.getAttribute('FullFileEncryption') || '').toLowerCase();
-  const fullFileEncryption = fullFileAttr === 'true' || fullFileAttr === '1';
+  const fullFileAttr = (
+    root.getAttribute("FullFileEncryption") || ""
+  ).toLowerCase();
+  const fullFileEncryption = fullFileAttr === "true" || fullFileAttr === "1";
 
   // Validate password against the Protected sentinel before doing any work.
-  const protectedB64 = (root.getAttribute('Protected') || '').trim();
+  const protectedB64 = (root.getAttribute("Protected") || "").trim();
   if (protectedB64) {
     const check = await verifyMRemoteNGPassword(content, password);
     if (!check.valid) {
-      throw new Error('Incorrect master password');
+      throw new Error("Incorrect master password");
     }
   }
 
   if (fullFileEncryption) {
-    const body = (root.textContent || '').trim();
-    if (!body) throw new Error('FullFileEncryption is on but body is empty');
+    const body = (root.textContent || "").trim();
+    if (!body) throw new Error("FullFileEncryption is on but body is empty");
     const innerBytes = await decryptMRemoteNGBlob(body, password, iterations);
     const innerXml = new TextDecoder().decode(innerBytes);
     // Rebuild a parseable document, preserving the original root attributes
     // so any post-processing can still see them.
-    const wrapped = `<?xml version="1.0" encoding="utf-8"?><Connections ConfVersion="${root.getAttribute('ConfVersion') || '2.6'}">${innerXml}</Connections>`;
-    const innerDoc = new DOMParser().parseFromString(wrapped, 'text/xml');
-    const parseError = innerDoc.querySelector('parsererror');
+    const wrapped = `<?xml version="1.0" encoding="utf-8"?><Connections ConfVersion="${root.getAttribute("ConfVersion") || "2.6"}">${innerXml}</Connections>`;
+    const innerDoc = new DOMParser().parseFromString(wrapped, "text/xml");
+    const parseError = innerDoc.querySelector("parsererror");
     if (parseError) {
       throw new Error(
-        'Decrypted body is not valid XML — file may be from an unsupported mRemoteNG version',
+        "Decrypted body is not valid XML — file may be from an unsupported mRemoteNG version",
       );
     }
     await decryptPerFieldPasswords(innerDoc, password, iterations);
@@ -853,7 +945,7 @@ async function encryptPerFieldPasswords(
   password: string,
   iterations: number,
 ): Promise<void> {
-  const nodes = Array.from(doc.querySelectorAll('Node'));
+  const nodes = Array.from(doc.querySelectorAll("Node"));
   for (const node of nodes) {
     for (const attr of MRNG_PER_FIELD_PASSWORD_ATTRS) {
       const plain = node.getAttribute(attr);
@@ -896,14 +988,14 @@ export async function encryptMRemoteNGXml(
   opts: EncryptMRemoteNGOptions,
 ): Promise<string> {
   const password = opts.password;
-  if (!password) throw new Error('encryptMRemoteNGXml requires a password');
+  if (!password) throw new Error("encryptMRemoteNGXml requires a password");
   const iterations = Math.max(1000, opts.iterations ?? 1000);
 
-  const doc = new DOMParser().parseFromString(plainXml, 'text/xml');
-  const parseError = doc.querySelector('parsererror');
-  if (parseError) throw new Error('Input is not valid XML');
-  const root = doc.querySelector('Connections');
-  if (!root) throw new Error('Input must have a <Connections> root');
+  const doc = new DOMParser().parseFromString(plainXml, "text/xml");
+  const parseError = doc.querySelector("parsererror");
+  if (parseError) throw new Error("Input is not valid XML");
+  const root = doc.querySelector("Connections");
+  if (!root) throw new Error("Input must have a <Connections> root");
 
   // Preserve any caller-supplied root attributes, then overwrite the
   // encryption headers so the file is self-describing.
@@ -912,24 +1004,29 @@ export async function encryptMRemoteNGXml(
       root.setAttribute(k, v);
     }
   }
-  if (!root.hasAttribute('Name')) root.setAttribute('Name', 'Connections');
-  if (!root.hasAttribute('Export')) root.setAttribute('Export', 'false');
-  if (!root.hasAttribute('ConfVersion')) root.setAttribute('ConfVersion', '2.6');
-  root.setAttribute('EncryptionEngine', 'AES');
-  root.setAttribute('BlockCipherMode', 'GCM');
-  root.setAttribute('KdfIterations', String(iterations));
+  if (!root.hasAttribute("Name")) root.setAttribute("Name", "Connections");
+  if (!root.hasAttribute("Export")) root.setAttribute("Export", "false");
+  if (!root.hasAttribute("ConfVersion"))
+    root.setAttribute("ConfVersion", "2.6");
+  root.setAttribute("EncryptionEngine", "AES");
+  root.setAttribute("BlockCipherMode", "GCM");
+  root.setAttribute("KdfIterations", String(iterations));
   root.setAttribute(
-    'FullFileEncryption',
-    opts.fullFileEncryption ? 'true' : 'false',
+    "FullFileEncryption",
+    opts.fullFileEncryption ? "true" : "false",
   );
 
   // Generate the Protected sentinel for this master.
   const sentinel =
     password === MREMOTENG_DEFAULT_MASTER_PASSWORD
-      ? 'ThisIsNotProtected'
-      : 'ThisIsProtected';
-  const protectedB64 = await encryptMRemoteNGBlob(sentinel, password, iterations);
-  root.setAttribute('Protected', protectedB64);
+      ? "ThisIsNotProtected"
+      : "ThisIsProtected";
+  const protectedB64 = await encryptMRemoteNGBlob(
+    sentinel,
+    password,
+    iterations,
+  );
+  root.setAttribute("Protected", protectedB64);
 
   // Always encrypt per-field passwords, regardless of full-file mode (real
   // mRemoteNG files always do; the full-file mode just adds a wrapper on top).
@@ -940,7 +1037,7 @@ export async function encryptMRemoteNGXml(
     // with a single encrypted blob.
     const inner = Array.from(root.childNodes)
       .map((n) => new XMLSerializer().serializeToString(n))
-      .join('');
+      .join("");
     while (root.firstChild) root.removeChild(root.firstChild);
     const ct = await encryptMRemoteNGBlob(inner, password, iterations);
     root.appendChild(doc.createTextNode(ct));
@@ -958,14 +1055,16 @@ export const detectMRemoteNGEncryption = (
     requiresPassword: false,
   };
   try {
-    const doc = new DOMParser().parseFromString(content, 'text/xml');
-    const root = doc.querySelector('Connections');
+    const doc = new DOMParser().parseFromString(content, "text/xml");
+    const root = doc.querySelector("Connections");
     if (!root) return empty;
-    const fullFileAttr = (root.getAttribute('FullFileEncryption') || '').toLowerCase();
-    const fullFileEncryption = fullFileAttr === 'true' || fullFileAttr === '1';
-    const protectedAttr = (root.getAttribute('Protected') || '').trim();
+    const fullFileAttr = (
+      root.getAttribute("FullFileEncryption") || ""
+    ).toLowerCase();
+    const fullFileEncryption = fullFileAttr === "true" || fullFileAttr === "1";
+    const protectedAttr = (root.getAttribute("Protected") || "").trim();
     const hasProtected = protectedAttr.length > 0;
-    const childNodeCount = root.querySelectorAll(':scope > Node').length;
+    const childNodeCount = root.querySelectorAll(":scope > Node").length;
     // Full-file encryption: body is one encrypted blob, no <Node> children present
     // (or the file explicitly advertises FullFileEncryption="true").
     const requiresPassword =
@@ -984,14 +1083,16 @@ export const detectMRemoteNGEncryption = (
  * Parse mRemoteNG XML format
  * mRemoteNG uses a nested Node structure with attributes for connection properties
  */
-export const importFromMRemoteNG = async (content: string): Promise<Connection[]> => {
+export const importFromMRemoteNG = async (
+  content: string,
+): Promise<Connection[]> => {
   const parser = new DOMParser();
-  const doc = parser.parseFromString(content, 'text/xml');
-  
+  const doc = parser.parseFromString(content, "text/xml");
+
   // Check for parse errors
-  const parseError = doc.querySelector('parsererror');
+  const parseError = doc.querySelector("parsererror");
   if (parseError) {
-    throw new Error('Invalid XML format: ' + parseError.textContent);
+    throw new Error("Invalid XML format: " + parseError.textContent);
   }
 
   const connections: Connection[] = [];
@@ -1010,29 +1111,30 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
     inheritedTunnelName?: string,
     inheritedProps?: MRemoteNGInheritableProps,
   ): void => {
-    const nodeType = node.getAttribute('Type') || 'Connection';
-    const name = node.getAttribute('Name') || 'Unnamed';
+    const nodeType = node.getAttribute("Type") || "Connection";
+    const name = node.getAttribute("Name") || "Unnamed";
     const sshTunnelConnectionName = resolveMRemoteNGSshTunnelName(
       node,
       inheritedTunnelName,
     );
 
-    if (nodeType === 'Container') {
+    if (nodeType === "Container") {
       // This is a folder
       const folderId = generateId();
-      const expanded = (node.getAttribute('Expanded') || '').toLowerCase() === 'true';
+      const expanded =
+        (node.getAttribute("Expanded") || "").toLowerCase() === "true";
       folderIdMap.set(node, folderId);
 
       connections.push({
         id: folderId,
         name: name,
-        protocol: 'rdp',
-        hostname: '',
+        protocol: "rdp",
+        hostname: "",
         port: 0,
         isGroup: true,
         expanded,
         parentId: parentId,
-        description: node.getAttribute('Descr') || undefined,
+        description: node.getAttribute("Descr") || undefined,
         tags: [],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -1043,43 +1145,96 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
       // Resolve the values the container exposes to its children (R7), so a
       // multi-level folder hierarchy propagates credentials correctly.
       const containerProps: MRemoteNGInheritableProps = {
-        username: resolveMRemoteNGInheritedProp(node, 'Username', 'InheritUsername', inheritedProps?.username),
-        password: resolveMRemoteNGInheritedProp(node, 'Password', 'InheritPassword', inheritedProps?.password),
-        domain: resolveMRemoteNGInheritedProp(node, 'Domain', 'InheritDomain', inheritedProps?.domain),
-        hostname: resolveMRemoteNGInheritedProp(node, 'Hostname', 'InheritHostname', inheritedProps?.hostname),
-        port: resolveMRemoteNGInheritedProp(node, 'Port', 'InheritPort', inheritedProps?.port),
+        username: resolveMRemoteNGInheritedProp(
+          node,
+          "Username",
+          "InheritUsername",
+          inheritedProps?.username,
+        ),
+        password: resolveMRemoteNGInheritedProp(
+          node,
+          "Password",
+          "InheritPassword",
+          inheritedProps?.password,
+        ),
+        domain: resolveMRemoteNGInheritedProp(
+          node,
+          "Domain",
+          "InheritDomain",
+          inheritedProps?.domain,
+        ),
+        hostname: resolveMRemoteNGInheritedProp(
+          node,
+          "Hostname",
+          "InheritHostname",
+          inheritedProps?.hostname,
+        ),
+        port: resolveMRemoteNGInheritedProp(
+          node,
+          "Port",
+          "InheritPort",
+          inheritedProps?.port,
+        ),
       };
 
       // Parse child nodes
-      const children = node.querySelectorAll(':scope > Node');
-      children.forEach(child =>
+      const children = node.querySelectorAll(":scope > Node");
+      children.forEach((child) =>
         parseNode(child, folderId, sshTunnelConnectionName, containerProps),
       );
     } else {
       // This is a connection
-      const protocol = node.getAttribute('Protocol') || 'RDP';
+      const protocol = node.getAttribute("Protocol") || "RDP";
       // Resolve credential/host/port honouring container inheritance (R7).
       const hostname =
-        resolveMRemoteNGInheritedProp(node, 'Hostname', 'InheritHostname', inheritedProps?.hostname) || '';
+        resolveMRemoteNGInheritedProp(
+          node,
+          "Hostname",
+          "InheritHostname",
+          inheritedProps?.hostname,
+        ) || "";
       const port = parsePortOrDefault(
-        resolveMRemoteNGInheritedProp(node, 'Port', 'InheritPort', inheritedProps?.port),
+        resolveMRemoteNGInheritedProp(
+          node,
+          "Port",
+          "InheritPort",
+          inheritedProps?.port,
+        ),
         protocol,
       );
       const username =
-        resolveMRemoteNGInheritedProp(node, 'Username', 'InheritUsername', inheritedProps?.username) || undefined;
+        resolveMRemoteNGInheritedProp(
+          node,
+          "Username",
+          "InheritUsername",
+          inheritedProps?.username,
+        ) || undefined;
       const password =
-        resolveMRemoteNGInheritedProp(node, 'Password', 'InheritPassword', inheritedProps?.password) || undefined;
+        resolveMRemoteNGInheritedProp(
+          node,
+          "Password",
+          "InheritPassword",
+          inheritedProps?.password,
+        ) || undefined;
       const domain =
-        resolveMRemoteNGInheritedProp(node, 'Domain', 'InheritDomain', inheritedProps?.domain) || undefined;
-      const description = node.getAttribute('Descr') || node.getAttribute('Description') || undefined;
-      
+        resolveMRemoteNGInheritedProp(
+          node,
+          "Domain",
+          "InheritDomain",
+          inheritedProps?.domain,
+        ) || undefined;
+      const description =
+        node.getAttribute("Descr") ||
+        node.getAttribute("Description") ||
+        undefined;
+
       // mRemoteNG specific fields
-      const resolution = node.getAttribute('Resolution') || undefined;
-      const colors = node.getAttribute('Colors') || undefined;
-      const useCredSsp = node.getAttribute('UseCredSsp') === 'True';
-      const renderingEngine = node.getAttribute('RenderingEngine') || undefined;
+      const resolution = node.getAttribute("Resolution") || undefined;
+      const colors = node.getAttribute("Colors") || undefined;
+      const useCredSsp = node.getAttribute("UseCredSsp") === "True";
+      const renderingEngine = node.getAttribute("RenderingEngine") || undefined;
       const connectionId = generateId();
-      
+
       connections.push({
         id: connectionId,
         name: name,
@@ -1114,12 +1269,12 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
   };
 
   // Get the root Connections element or find Node elements directly
-  const rootConnections = doc.querySelector('Connections');
-  const rootNodes = rootConnections 
-    ? rootConnections.querySelectorAll(':scope > Node')
-    : doc.querySelectorAll('Node');
+  const rootConnections = doc.querySelector("Connections");
+  const rootNodes = rootConnections
+    ? rootConnections.querySelectorAll(":scope > Node")
+    : doc.querySelectorAll("Node");
 
-  rootNodes.forEach(node => parseNode(node));
+  rootNodes.forEach((node) => parseNode(node));
 
   // Jump/bastion hosts referenced by `SSHTunnelConnectionName` are SSH
   // connections. mRemoteNG resolves the tunnel target by NAME across the whole
@@ -1127,7 +1282,7 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
   // in tree order (R8). `connections` is populated in document order by the
   // recursive parse above, so a first-write-wins map yields that ordering.
   const sshConnections = connections.filter(
-    (connection) => !connection.isGroup && connection.protocol === 'ssh',
+    (connection) => !connection.isGroup && connection.protocol === "ssh",
   );
   const sshConnectionsByName = new Map<string, Connection>();
   const sshConnectionsByLowerName = new Map<string, Connection>();
@@ -1150,7 +1305,7 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
     const tunnelConnection =
       sshConnectionsByName.get(pending.tunnelConnectionName) ||
       sshConnectionsByLowerName.get(pending.tunnelConnectionName.toLowerCase());
-    const tunnelHost = tunnelConnection?.hostname?.trim() || '';
+    const tunnelHost = tunnelConnection?.hostname?.trim() || "";
     const tunnelPort =
       tunnelConnection && Number.isFinite(Number(tunnelConnection.port))
         ? Number(tunnelConnection.port)
@@ -1163,23 +1318,27 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
     // connection store) and inline host/port/creds are inlined whenever the
     // jump host resolves.
     const layerType: TunnelType =
-      targetConnection.protocol === 'ssh' ? 'ssh-jump' : 'ssh-tunnel';
+      targetConnection.protocol === "ssh" ? "ssh-jump" : "ssh-tunnel";
 
     const layer: TunnelChainLayer = {
       id: generateId(),
       type: layerType,
       enabled: Boolean(tunnelHost),
       name: `mRemoteNG SSH tunnel via ${pending.tunnelConnectionName}`,
-      localBindHost: '127.0.0.1',
+      localBindHost: "127.0.0.1",
       localBindPort: 0,
       sshTunnel: {
-        forwardType: 'local',
+        forwardType: "local",
         ...(tunnelConnection?.id && { connectionId: tunnelConnection.id }),
         ...(tunnelHost && { host: tunnelHost }),
         port: tunnelPort > 0 ? tunnelPort : 22,
-        ...(tunnelConnection?.username && { username: tunnelConnection.username }),
-        ...(tunnelConnection?.password && { password: tunnelConnection.password }),
-        remoteHost: pending.targetHost || 'localhost',
+        ...(tunnelConnection?.username && {
+          username: tunnelConnection.username,
+        }),
+        ...(tunnelConnection?.password && {
+          password: tunnelConnection.password,
+        }),
+        remoteHost: pending.targetHost || "localhost",
         remotePort: pending.targetPort,
       },
     };
@@ -1196,28 +1355,31 @@ export const importFromMRemoteNG = async (content: string): Promise<Connection[]
 /**
  * Parse Remote Desktop Connection Manager (RDCMan) XML format
  */
-export const importFromRDCMan = async (content: string): Promise<Connection[]> => {
+export const importFromRDCMan = async (
+  content: string,
+): Promise<Connection[]> => {
   const parser = new DOMParser();
-  const doc = parser.parseFromString(content, 'text/xml');
-  
-  const parseError = doc.querySelector('parsererror');
+  const doc = parser.parseFromString(content, "text/xml");
+
+  const parseError = doc.querySelector("parsererror");
   if (parseError) {
-    throw new Error('Invalid XML format: ' + parseError.textContent);
+    throw new Error("Invalid XML format: " + parseError.textContent);
   }
 
   const connections: Connection[] = [];
 
   // Parse groups
   const parseGroup = (groupEl: Element, parentId?: string): void => {
-    const properties = groupEl.querySelector(':scope > properties');
-    const name = properties?.querySelector('name')?.textContent || 'Unnamed Group';
+    const properties = groupEl.querySelector(":scope > properties");
+    const name =
+      properties?.querySelector("name")?.textContent || "Unnamed Group";
     const groupId = generateId();
-    
+
     connections.push({
       id: groupId,
       name: name,
-      protocol: 'rdp',
-      hostname: '',
+      protocol: "rdp",
+      hostname: "",
       port: 0,
       isGroup: true,
       parentId: parentId,
@@ -1227,23 +1389,23 @@ export const importFromRDCMan = async (content: string): Promise<Connection[]> =
     });
 
     // Parse servers in this group
-    groupEl.querySelectorAll(':scope > server').forEach(serverEl => {
+    groupEl.querySelectorAll(":scope > server").forEach((serverEl) => {
       parseRDCManServer(serverEl, connections, groupId);
     });
 
     // Recursively parse subgroups
-    groupEl.querySelectorAll(':scope > group').forEach(subGroupEl => {
+    groupEl.querySelectorAll(":scope > group").forEach((subGroupEl) => {
       parseGroup(subGroupEl, groupId);
     });
   };
 
   // Start parsing from file > group elements
-  doc.querySelectorAll('file > group').forEach(groupEl => {
+  doc.querySelectorAll("file > group").forEach((groupEl) => {
     parseGroup(groupEl);
   });
 
   // Also check for servers at root level
-  doc.querySelectorAll('file > server').forEach(serverEl => {
+  doc.querySelectorAll("file > server").forEach((serverEl) => {
     parseRDCManServer(serverEl, connections);
   });
 
@@ -1256,26 +1418,28 @@ const parseRDCManServer = (
   connections: Connection[],
   parentId?: string,
 ): void => {
-  const props = serverEl.querySelector('properties');
-  const displayName = props?.querySelector('displayName')?.textContent;
-  const serverName = props?.querySelector('name')?.textContent || '';
+  const props = serverEl.querySelector("properties");
+  const displayName = props?.querySelector("displayName")?.textContent;
+  const serverName = props?.querySelector("name")?.textContent || "";
 
   // RDCMan stores credentials in <logonCredentials> (group or server level)
-  const creds = serverEl.querySelector('logonCredentials');
-  const username = creds?.querySelector('userName')?.textContent || undefined;
-  const domain = creds?.querySelector('domain')?.textContent || undefined;
+  const creds = serverEl.querySelector("logonCredentials");
+  const username = creds?.querySelector("userName")?.textContent || undefined;
+  const domain = creds?.querySelector("domain")?.textContent || undefined;
 
   // Port lives in <connectionSettings>
-  const connSettings = serverEl.querySelector('connectionSettings');
-  const port = parseInt(connSettings?.querySelector('port')?.textContent || '3389') || 3389;
+  const connSettings = serverEl.querySelector("connectionSettings");
+  const port =
+    parseInt(connSettings?.querySelector("port")?.textContent || "3389") ||
+    3389;
 
   // Comment/description
-  const comment = props?.querySelector('comment')?.textContent || undefined;
+  const comment = props?.querySelector("comment")?.textContent || undefined;
 
   connections.push({
     id: generateId(),
     name: displayName || serverName,
-    protocol: 'rdp',
+    protocol: "rdp",
     hostname: serverName,
     port,
     username,
@@ -1292,34 +1456,39 @@ const parseRDCManServer = (
 /**
  * Parse MobaXterm bookmarks INI format
  */
-export const importFromMobaXterm = async (content: string): Promise<Connection[]> => {
+export const importFromMobaXterm = async (
+  content: string,
+): Promise<Connection[]> => {
   const connections: Connection[] = [];
   const lines = content.split(/\r?\n/);
-  let currentSection = '';
-  let currentSubRep = '';
+  let currentSection = "";
+  let currentSubRep = "";
   const folderMap = new Map<string, string>();
 
   for (const line of lines) {
     const trimmed = line.trim();
-    
+
     // Section header
-    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
       currentSection = trimmed.slice(1, -1);
       continue;
     }
-    
-    if (currentSection === 'Bookmarks' || currentSection.startsWith('Bookmarks_')) {
+
+    if (
+      currentSection === "Bookmarks" ||
+      currentSection.startsWith("Bookmarks_")
+    ) {
       // Parse SubRep (folder path)
-      if (trimmed.startsWith('SubRep=')) {
+      if (trimmed.startsWith("SubRep=")) {
         currentSubRep = trimmed.slice(7);
         if (currentSubRep && !folderMap.has(currentSubRep)) {
           const folderId = generateId();
           folderMap.set(currentSubRep, folderId);
           connections.push({
             id: folderId,
-            name: currentSubRep.split('\\').pop() || currentSubRep,
-            protocol: 'ssh',
-            hostname: '',
+            name: currentSubRep.split("\\").pop() || currentSubRep,
+            protocol: "ssh",
+            hostname: "",
             port: 0,
             isGroup: true,
             tags: [],
@@ -1329,32 +1498,32 @@ export const importFromMobaXterm = async (content: string): Promise<Connection[]
         }
         continue;
       }
-      
+
       // Parse bookmark entry
       // Format: Name=#sessionType#hostname%port%username%...
       const match = trimmed.match(/^(.+?)=#(\d+)#(.+)/);
       if (match) {
         const [, name, typeNum, params] = match;
-        const parts = params.split('%');
-        const hostname = parts[0] || '';
+        const parts = params.split("%");
+        const hostname = parts[0] || "";
         // Map MobaXterm session types
-        const protocolMap: Record<string, Connection['protocol']> = {
-          '0': 'ssh',    // SSH
-          '1': 'telnet', // Telnet
-          '2': 'rlogin', // Rlogin
-          '4': 'rdp',    // RDP
-          '5': 'vnc',    // VNC
-          '3': 'rdp',    // XDMCP (remote display → rdp)
-          '6': 'ftp',    // FTP
-          '7': 'sftp',   // SFTP (map to SSH)
-          '8': 'ssh',    // Mosh (→ ssh)
-          '9': 'telnet', // Serial (→ telnet)
-          '10': 'ssh',   // WSL
+        const protocolMap: Record<string, Connection["protocol"]> = {
+          "0": "ssh", // SSH
+          "1": "telnet", // Telnet
+          "2": "rlogin", // Rlogin
+          "4": "rdp", // RDP
+          "5": "vnc", // VNC
+          "3": "rdp", // XDMCP (remote display → rdp)
+          "6": "ftp", // FTP
+          "7": "sftp", // SFTP (map to SSH)
+          "8": "ssh", // Mosh (→ ssh)
+          "9": "telnet", // Serial (→ telnet)
+          "10": "ssh", // WSL
         };
-        const protocol = protocolMap[typeNum] || 'ssh';
+        const protocol = protocolMap[typeNum] || "ssh";
         const port = parsePortOrDefault(parts[1], protocol);
         const username = parts[2] || undefined;
-        
+
         connections.push({
           id: generateId(),
           name: name,
@@ -1378,7 +1547,9 @@ export const importFromMobaXterm = async (content: string): Promise<Connection[]
 /**
  * Parse PuTTY registry export format
  */
-export const importFromPuTTY = async (content: string): Promise<Connection[]> => {
+export const importFromPuTTY = async (
+  content: string,
+): Promise<Connection[]> => {
   const connections: Connection[] = [];
   const lines = content.split(/\r?\n/);
   let currentSession: string | null = null;
@@ -1386,26 +1557,30 @@ export const importFromPuTTY = async (content: string): Promise<Connection[]> =>
 
   for (const line of lines) {
     const trimmed = line.trim();
-    
+
     // Session header
-    const sessionMatch = trimmed.match(/\[HKEY_CURRENT_USER\\Software\\SimonTatham\\PuTTY\\Sessions\\(.+)\]/);
+    const sessionMatch = trimmed.match(
+      /\[HKEY_CURRENT_USER\\Software\\SimonTatham\\PuTTY\\Sessions\\(.+)\]/,
+    );
     if (sessionMatch) {
       // Save previous session
       if (currentSession && currentProps.HostName) {
         connections.push(createPuTTYConnection(currentSession, currentProps));
       }
-      currentSession = decodeURIComponent(sessionMatch[1].replace(/%([0-9A-F]{2})/gi, (_, hex) => 
-        String.fromCharCode(parseInt(hex, 16))
-      ));
+      currentSession = decodeURIComponent(
+        sessionMatch[1].replace(/%([0-9A-F]{2})/gi, (_, hex) =>
+          String.fromCharCode(parseInt(hex, 16)),
+        ),
+      );
       currentProps = {};
       continue;
     }
-    
+
     // Property line
     const propMatch = trimmed.match(/"(.+?)"=(?:"(.*)"|dword:([0-9a-f]+))/);
     if (propMatch && currentSession) {
       const [, key, strValue, dwordValue] = propMatch;
-      currentProps[key] = strValue ?? String(parseInt(dwordValue || '0', 16));
+      currentProps[key] = strValue ?? String(parseInt(dwordValue || "0", 16));
     }
   }
 
@@ -1417,17 +1592,20 @@ export const importFromPuTTY = async (content: string): Promise<Connection[]> =>
   return connections;
 };
 
-const createPuTTYConnection = (name: string, props: Record<string, string>): Connection => {
-  const protocolMap: Record<string, Connection['protocol']> = {
-    'ssh': 'ssh',
-    'serial': 'telnet',
-    'telnet': 'telnet',
-    'rlogin': 'rlogin',
-    'raw': 'telnet',
+const createPuTTYConnection = (
+  name: string,
+  props: Record<string, string>,
+): Connection => {
+  const protocolMap: Record<string, Connection["protocol"]> = {
+    ssh: "ssh",
+    serial: "telnet",
+    telnet: "telnet",
+    rlogin: "rlogin",
+    raw: "telnet",
   };
 
-  const protocol = protocolMap[props.Protocol?.toLowerCase() || 'ssh'] || 'ssh';
-  
+  const protocol = protocolMap[props.Protocol?.toLowerCase() || "ssh"] || "ssh";
+
   return {
     id: generateId(),
     name: name,
@@ -1445,7 +1623,9 @@ const createPuTTYConnection = (name: string, props: Record<string, string>): Con
 /**
  * Parse Termius JSON export format
  */
-export const importFromTermius = async (content: string): Promise<Connection[]> => {
+export const importFromTermius = async (
+  content: string,
+): Promise<Connection[]> => {
   const data = JSON.parse(content);
   const connections: Connection[] = [];
   const groupMap = new Map<string, string>();
@@ -1457,9 +1637,9 @@ export const importFromTermius = async (content: string): Promise<Connection[]> 
       groupMap.set(group.id || group.label, groupId);
       connections.push({
         id: groupId,
-        name: group.label || 'Unnamed Group',
-        protocol: 'ssh',
-        hostname: '',
+        name: group.label || "Unnamed Group",
+        protocol: "ssh",
+        hostname: "",
         port: 0,
         isGroup: true,
         tags: [],
@@ -1473,16 +1653,14 @@ export const importFromTermius = async (content: string): Promise<Connection[]> 
   if (data.hosts) {
     for (const host of data.hosts) {
       // Termius stores username either at top-level or inside ssh_config
-      const username = host.username
-        || host.ssh_config?.username
-        || undefined;
+      const username = host.username || host.ssh_config?.username || undefined;
 
       connections.push({
         id: generateId(),
-        name: host.label || host.address || 'Unnamed',
-        protocol: 'ssh',
-        hostname: host.address || '',
-        port: parsePortOrDefault(host.port, 'ssh'),
+        name: host.label || host.address || "Unnamed",
+        protocol: "ssh",
+        hostname: host.address || "",
+        port: parsePortOrDefault(host.port, "ssh"),
         username,
         isGroup: false,
         parentId: host.group_id ? groupMap.get(host.group_id) : undefined,
@@ -1500,32 +1678,34 @@ export const importFromTermius = async (content: string): Promise<Connection[]> 
  * Parse Royal TS/TSX JSON export format.
  * Royal TS exports nested Objects arrays with Type indicating the object kind.
  */
-export const importFromRoyalTS = async (content: string): Promise<Connection[]> => {
+export const importFromRoyalTS = async (
+  content: string,
+): Promise<Connection[]> => {
   const data = JSON.parse(content);
   const connections: Connection[] = [];
 
-  const mapRoyalType = (type: string): Connection['protocol'] => {
-    const map: Record<string, Connection['protocol']> = {
-      'RoyalRDSConnection': 'rdp',
-      'RoyalSSHConnection': 'ssh',
-      'RoyalVNCConnection': 'vnc',
-      'RoyalSFTPConnection': 'ssh',
-      'RoyalFTPConnection': 'ftp',
-      'RoyalTelnetConnection': 'telnet',
-      'RoyalWebConnection': 'https',
+  const mapRoyalType = (type: string): Connection["protocol"] => {
+    const map: Record<string, Connection["protocol"]> = {
+      RoyalRDSConnection: "rdp",
+      RoyalSSHConnection: "ssh",
+      RoyalVNCConnection: "vnc",
+      RoyalSFTPConnection: "ssh",
+      RoyalFTPConnection: "ftp",
+      RoyalTelnetConnection: "telnet",
+      RoyalWebConnection: "https",
     };
-    return map[type] || 'rdp';
+    return map[type] || "rdp";
   };
 
   const parseObjects = (objects: any[], parentId?: string): void => {
     for (const obj of objects) {
-      if (obj.Type === 'RoyalFolder') {
+      if (obj.Type === "RoyalFolder") {
         const folderId = generateId();
         connections.push({
           id: folderId,
-          name: obj.Name || 'Unnamed Folder',
-          protocol: 'rdp',
-          hostname: '',
+          name: obj.Name || "Unnamed Folder",
+          protocol: "rdp",
+          hostname: "",
           port: 0,
           isGroup: true,
           parentId,
@@ -1538,12 +1718,12 @@ export const importFromRoyalTS = async (content: string): Promise<Connection[]> 
           parseObjects(obj.Objects, folderId);
         }
       } else {
-        const protocol = mapRoyalType(obj.Type || '');
+        const protocol = mapRoyalType(obj.Type || "");
         connections.push({
           id: generateId(),
-          name: obj.Name || obj.URI || 'Unnamed',
+          name: obj.Name || obj.URI || "Unnamed",
           protocol,
-          hostname: obj.URI || obj.ComputerName || '',
+          hostname: obj.URI || obj.ComputerName || "",
           port: parsePortOrDefault(obj.Port, protocol),
           username: obj.CredentialUsername || obj.Username || undefined,
           domain: obj.CredentialDomain || undefined,
@@ -1568,7 +1748,9 @@ export const importFromRoyalTS = async (content: string): Promise<Connection[]> 
  * SecureCRT uses non-standard XML tag names like <S:"Hostname"> which DOMParser
  * cannot handle, so we use regex-based parsing instead.
  */
-export const importFromSecureCRT = async (content: string): Promise<Connection[]> => {
+export const importFromSecureCRT = async (
+  content: string,
+): Promise<Connection[]> => {
   const connections: Connection[] = [];
 
   // Match each <Session Name="...">...</Session> block
@@ -1579,13 +1761,13 @@ export const importFromSecureCRT = async (content: string): Promise<Connection[]
     const nameAttr = match[1];
     const body = match[2];
 
-    const nameParts = nameAttr.split('/');
+    const nameParts = nameAttr.split("/");
     const name = nameParts[nameParts.length - 1] || nameAttr;
 
-    let hostname = '';
+    let hostname = "";
     let rawPort: string | undefined;
-    let username = '';
-    let protocol: Connection['protocol'] = 'ssh';
+    let username = "";
+    let protocol: Connection["protocol"] = "ssh";
 
     // Extract string values: <S:"Key">value</S:"Key">
     const strRegex = /<S:"([^"]+)">([^<]*)<\/S:"[^"]+">/g;
@@ -1593,13 +1775,13 @@ export const importFromSecureCRT = async (content: string): Promise<Connection[]
     while ((strMatch = strRegex.exec(body)) !== null) {
       const key = strMatch[1];
       const value = strMatch[2];
-      if (key === 'Hostname') hostname = value;
-      else if (key === 'Username') username = value;
-      else if (key === 'Protocol Name') {
+      if (key === "Hostname") hostname = value;
+      else if (key === "Username") username = value;
+      else if (key === "Protocol Name") {
         const lower = value.toLowerCase();
-        if (lower.includes('ssh')) protocol = 'ssh';
-        else if (lower.includes('telnet')) protocol = 'telnet';
-        else if (lower.includes('rlogin')) protocol = 'rlogin';
+        if (lower.includes("ssh")) protocol = "ssh";
+        else if (lower.includes("telnet")) protocol = "telnet";
+        else if (lower.includes("rlogin")) protocol = "rlogin";
       }
     }
 
@@ -1609,7 +1791,7 @@ export const importFromSecureCRT = async (content: string): Promise<Connection[]
     while ((intMatch = intRegex.exec(body)) !== null) {
       const key = intMatch[1];
       const value = intMatch[2];
-      if (key === '[SSH2] Port' || key === 'Port') {
+      if (key === "[SSH2] Port" || key === "Port") {
         rawPort = value;
       }
     }
@@ -1635,23 +1817,36 @@ export const importFromSecureCRT = async (content: string): Promise<Connection[]
   return connections;
 };
 
+const dropImportedProxyCommandConfirmation = (
+  override: Connection["sshConnectionConfigOverride"],
+): Connection["sshConnectionConfigOverride"] => {
+  if (!override) return override;
+
+  const { proxyCommandConfirmed: _proxyCommandConfirmed, ...safeOverride } =
+    override;
+  return safeOverride;
+};
+
 /**
  * Parse generic JSON format
  */
-export const importFromJSON = async (content: string): Promise<Connection[]> => {
+export const importFromJSON = async (
+  content: string,
+): Promise<Connection[]> => {
   const data = JSON.parse(content);
-  
+
   // Handle array format
   if (Array.isArray(data)) {
-    return data.map(conn => {
-      const protocol = (conn.protocol?.toLowerCase() || 'rdp') as Connection['protocol'];
+    return data.map((conn) => {
+      const protocol = (conn.protocol?.toLowerCase() ||
+        "rdp") as Connection["protocol"];
 
       return {
         ...conn,
         protocol,
         id: conn.id || generateId(),
-        name: conn.name || 'Imported Connection',
-        hostname: conn.hostname || conn.host || '',
+        name: conn.name || "Imported Connection",
+        hostname: conn.hostname || conn.host || "",
         port: parsePortOrDefault(conn.port, protocol),
         username: conn.username || undefined,
         password: conn.password || undefined,
@@ -1662,77 +1857,86 @@ export const importFromJSON = async (content: string): Promise<Connection[]> => 
         tags: conn.tags || [],
         createdAt: new Date(conn.createdAt || Date.now()).toISOString(),
         updatedAt: new Date(conn.updatedAt || Date.now()).toISOString(),
+        sshConnectionConfigOverride: dropImportedProxyCommandConfirmation(
+          conn.sshConnectionConfigOverride,
+        ),
       } as Connection;
     });
   }
 
   // Handle native multi-database export package format.
   if (Array.isArray(data?.databases)) {
-    return data.databases.flatMap((database: any) =>
-      Array.isArray(database?.connections)
-        ? database.connections
-        : [],
-    ).map((conn: any) => {
-      const protocol = (conn.protocol?.toLowerCase() || 'rdp') as Connection['protocol'];
+    return data.databases
+      .flatMap((database: any) =>
+        Array.isArray(database?.connections) ? database.connections : [],
+      )
+      .map((conn: any) => {
+        const protocol = (conn.protocol?.toLowerCase() ||
+          "rdp") as Connection["protocol"];
 
-      return {
-        ...conn,
-        protocol,
-        id: conn.id || generateId(),
-        name: conn.name || 'Imported Connection',
-        hostname: conn.hostname || conn.host || '',
-        port: parsePortOrDefault(conn.port, protocol),
-        username: conn.username || undefined,
-        password: conn.password || undefined,
-        domain: conn.domain || undefined,
-        description: conn.description || undefined,
-        parentId: conn.parentId || undefined,
-        isGroup: conn.isGroup || conn.isFolder || false,
-        tags: conn.tags || [],
-        createdAt: new Date(conn.createdAt || Date.now()).toISOString(),
-        updatedAt: new Date(conn.updatedAt || Date.now()).toISOString(),
-      } as Connection;
-    });
+        return {
+          ...conn,
+          protocol,
+          id: conn.id || generateId(),
+          name: conn.name || "Imported Connection",
+          hostname: conn.hostname || conn.host || "",
+          port: parsePortOrDefault(conn.port, protocol),
+          username: conn.username || undefined,
+          password: conn.password || undefined,
+          domain: conn.domain || undefined,
+          description: conn.description || undefined,
+          parentId: conn.parentId || undefined,
+          isGroup: conn.isGroup || conn.isFolder || false,
+          tags: conn.tags || [],
+          createdAt: new Date(conn.createdAt || Date.now()).toISOString(),
+          updatedAt: new Date(conn.updatedAt || Date.now()).toISOString(),
+          sshConnectionConfigOverride: dropImportedProxyCommandConfirmation(
+            conn.sshConnectionConfigOverride,
+          ),
+        } as Connection;
+      });
   }
-  
+
   // Handle object with connections array
   if (data.connections && Array.isArray(data.connections)) {
     return importFromJSON(JSON.stringify(data.connections));
   }
 
-  throw new Error('Invalid JSON format: expected array or object with connections array');
+  throw new Error(
+    "Invalid JSON format: expected array or object with connections array",
+  );
 };
 
 /**
  * Main import function that auto-detects format
  */
 export const importConnections = async (
-  content: string, 
+  content: string,
   filename?: string,
-  format?: ImportFormat
+  format?: ImportFormat,
 ): Promise<Connection[]> => {
   const detectedFormat = format || detectImportFormat(content, filename);
-  
+
   switch (detectedFormat) {
-    case 'xml':
+    case "xml":
       return importFromXML(content);
-    case 'mremoteng':
+    case "mremoteng":
       return importFromMRemoteNG(content);
-    case 'rdcman':
+    case "rdcman":
       return importFromRDCMan(content);
-    case 'mobaxterm':
+    case "mobaxterm":
       return importFromMobaXterm(content);
-    case 'putty':
+    case "putty":
       return importFromPuTTY(content);
-    case 'termius':
+    case "termius":
       return importFromTermius(content);
-    case 'royalts':
+    case "royalts":
       return importFromRoyalTS(content);
-    case 'securecrt':
+    case "securecrt":
       return importFromSecureCRT(content);
-    case 'json':
+    case "json":
       return importFromJSON(content);
-    case 'csv':
+    case "csv":
     default:
       return importFromCSV(content);
   }
@@ -1743,16 +1947,16 @@ export const importConnections = async (
  */
 export const getFormatName = (format: ImportFormat): string => {
   const names: Record<ImportFormat, string> = {
-    'json': 'JSON',
-    'xml': 'XML',
-    'csv': 'CSV',
-    'mremoteng': 'mRemoteNG',
-    'rdcman': 'Remote Desktop Connection Manager',
-    'royalts': 'Royal TS/TSX',
-    'mobaxterm': 'MobaXterm',
-    'putty': 'PuTTY',
-    'securecrt': 'SecureCRT',
-    'termius': 'Termius',
+    json: "JSON",
+    xml: "XML",
+    csv: "CSV",
+    mremoteng: "mRemoteNG",
+    rdcman: "Remote Desktop Connection Manager",
+    royalts: "Royal TS/TSX",
+    mobaxterm: "MobaXterm",
+    putty: "PuTTY",
+    securecrt: "SecureCRT",
+    termius: "Termius",
   };
   return names[format] || format;
 };

--- a/src/hooks/ssh/useWebTerminal.ts
+++ b/src/hooks/ssh/useWebTerminal.ts
@@ -1,17 +1,14 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { TOTPConfig } from "../../types/settings/settings";
 import { useTerminalRecorder } from "../recording/useTerminalRecorder";
 import { useMacroRecorder } from "../recording/useMacroRecorder";
-import { TerminalMacro, SavedRecording } from "../../types/recording/macroTypes";
+import {
+  TerminalMacro,
+  SavedRecording,
+} from "../../types/recording/macroTypes";
 import * as macroService from "../../utils/recording/macroService";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, emit } from "@tauri-apps/api/event";
@@ -19,8 +16,16 @@ import { ConnectionSession } from "../../types/connection/connection";
 import { useConnections } from "../../contexts/useConnections";
 import { useToastContext } from "../../contexts/ToastContext";
 import { useSettings } from "../../contexts/SettingsContext";
-import { mergeSSHTerminalConfig, mergeSSHConnectionConfig, defaultSSHConnectionConfig } from "../../types/settings/settings";
-import { ManagedScript, getDefaultScripts, OSTag } from "../../components/recording/ScriptManager";
+import {
+  mergeSSHTerminalConfig,
+  mergeSSHConnectionConfig,
+  defaultSSHConnectionConfig,
+} from "../../types/settings/settings";
+import {
+  ManagedScript,
+  getDefaultScripts,
+  OSTag,
+} from "../../components/recording/ScriptManager";
 import {
   verifyIdentity,
   trustIdentity,
@@ -28,7 +33,10 @@ import {
   type SshHostKeyIdentity,
   type TrustVerifyResult,
 } from "../../utils/auth/trustStore";
-import { resolveChainConfig, type ResolvedChainConfig } from '../../utils/ssh/resolveChainConfig';
+import {
+  resolveChainConfig,
+  type ResolvedChainConfig,
+} from "../../utils/ssh/resolveChainConfig";
 import { redactSecrets } from "../../utils/errors/redact";
 import { useSSHCommandHistory } from "./useSSHCommandHistory";
 
@@ -38,7 +46,8 @@ import { useSSHCommandHistory } from "./useSSHCommandHistory";
  * Stable prefix the backend uses to refuse an unconfirmed (imported/synced)
  * ProxyCommand. Mirrors Rust `PROXY_COMMAND_CONFIRMATION_REQUIRED_CODE`.
  */
-const PROXY_COMMAND_CONFIRMATION_REQUIRED = "PROXY_COMMAND_CONFIRMATION_REQUIRED";
+const PROXY_COMMAND_CONFIRMATION_REQUIRED =
+  "PROXY_COMMAND_CONFIRMATION_REQUIRED";
 
 type ConnectionStatus = "idle" | "connecting" | "connected" | "error";
 type SshOutputEvent = { session_id: string; data: string };
@@ -113,19 +122,29 @@ export function useWebTerminal(
   const [showScriptSelector, setShowScriptSelector] = useState(false);
   const [scripts, setScripts] = useState<ManagedScript[]>([]);
   const [scriptSearchQuery, setScriptSearchQuery] = useState("");
-  const [scriptCategoryFilter, setScriptCategoryFilter] = useState<string>("all");
-  const [scriptLanguageFilter, setScriptLanguageFilter] = useState<string>("all");
+  const [scriptCategoryFilter, setScriptCategoryFilter] =
+    useState<string>("all");
+  const [scriptLanguageFilter, setScriptLanguageFilter] =
+    useState<string>("all");
   const [scriptOsTagFilter, setScriptOsTagFilter] = useState<string>("all");
 
   /* ── SSH host-key trust state ── */
   const [showKeyPopup, setShowKeyPopup] = useState(false);
-  const [hostKeyIdentity, setHostKeyIdentity] = useState<SshHostKeyIdentity | null>(null);
-  const [sshTrustPrompt, setSshTrustPrompt] = useState<TrustVerifyResult | null>(null);
-  const sshTrustResolveRef = useRef<((decision: HostKeyPromptDecision) => void) | null>(null);
+  const [hostKeyIdentity, setHostKeyIdentity] =
+    useState<SshHostKeyIdentity | null>(null);
+  const [sshTrustPrompt, setSshTrustPrompt] =
+    useState<TrustVerifyResult | null>(null);
+  const sshTrustResolveRef = useRef<
+    ((decision: HostKeyPromptDecision) => void) | null
+  >(null);
 
   /* ── ProxyCommand import-confirmation gate state ── */
-  const [proxyCommandPrompt, setProxyCommandPrompt] = useState<{ command: string } | null>(null);
-  const proxyCommandResolveRef = useRef<((confirmed: boolean) => void) | null>(null);
+  const [proxyCommandPrompt, setProxyCommandPrompt] = useState<{
+    command: string;
+  } | null>(null);
+  const proxyCommandResolveRef = useRef<((confirmed: boolean) => void) | null>(
+    null,
+  );
   const keyPopupRef = useRef<HTMLDivElement>(null);
   const totpBtnRef = useRef<HTMLDivElement>(null);
   const [showTotpPanel, setShowTotpPanel] = useState(false);
@@ -148,9 +167,15 @@ export function useWebTerminal(
   const settingsRef = useRef(settings);
   const isSsh = session.protocol === "ssh";
 
-  useEffect(() => { sessionRef.current = session; }, [session]);
-  useEffect(() => { connectionRef.current = connection; }, [connection]);
-  useEffect(() => { settingsRef.current = settings; }, [settings]);
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+  useEffect(() => {
+    connectionRef.current = connection;
+  }, [connection]);
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
 
   /* ──────────────────────────────────────────────────────────────
    * Script loading
@@ -163,13 +188,22 @@ export function useWebTerminal(
         const stored = localStorage.getItem("managedScripts");
         if (stored) {
           const parsed = JSON.parse(stored);
-          if (parsed && typeof parsed === "object" && "customScripts" in parsed) {
-            const { customScripts = [], modifiedDefaults = [], deletedDefaultIds = [] } = parsed;
+          if (
+            parsed &&
+            typeof parsed === "object" &&
+            "customScripts" in parsed
+          ) {
+            const {
+              customScripts = [],
+              modifiedDefaults = [],
+              deletedDefaultIds = [],
+            } = parsed;
             const activeDefaults = defaults
               .filter((d: ManagedScript) => !deletedDefaultIds.includes(d.id))
               .map(
                 (d: ManagedScript) =>
-                  modifiedDefaults.find((m: ManagedScript) => m.id === d.id) || d,
+                  modifiedDefaults.find((m: ManagedScript) => m.id === d.id) ||
+                  d,
               );
             setScripts([...activeDefaults, ...customScripts]);
           } else if (Array.isArray(parsed)) {
@@ -217,11 +251,15 @@ export function useWebTerminal(
   const filteredScripts = useMemo(() => {
     let result = scripts;
     if (scriptCategoryFilter !== "all")
-      result = result.filter((s) => (s.category || "Uncategorized") === scriptCategoryFilter);
+      result = result.filter(
+        (s) => (s.category || "Uncategorized") === scriptCategoryFilter,
+      );
     if (scriptLanguageFilter !== "all")
       result = result.filter((s) => s.language === scriptLanguageFilter);
     if (scriptOsTagFilter !== "all")
-      result = result.filter((s) => s.osTags && s.osTags.includes(scriptOsTagFilter as OSTag));
+      result = result.filter(
+        (s) => s.osTags && s.osTags.includes(scriptOsTagFilter as OSTag),
+      );
     if (scriptSearchQuery.trim()) {
       const q = scriptSearchQuery.toLowerCase();
       result = result.filter(
@@ -232,7 +270,13 @@ export function useWebTerminal(
       );
     }
     return result;
-  }, [scripts, scriptSearchQuery, scriptCategoryFilter, scriptLanguageFilter, scriptOsTagFilter]);
+  }, [
+    scripts,
+    scriptSearchQuery,
+    scriptCategoryFilter,
+    scriptLanguageFilter,
+    scriptOsTagFilter,
+  ]);
 
   const scriptsByCategory = useMemo(() => {
     const groups: Record<string, ManagedScript[]> = {};
@@ -281,7 +325,9 @@ export function useWebTerminal(
         if (text.trim()) lastNonEmptyLine = i;
       }
     }
-    return lastNonEmptyLine >= 0 ? lines.slice(0, lastNonEmptyLine + 1).join("\n") : "";
+    return lastNonEmptyLine >= 0
+      ? lines.slice(0, lastNonEmptyLine + 1).join("\n")
+      : "";
   }, []);
 
   const restoreBuffer = useCallback((content: string) => {
@@ -310,7 +356,9 @@ export function useWebTerminal(
       let buffer = "";
       if (sshSessionId.current && session.protocol === "ssh") {
         try {
-          buffer = await invoke<string>("get_terminal_buffer", { sessionId: sshSessionId.current });
+          buffer = await invoke<string>("get_terminal_buffer", {
+            sessionId: sshSessionId.current,
+          });
         } catch {
           buffer = serializeBuffer();
         }
@@ -319,9 +367,13 @@ export function useWebTerminal(
       }
       await emit("terminal-buffer-response", { sessionId: session.id, buffer });
     })
-      .then((fn) => { unlisten = fn; })
+      .then((fn) => {
+        unlisten = fn;
+      })
       .catch(console.error);
-    return () => { unlisten?.(); };
+    return () => {
+      unlisten?.();
+    };
   }, [session.id, session.protocol, serializeBuffer]);
 
   const bufferRestoredRef = useRef(false);
@@ -330,10 +382,16 @@ export function useWebTerminal(
     if (!session.terminalBuffer || bufferRestoredRef.current) return;
     const tryRestore = (attempts = 0) => {
       if (attempts > 30) return;
-      if (!termRef.current) { setTimeout(() => tryRestore(attempts + 1), 100); return; }
+      if (!termRef.current) {
+        setTimeout(() => tryRestore(attempts + 1), 100);
+        return;
+      }
       const core = (termRef.current as any)?._core;
       const renderService = core?.renderService ?? core?._renderService;
-      if (!renderService?.dimensions) { setTimeout(() => tryRestore(attempts + 1), 100); return; }
+      if (!renderService?.dimensions) {
+        setTimeout(() => tryRestore(attempts + 1), 100);
+        return;
+      }
       bufferRestoredRef.current = true;
       restoreBuffer(session.terminalBuffer!);
     };
@@ -351,25 +409,47 @@ export function useWebTerminal(
     if (!renderService) return false;
     const dims = renderService?.dimensions;
     if (!dims) return false;
-    if (typeof dims.css?.cell?.width !== "number" || dims.css?.cell?.width <= 0) return false;
+    if (typeof dims.css?.cell?.width !== "number" || dims.css?.cell?.width <= 0)
+      return false;
     return true;
   }, []);
 
-  const safeWrite = useCallback((text: string) => {
-    if (isDisposed.current || !termRef.current) return;
-    if (termRef.current.element && !termRef.current.element.isConnected) return;
-    if (!canRender()) return;
-    try { termRef.current.write(text); } catch { /* ignore */ }
-  }, [canRender]);
+  const safeWrite = useCallback(
+    (text: string) => {
+      if (isDisposed.current || !termRef.current) return;
+      if (termRef.current.element && !termRef.current.element.isConnected)
+        return;
+      if (!canRender()) return;
+      try {
+        termRef.current.write(text);
+      } catch {
+        /* ignore */
+      }
+    },
+    [canRender],
+  );
 
-  const safeWriteln = useCallback((text: string) => {
-    if (isDisposed.current || !termRef.current) return;
-    if (termRef.current.element && !termRef.current.element.isConnected) return;
-    if (!canRender()) return;
-    try { termRef.current.writeln(text); } catch { /* ignore */ }
-  }, [canRender]);
+  const safeWriteln = useCallback(
+    (text: string) => {
+      if (isDisposed.current || !termRef.current) return;
+      if (termRef.current.element && !termRef.current.element.isConnected)
+        return;
+      if (!canRender()) return;
+      try {
+        termRef.current.writeln(text);
+      } catch {
+        /* ignore */
+      }
+    },
+    [canRender],
+  );
 
-  const writeLine = useCallback((text: string) => { safeWriteln(text); }, [safeWriteln]);
+  const writeLine = useCallback(
+    (text: string) => {
+      safeWriteln(text);
+    },
+    [safeWriteln],
+  );
 
   /* ── Theme ── */
 
@@ -385,10 +465,14 @@ export function useWebTerminal(
       };
     }
     const styles = getComputedStyle(document.body);
-    const background = styles.getPropertyValue("--color-background").trim() || "#0b1120";
-    const foreground = styles.getPropertyValue("--color-text").trim() || "#e2e8f0";
-    const cursor = styles.getPropertyValue("--color-primary").trim() || "#7dd3fc";
-    const primaryRgb = styles.getPropertyValue("--color-primary-rgb").trim() || "59 130 246";
+    const background =
+      styles.getPropertyValue("--color-background").trim() || "#0b1120";
+    const foreground =
+      styles.getPropertyValue("--color-text").trim() || "#e2e8f0";
+    const cursor =
+      styles.getPropertyValue("--color-primary").trim() || "#7dd3fc";
+    const primaryRgb =
+      styles.getPropertyValue("--color-primary-rgb").trim() || "59 130 246";
     const rgb = primaryRgb.replace(/ /g, ", ");
     return {
       background,
@@ -406,9 +490,14 @@ export function useWebTerminal(
     const theme = getTerminalTheme();
     const terminal = termRef.current as any;
     try {
-      if (typeof terminal.setOption === "function") { terminal.setOption("theme", theme); return; }
+      if (typeof terminal.setOption === "function") {
+        terminal.setOption("theme", theme);
+        return;
+      }
       if (terminal.options) terminal.options.theme = theme;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, [canRender, getTerminalTheme]);
 
   /* ── Error helpers ── */
@@ -420,9 +509,14 @@ export function useWebTerminal(
         name: err.name || "Error",
         stack: redactSecrets(err.stack || ""),
       };
-    if (typeof err === "string") return { message: redactSecrets(err), name: "Error", stack: "" };
+    if (typeof err === "string")
+      return { message: redactSecrets(err), name: "Error", stack: "" };
     try {
-      return { message: redactSecrets(JSON.stringify(err)), name: "Error", stack: "" };
+      return {
+        message: redactSecrets(JSON.stringify(err)),
+        name: "Error",
+        stack: "",
+      };
     } catch {
       return { message: redactSecrets(String(err)), name: "Error", stack: "" };
     }
@@ -430,25 +524,76 @@ export function useWebTerminal(
 
   const classifySshError = useCallback((message: string) => {
     const lower = message.toLowerCase();
-    if (message.includes("All authentication methods failed") || message.includes("Authentication failed"))
-      return { kind: "auth", friendly: "Authentication failed - please check your credentials" };
-    if (lower.includes("connection refused") || lower.includes("os error 10061"))
-      return { kind: "connection_refused", friendly: "Connection refused - please check the host and port" };
-    if (lower.includes("timeout") || lower.includes("timed out") || lower.includes("os error 10060") || lower.includes("connection attempt failed"))
-      return { kind: "timeout", friendly: "Connection timeout - please check network connectivity" };
+    if (
+      message.includes("All authentication methods failed") ||
+      message.includes("Authentication failed")
+    )
+      return {
+        kind: "auth",
+        friendly: "Authentication failed - please check your credentials",
+      };
+    if (
+      lower.includes("connection refused") ||
+      lower.includes("os error 10061")
+    )
+      return {
+        kind: "connection_refused",
+        friendly: "Connection refused - please check the host and port",
+      };
+    if (
+      lower.includes("timeout") ||
+      lower.includes("timed out") ||
+      lower.includes("os error 10060") ||
+      lower.includes("connection attempt failed")
+    )
+      return {
+        kind: "timeout",
+        friendly: "Connection timeout - please check network connectivity",
+      };
     if (message.includes("Host key verification failed"))
-      return { kind: "host_key", friendly: "Host key verification failed - server may have changed" };
+      return {
+        kind: "host_key",
+        friendly: "Host key verification failed - server may have changed",
+      };
     if (lower.includes("certificate") || lower.includes("x509"))
-      return { kind: "certificate", friendly: "Certificate validation failed - please verify the server identity" };
-    if (message.includes("No such file or directory") && message.includes("private key"))
-      return { kind: "key_missing", friendly: "Private key file not found - please check the key path" };
+      return {
+        kind: "certificate",
+        friendly:
+          "Certificate validation failed - please verify the server identity",
+      };
+    if (
+      message.includes("No such file or directory") &&
+      message.includes("private key")
+    )
+      return {
+        kind: "key_missing",
+        friendly: "Private key file not found - please check the key path",
+      };
     if (message.includes("Permission denied"))
-      return { kind: "permission", friendly: "Permission denied - please check your credentials" };
-    if (lower.includes("failed to establish tcp connection") || lower.includes("failed to connect"))
-      return { kind: "tcp_connect", friendly: "TCP connection failed - please verify the host and port" };
-    if (lower.includes("no route to host") || lower.includes("network unreachable"))
-      return { kind: "network_unreachable", friendly: "Network unreachable - please check routing or VPN" };
-    return { kind: "unknown", friendly: "SSH connection failed - please check credentials and network" };
+      return {
+        kind: "permission",
+        friendly: "Permission denied - please check your credentials",
+      };
+    if (
+      lower.includes("failed to establish tcp connection") ||
+      lower.includes("failed to connect")
+    )
+      return {
+        kind: "tcp_connect",
+        friendly: "TCP connection failed - please verify the host and port",
+      };
+    if (
+      lower.includes("no route to host") ||
+      lower.includes("network unreachable")
+    )
+      return {
+        kind: "network_unreachable",
+        friendly: "Network unreachable - please check routing or VPN",
+      };
+    return {
+      kind: "unknown",
+      friendly: "SSH connection failed - please check credentials and network",
+    };
   }, []);
 
   /* ── SSH connect / disconnect ── */
@@ -465,7 +610,9 @@ export function useWebTerminal(
           timestamp: new Date().toISOString(),
         },
       }).catch(() => {});
-      invoke("ssh_scripts_unregister_session", { sessionId: sid }).catch(() => {});
+      invoke("ssh_scripts_unregister_session", { sessionId: sid }).catch(
+        () => {},
+      );
 
       invoke("disconnect_ssh", { sessionId: sid }).catch(() => undefined);
       sshSessionId.current = null;
@@ -477,501 +624,648 @@ export function useWebTerminal(
     }
   }, [setStatusState, writeLine]);
 
-  const initSsh = useCallback(async (force = false) => {
-    const currentSession = sessionRef.current;
-    const currentConnection = connectionRef.current;
-    if (!isSsh || !currentConnection || !termRef.current) return;
-    if (!force && (isConnecting.current || isSshReady.current)) return;
-    if (!force && sshSessionId.current && currentSession.shellId) {
-      setStatusState("connected");
-      return;
-    }
-    if (force) sshSessionId.current = null;
+  const initSsh = useCallback(
+    async (force = false) => {
+      const currentSession = sessionRef.current;
+      const currentConnection = connectionRef.current;
+      if (!isSsh || !currentConnection || !termRef.current) return;
+      if (!force && (isConnecting.current || isSshReady.current)) return;
+      if (!force && sshSessionId.current && currentSession.shellId) {
+        setStatusState("connected");
+        return;
+      }
+      if (force) sshSessionId.current = null;
 
-    const ignoreHostKey = currentConnection.ignoreSshSecurityErrors ?? false;
-    const currentSettings = settingsRef.current;
-    const sshTrustPolicy = resolveEffectiveTrustPolicy(
-      currentConnection.sshTrustPolicy,
-      currentSettings.sshTrustPolicy,
-      currentSettings.trustPolicy,
-    );
-    const strictHostKeyChecking = !ignoreHostKey && sshTrustPolicy !== "always-trust";
-    isConnecting.current = true;
-    setStatusState("connecting");
-    setError("");
-    if (typeof (termRef.current as any).reset === "function") {
-      try { (termRef.current as any).reset(); } catch { /* ignore */ }
-    } else {
-      try { termRef.current.clear(); } catch { /* ignore */ }
-    }
+      const ignoreHostKey = currentConnection.ignoreSshSecurityErrors ?? false;
+      const currentSettings = settingsRef.current;
+      const sshTrustPolicy = resolveEffectiveTrustPolicy(
+        currentConnection.sshTrustPolicy,
+        currentSettings.sshTrustPolicy,
+        currentSettings.trustPolicy,
+      );
+      const strictHostKeyChecking =
+        !ignoreHostKey && sshTrustPolicy !== "always-trust";
+      isConnecting.current = true;
+      setStatusState("connecting");
+      setError("");
+      if (typeof (termRef.current as any).reset === "function") {
+        try {
+          (termRef.current as any).reset();
+        } catch {
+          /* ignore */
+        }
+      } else {
+        try {
+          termRef.current.clear();
+        } catch {
+          /* ignore */
+        }
+      }
 
-    writeLine("\x1b[36mConnecting to SSH server...\x1b[0m");
-    writeLine(`\x1b[90mHost: ${currentSession.hostname}\x1b[0m`);
-    writeLine(`\x1b[90mPort: ${currentConnection.port || 22}\x1b[0m`);
-    writeLine(`\x1b[90mUser: ${currentConnection.username || "unknown"}\x1b[0m`);
+      writeLine("\x1b[36mConnecting to SSH server...\x1b[0m");
+      writeLine(`\x1b[90mHost: ${currentSession.hostname}\x1b[0m`);
+      writeLine(`\x1b[90mPort: ${currentConnection.port || 22}\x1b[0m`);
+      writeLine(
+        `\x1b[90mUser: ${currentConnection.username || "unknown"}\x1b[0m`,
+      );
 
-    const authMethod = currentConnection.authType || (currentConnection.privateKey ? "key" : "password");
-    writeLine(`\x1b[90mAuth: ${authMethod}\x1b[0m`);
-    writeLine(`\x1b[90mHost key checking: ${strictHostKeyChecking ? "enabled" : "disabled"}\x1b[0m`);
+      const authMethod =
+        currentConnection.authType ||
+        (currentConnection.privateKey ? "key" : "password");
+      writeLine(`\x1b[90mAuth: ${authMethod}\x1b[0m`);
+      writeLine(
+        `\x1b[90mHost key checking: ${strictHostKeyChecking ? "enabled" : "disabled"}\x1b[0m`,
+      );
 
-    let unlistenHostKeyPrompt: (() => void) | null = null;
-    let sshPassword: string | null = null;
-    let privateKeyPassphrase: string | null = null;
-    let totpSecret: string | null = null;
-    let proxyCommandPassword: string | null = null;
+      let unlistenHostKeyPrompt: (() => void) | null = null;
+      let sshPassword: string | null = null;
+      let privateKeyPassphrase: string | null = null;
+      let totpSecret: string | null = null;
+      let proxyCommandPassword: string | null = null;
 
-    // ── ProxyCommand config (snake_case, mirrors Rust ProxyCommandConfig) ──
-    // Built once and reused for connect, expand, and confirm so the backend
-    // rebuilds the EXACT same expanded command (the confirmation fingerprint
-    // must match). Declared outside the try so the import-confirmation gate in
-    // the catch block can re-expand/confirm with identical inputs.
-    const hasProxyCommand = Boolean(
-      sshConnectionConfig.proxyCommand || sshConnectionConfig.proxyCommandTemplate,
-    );
-    const buildProxyCommandConfig = (confirmed: boolean): Record<string, unknown> | null =>
-      hasProxyCommand
-        ? {
-            command: sshConnectionConfig.proxyCommand || null,
-            template: sshConnectionConfig.proxyCommandTemplate || null,
-            proxy_host: sshConnectionConfig.proxyCommandHost || null,
-            proxy_port: sshConnectionConfig.proxyCommandPort || null,
-            proxy_username: sshConnectionConfig.proxyCommandUsername || null,
-            proxy_password: proxyCommandPassword,
-            proxy_type: sshConnectionConfig.proxyCommandProxyType || null,
-            timeout_secs: sshConnectionConfig.proxyCommandTimeout || null,
-            command_confirmed: confirmed,
-          }
-        : null;
+      // ── ProxyCommand config (snake_case, mirrors Rust ProxyCommandConfig) ──
+      // Built once and reused for connect, expand, and confirm so the backend
+      // rebuilds the EXACT same expanded command (the confirmation fingerprint
+      // must match). Declared outside the try so the import-confirmation gate in
+      // the catch block can re-expand/confirm with identical inputs.
+      const hasProxyCommand = Boolean(
+        sshConnectionConfig.proxyCommand ||
+        sshConnectionConfig.proxyCommandTemplate,
+      );
+      const buildProxyCommandConfig = (): Record<string, unknown> | null =>
+        hasProxyCommand
+          ? {
+              command: sshConnectionConfig.proxyCommand || null,
+              template: sshConnectionConfig.proxyCommandTemplate || null,
+              proxy_host: sshConnectionConfig.proxyCommandHost || null,
+              proxy_port: sshConnectionConfig.proxyCommandPort || null,
+              proxy_username: sshConnectionConfig.proxyCommandUsername || null,
+              proxy_password: proxyCommandPassword,
+              proxy_type: sshConnectionConfig.proxyCommandProxyType || null,
+              timeout_secs: sshConnectionConfig.proxyCommandTimeout || null,
+              // Never trust persisted/imported confirmation state; the backend
+              // only honors its fingerprint-scoped runtime confirmation registry.
+              command_confirmed: false,
+            }
+          : null;
 
-    try {
-      // Try reattaching to existing backend session
-      if (currentSession.backendSessionId && !force) {
-        const isAlive = await invoke<boolean>("is_session_alive", { sessionId: currentSession.backendSessionId }).catch(() => false);
-        if (isAlive) {
-          sshSessionId.current = currentSession.backendSessionId;
-          const buffer = await invoke<string>("get_terminal_buffer", { sessionId: currentSession.backendSessionId }).catch(() => "");
-          if (buffer) { restoreBuffer(buffer); writeLine("\x1b[32mRestored terminal buffer from session\x1b[0m"); }
-          const existingShellId = await invoke<string | null>("get_shell_info", { sessionId: currentSession.backendSessionId }).catch(() => null);
-          if (existingShellId) {
-            dispatch({ type: "UPDATE_SESSION", payload: { ...currentSession, shellId: existingShellId } });
-            writeLine("\x1b[32mReattached to existing SSH session\x1b[0m");
+      try {
+        // Try reattaching to existing backend session
+        if (currentSession.backendSessionId && !force) {
+          const isAlive = await invoke<boolean>("is_session_alive", {
+            sessionId: currentSession.backendSessionId,
+          }).catch(() => false);
+          if (isAlive) {
+            sshSessionId.current = currentSession.backendSessionId;
+            const buffer = await invoke<string>("get_terminal_buffer", {
+              sessionId: currentSession.backendSessionId,
+            }).catch(() => "");
+            if (buffer) {
+              restoreBuffer(buffer);
+              writeLine("\x1b[32mRestored terminal buffer from session\x1b[0m");
+            }
+            const existingShellId = await invoke<string | null>(
+              "get_shell_info",
+              { sessionId: currentSession.backendSessionId },
+            ).catch(() => null);
+            if (existingShellId) {
+              dispatch({
+                type: "UPDATE_SESSION",
+                payload: { ...currentSession, shellId: existingShellId },
+              });
+              writeLine("\x1b[32mReattached to existing SSH session\x1b[0m");
+              setStatusState("connected");
+              return;
+            }
+            const shellId = await invoke<string>("reattach_session", {
+              sessionId: currentSession.backendSessionId,
+            });
+            dispatch({
+              type: "UPDATE_SESSION",
+              payload: { ...currentSession, shellId },
+            });
+            writeLine(
+              "\x1b[32mRestarted shell on existing SSH connection\x1b[0m",
+            );
             setStatusState("connected");
             return;
-          }
-          const shellId = await invoke<string>("reattach_session", { sessionId: currentSession.backendSessionId });
-          dispatch({ type: "UPDATE_SESSION", payload: { ...currentSession, shellId } });
-          writeLine("\x1b[32mRestarted shell on existing SSH connection\x1b[0m");
-          setStatusState("connected");
-          return;
-        } else {
-          writeLine("\x1b[33mPrevious session expired, creating new connection...\x1b[0m");
-        }
-      }
-
-      disconnectSsh();
-
-      // ── Resolve chain/tunnel/VPN associations ──
-      let resolved: ResolvedChainConfig | null = null;
-      try {
-        resolved = await resolveChainConfig(currentConnection);
-      } catch (err) {
-        writeLine(`\x1b[33mWarning: Failed to resolve chain config: ${err}\x1b[0m`);
-      }
-
-      // ── Ensure VPN pre-layers are connected ──
-      if (resolved?.vpnPreSteps.length) {
-        writeLine("\x1b[36mEstablishing VPN tunnel(s)...\x1b[0m");
-        for (const step of resolved.vpnPreSteps) {
-          writeLine(`\x1b[90m  Checking ${step.vpnType}: ${step.connectionId}\x1b[0m`);
-          try {
-            const vpnResult = await invoke<{
-              was_already_connected: boolean;
-              is_now_connected: boolean;
-              vpn_type: string;
-              connection_id: string;
-              error: string | null;
-            }>("ensure_vpn_connected", {
-              vpnType: step.vpnType,
-              connectionId: step.connectionId,
-              autoConnect: true,
-            });
-            if (!vpnResult.is_now_connected) {
-              throw new Error(`VPN ${step.vpnType} failed: ${vpnResult.error || "unknown error"}`);
-            }
-            writeLine(
-              vpnResult.was_already_connected
-                ? `\x1b[32m  ${step.vpnType} already connected\x1b[0m`
-                : `\x1b[32m  ${step.vpnType} connected successfully\x1b[0m`
-            );
-          } catch (vpnErr) {
-            writeLine(`\x1b[31m  Failed to establish ${step.vpnType} VPN: ${vpnErr}\x1b[0m`);
-            throw vpnErr;
-          }
-        }
-      }
-
-      const tcpOptions = sshTerminalConfig?.tcpOptions;
-      proxyCommandPassword = sshConnectionConfig.proxyCommandPassword || null;
-
-      unlistenHostKeyPrompt = await listen<SshHostKeyPromptEvent>(
-        "ssh://host-key-prompt",
-        async (event) => {
-          const payload = event.payload;
-          const expectedPort = currentConnection.port || 22;
-          const expectedUsername = currentConnection.username || "";
-          if (
-            payload.host !== currentSession.hostname ||
-            payload.port !== expectedPort ||
-            payload.username !== expectedUsername
-          ) {
-            return;
-          }
-
-          const identity: SshHostKeyIdentity = {
-            fingerprint: payload.fingerprint,
-            keyType: payload.key_type ?? undefined,
-            keyBits: payload.key_bits ?? undefined,
-            firstSeen: new Date().toISOString(),
-            lastSeen: new Date().toISOString(),
-            publicKey: payload.public_key ?? undefined,
-          };
-          setHostKeyIdentity(identity);
-
-          const connectionId = currentConnection.id;
-          const verification = verifyIdentity(
-            currentSession.hostname,
-            expectedPort,
-            "ssh",
-            identity,
-            connectionId,
-          );
-          const isMismatchPrompt = payload.status === "mismatch" || verification.status === "mismatch";
-
-          writeLine(`\x1b[90mHost key fingerprint (SHA-256): ${payload.fingerprint}\x1b[0m`);
-          writeLine(`\x1b[90mKey type: ${payload.key_type ?? "unknown"}\x1b[0m`);
-
-          if (verification.status === "trusted" && !isMismatchPrompt) {
-            writeLine("\x1b[32mHost key matches stored identity\x1b[0m");
-            await invoke("ssh_respond_to_host_key_prompt", {
-              sessionId: payload.session_id,
-              decision: "accept_and_save",
-            });
-            return;
-          }
-
-          if ((verification.status === "first-use" || isMismatchPrompt) && sshTrustPolicy === "strict") {
-            writeLine("\x1b[31mConnection rejected: strict host-key policy requires pre-approved identities\x1b[0m");
-            await invoke("ssh_respond_to_host_key_prompt", {
-              sessionId: payload.session_id,
-              decision: "reject",
-            });
-            return;
-          }
-
-          if (isMismatchPrompt) {
-            writeLine("\x1b[31;1m*** WARNING: HOST KEY HAS CHANGED! ***\x1b[0m");
           } else {
-            writeLine("\x1b[33mNew host key — user confirmation required\x1b[0m");
+            writeLine(
+              "\x1b[33mPrevious session expired, creating new connection...\x1b[0m",
+            );
           }
+        }
 
-          const decision = await new Promise<HostKeyPromptDecision>((resolve) => {
-            sshTrustResolveRef.current = resolve;
-            setSshTrustPrompt(verification);
-          });
+        disconnectSsh();
 
-          if (decision === "accept_and_save") {
-            trustIdentity(
+        // ── Resolve chain/tunnel/VPN associations ──
+        let resolved: ResolvedChainConfig | null = null;
+        try {
+          resolved = await resolveChainConfig(currentConnection);
+        } catch (err) {
+          writeLine(
+            `\x1b[33mWarning: Failed to resolve chain config: ${err}\x1b[0m`,
+          );
+        }
+
+        // ── Ensure VPN pre-layers are connected ──
+        if (resolved?.vpnPreSteps.length) {
+          writeLine("\x1b[36mEstablishing VPN tunnel(s)...\x1b[0m");
+          for (const step of resolved.vpnPreSteps) {
+            writeLine(
+              `\x1b[90m  Checking ${step.vpnType}: ${step.connectionId}\x1b[0m`,
+            );
+            try {
+              const vpnResult = await invoke<{
+                was_already_connected: boolean;
+                is_now_connected: boolean;
+                vpn_type: string;
+                connection_id: string;
+                error: string | null;
+              }>("ensure_vpn_connected", {
+                vpnType: step.vpnType,
+                connectionId: step.connectionId,
+                autoConnect: true,
+              });
+              if (!vpnResult.is_now_connected) {
+                throw new Error(
+                  `VPN ${step.vpnType} failed: ${vpnResult.error || "unknown error"}`,
+                );
+              }
+              writeLine(
+                vpnResult.was_already_connected
+                  ? `\x1b[32m  ${step.vpnType} already connected\x1b[0m`
+                  : `\x1b[32m  ${step.vpnType} connected successfully\x1b[0m`,
+              );
+            } catch (vpnErr) {
+              writeLine(
+                `\x1b[31m  Failed to establish ${step.vpnType} VPN: ${vpnErr}\x1b[0m`,
+              );
+              throw vpnErr;
+            }
+          }
+        }
+
+        const tcpOptions = sshTerminalConfig?.tcpOptions;
+        proxyCommandPassword = sshConnectionConfig.proxyCommandPassword || null;
+
+        unlistenHostKeyPrompt = await listen<SshHostKeyPromptEvent>(
+          "ssh://host-key-prompt",
+          async (event) => {
+            const payload = event.payload;
+            const expectedPort = currentConnection.port || 22;
+            const expectedUsername = currentConnection.username || "";
+            if (
+              payload.host !== currentSession.hostname ||
+              payload.port !== expectedPort ||
+              payload.username !== expectedUsername
+            ) {
+              return;
+            }
+
+            const identity: SshHostKeyIdentity = {
+              fingerprint: payload.fingerprint,
+              keyType: payload.key_type ?? undefined,
+              keyBits: payload.key_bits ?? undefined,
+              firstSeen: new Date().toISOString(),
+              lastSeen: new Date().toISOString(),
+              publicKey: payload.public_key ?? undefined,
+            };
+            setHostKeyIdentity(identity);
+
+            const connectionId = currentConnection.id;
+            const verification = verifyIdentity(
               currentSession.hostname,
               expectedPort,
               "ssh",
               identity,
-              true,
               connectionId,
             );
-            writeLine("\x1b[32mHost key accepted and memorized\x1b[0m");
-          } else if (decision === "accept_once") {
-            writeLine("\x1b[33mHost key accepted for this session only\x1b[0m");
-          } else {
-            writeLine("\x1b[31mConnection aborted by user\x1b[0m");
-          }
+            const isMismatchPrompt =
+              payload.status === "mismatch" ||
+              verification.status === "mismatch";
 
-          await invoke("ssh_respond_to_host_key_prompt", {
-            sessionId: payload.session_id,
-            decision,
-          });
-        },
-      );
+            writeLine(
+              `\x1b[90mHost key fingerprint (SHA-256): ${payload.fingerprint}\x1b[0m`,
+            );
+            writeLine(
+              `\x1b[90mKey type: ${payload.key_type ?? "unknown"}\x1b[0m`,
+            );
 
-      const sshConfig: Record<string, unknown> = {
-        host: currentSession.hostname,
-        port: currentConnection.port || 22,
-        username: currentConnection.username || "",
-        jump_hosts: resolved?.jump_hosts ?? [],
-        proxy_config: resolved?.proxy_config ?? null,
-        proxy_chain: resolved?.proxy_chain ?? null,
-        mixed_chain: resolved?.mixed_chain ?? null,
-        openvpn_config: resolved?.openvpn_config ?? null,
-        connect_timeout: tcpOptions?.connectionTimeout ?? currentConnection.sshConnectTimeout ?? 30,
-        keep_alive_interval: tcpOptions?.tcpKeepAlive ? (tcpOptions?.keepAliveInterval ?? currentConnection.sshKeepAliveInterval ?? 60) : null,
-        strict_host_key_checking: strictHostKeyChecking,
-        known_hosts_path: currentConnection.sshKnownHostsPath || null,
-        tcp_no_delay: tcpOptions?.tcpNoDelay ?? true,
-        tcp_keepalive: tcpOptions?.tcpKeepAlive ?? true,
-        keepalive_probes: tcpOptions?.keepAliveProbes ?? 3,
-        ip_protocol: tcpOptions?.ipProtocol ?? "auto",
-        compression: sshTerminalConfig?.enableCompression ?? false,
-        compression_level: sshTerminalConfig?.compressionLevel ?? 6,
-        ssh_version: sshTerminalConfig?.sshVersion ?? "auto",
-        preferred_ciphers: sshTerminalConfig?.preferredCiphers ?? [],
-        preferred_macs: sshTerminalConfig?.preferredMACs ?? [],
-        preferred_kex: sshTerminalConfig?.preferredKeyExchanges ?? [],
-        preferred_host_key_algorithms: sshTerminalConfig?.preferredHostKeyAlgorithms ?? [],
-
-        // ── Agent forwarding ──
-        agent_forwarding: sshConnectionConfig.agentForwarding ?? false,
-
-        // ── PTY type & environment ──
-        pty_type: sshConnectionConfig.ptyType || null,
-        environment: sshConnectionConfig.environment ?? {},
-
-        // ── X11 forwarding ──
-        x11_forwarding: sshConnectionConfig.enableX11Forwarding
-          ? {
-              enabled: true,
-              trusted: sshConnectionConfig.x11Trusted ?? false,
-              display_offset: sshConnectionConfig.x11DisplayOffset ?? 10,
-              screen: sshConnectionConfig.x11Screen ?? 0,
-              display_override: sshConnectionConfig.x11DisplayOverride || null,
-              xauthority_path: sshConnectionConfig.x11XauthorityPath || null,
-              timeout_secs: sshConnectionConfig.x11TimeoutSecs ?? 0,
+            if (verification.status === "trusted" && !isMismatchPrompt) {
+              writeLine("\x1b[32mHost key matches stored identity\x1b[0m");
+              await invoke("ssh_respond_to_host_key_prompt", {
+                sessionId: payload.session_id,
+                decision: "accept_and_save",
+              });
+              return;
             }
-          : null,
 
-        // ── ProxyCommand ──
-        // Seed command_confirmed from the persisted per-connection flag. An
-        // imported/synced config leaves it false → the backend gate fires and
-        // the catch block below runs the review-and-confirm flow.
-        proxy_command: buildProxyCommandConfig(sshConnectionConfig.proxyCommandConfirmed ?? false),
-      };
+            if (
+              (verification.status === "first-use" || isMismatchPrompt) &&
+              sshTrustPolicy === "strict"
+            ) {
+              writeLine(
+                "\x1b[31mConnection rejected: strict host-key policy requires pre-approved identities\x1b[0m",
+              );
+              await invoke("ssh_respond_to_host_key_prompt", {
+                sessionId: payload.session_id,
+                decision: "reject",
+              });
+              return;
+            }
 
-      switch (authMethod) {
-        case "password":
-          if (!currentConnection.password) throw new Error("Password authentication requires a password");
-          sshPassword = currentConnection.password;
-          sshConfig.password = sshPassword;
-          sshConfig.private_key_path = null;
-          sshConfig.private_key_passphrase = null;
-          break;
-        case "key":
-          if (!currentConnection.privateKey) throw new Error("Key authentication requires a key path");
-          privateKeyPassphrase = currentConnection.passphrase || null;
-          sshConfig.password = null;
-          sshConfig.private_key_path = currentConnection.privateKey;
-          sshConfig.private_key_passphrase = privateKeyPassphrase;
-          break;
-        case "totp":
-          if (!currentConnection.password || !currentConnection.totpSecret) throw new Error("TOTP requires password and TOTP secret");
-          sshPassword = currentConnection.password;
-          totpSecret = currentConnection.totpSecret;
-          sshConfig.password = sshPassword;
-          sshConfig.totp_secret = totpSecret;
-          sshConfig.private_key_path = null;
-          sshConfig.private_key_passphrase = null;
-          break;
-        default:
-          throw new Error(`Unsupported authentication method: ${authMethod}`);
-      }
+            if (isMismatchPrompt) {
+              writeLine(
+                "\x1b[31;1m*** WARNING: HOST KEY HAS CHANGED! ***\x1b[0m",
+              );
+            } else {
+              writeLine(
+                "\x1b[33mNew host key — user confirmation required\x1b[0m",
+              );
+            }
 
-      const sessionId = await invoke<string>("connect_ssh", { config: sshConfig });
-      unlistenHostKeyPrompt?.();
-      unlistenHostKeyPrompt = null;
-      sshSessionId.current = sessionId;
-      dispatch({ type: "UPDATE_SESSION", payload: { ...currentSession, backendSessionId: sessionId } });
-      writeLine("\x1b[32mSSH connection established\x1b[0m");
+            const decision = await new Promise<HostKeyPromptDecision>(
+              (resolve) => {
+                sshTrustResolveRef.current = resolve;
+                setSshTrustPrompt(verification);
+              },
+            );
 
-      const shellId = await invoke<string>("start_shell", { sessionId });
-      dispatch({ type: "UPDATE_SESSION", payload: { ...currentSession, backendSessionId: sessionId, shellId } });
-      writeLine("\x1b[32mShell started successfully\x1b[0m");
-      setStatusState("connected");
+            if (decision === "accept_and_save") {
+              trustIdentity(
+                currentSession.hostname,
+                expectedPort,
+                "ssh",
+                identity,
+                true,
+                connectionId,
+              );
+              writeLine("\x1b[32mHost key accepted and memorized\x1b[0m");
+            } else if (decision === "accept_once") {
+              writeLine(
+                "\x1b[33mHost key accepted for this session only\x1b[0m",
+              );
+            } else {
+              writeLine("\x1b[31mConnection aborted by user\x1b[0m");
+            }
 
-      // Register session with the SSH scripts engine for event-driven scripts
-      invoke("ssh_scripts_register_session", {
-        sessionId,
-        connectionId: currentConnection.id ?? null,
-        host: currentSession.hostname ?? null,
-        username: currentConnection.username ?? null,
-      }).catch(() => {});
+            await invoke("ssh_respond_to_host_key_prompt", {
+              sessionId: payload.session_id,
+              decision,
+            });
+          },
+        );
 
-      // Fire the "connected" lifecycle event
-      invoke("ssh_scripts_notify_event", {
-        event: {
-          sessionId,
-          connectionId: currentConnection.id,
+        const sshConfig: Record<string, unknown> = {
           host: currentSession.hostname,
-          username: currentConnection.username,
           port: currentConnection.port || 22,
-          eventType: "connected",
-          timestamp: new Date().toISOString(),
-        },
-      }).catch(() => {});
-    } catch (err: unknown) {
-      // ── ProxyCommand import-confirmation gate ──
-      // The backend refuses an unconfirmed (imported/synced) ProxyCommand with a
-      // distinct error. This is NOT a normal failure: show the user the exact
-      // (redacted) command, and on approval confirm + persist + retry.
-      const rawErr = typeof err === "string" ? err : err instanceof Error ? err.message : String(err);
-      if (rawErr.startsWith(PROXY_COMMAND_CONFIRMATION_REQUIRED) && hasProxyCommand) {
-        try {
-          unlistenHostKeyPrompt?.();
-          unlistenHostKeyPrompt = null;
-          const proxyConfig = buildProxyCommandConfig(false);
-          const host = currentSession.hostname;
-          const port = currentConnection.port || 22;
-          const username = currentConnection.username || "";
-          // Fetch the exact redacted command for review.
-          const expanded = await invoke<string>("expand_proxy_command", {
-            config: proxyConfig,
-            host,
-            port,
-            username,
-          });
-          writeLine("\x1b[33mThis connection's ProxyCommand has not been confirmed (imported/synced).\x1b[0m");
-          const confirmed = await new Promise<boolean>((resolve) => {
-            proxyCommandResolveRef.current = resolve;
-            setProxyCommandPrompt({ command: expanded });
-          });
-          if (confirmed) {
-            // Record runtime confirmation (fingerprint-scoped) ...
-            await invoke<string>("confirm_proxy_command", {
+          username: currentConnection.username || "",
+          jump_hosts: resolved?.jump_hosts ?? [],
+          proxy_config: resolved?.proxy_config ?? null,
+          proxy_chain: resolved?.proxy_chain ?? null,
+          mixed_chain: resolved?.mixed_chain ?? null,
+          openvpn_config: resolved?.openvpn_config ?? null,
+          connect_timeout:
+            tcpOptions?.connectionTimeout ??
+            currentConnection.sshConnectTimeout ??
+            30,
+          keep_alive_interval: tcpOptions?.tcpKeepAlive
+            ? (tcpOptions?.keepAliveInterval ??
+              currentConnection.sshKeepAliveInterval ??
+              60)
+            : null,
+          strict_host_key_checking: strictHostKeyChecking,
+          known_hosts_path: currentConnection.sshKnownHostsPath || null,
+          tcp_no_delay: tcpOptions?.tcpNoDelay ?? true,
+          tcp_keepalive: tcpOptions?.tcpKeepAlive ?? true,
+          keepalive_probes: tcpOptions?.keepAliveProbes ?? 3,
+          ip_protocol: tcpOptions?.ipProtocol ?? "auto",
+          compression: sshTerminalConfig?.enableCompression ?? false,
+          compression_level: sshTerminalConfig?.compressionLevel ?? 6,
+          ssh_version: sshTerminalConfig?.sshVersion ?? "auto",
+          preferred_ciphers: sshTerminalConfig?.preferredCiphers ?? [],
+          preferred_macs: sshTerminalConfig?.preferredMACs ?? [],
+          preferred_kex: sshTerminalConfig?.preferredKeyExchanges ?? [],
+          preferred_host_key_algorithms:
+            sshTerminalConfig?.preferredHostKeyAlgorithms ?? [],
+
+          // ── Agent forwarding ──
+          agent_forwarding: sshConnectionConfig.agentForwarding ?? false,
+
+          // ── PTY type & environment ──
+          pty_type: sshConnectionConfig.ptyType || null,
+          environment: sshConnectionConfig.environment ?? {},
+
+          // ── X11 forwarding ──
+          x11_forwarding: sshConnectionConfig.enableX11Forwarding
+            ? {
+                enabled: true,
+                trusted: sshConnectionConfig.x11Trusted ?? false,
+                display_offset: sshConnectionConfig.x11DisplayOffset ?? 10,
+                screen: sshConnectionConfig.x11Screen ?? 0,
+                display_override:
+                  sshConnectionConfig.x11DisplayOverride || null,
+                xauthority_path: sshConnectionConfig.x11XauthorityPath || null,
+                timeout_secs: sshConnectionConfig.x11TimeoutSecs ?? 0,
+              }
+            : null,
+
+          // ── ProxyCommand ──
+          // Confirmation is intentionally runtime/fingerprint-scoped. Persisted
+          // or imported booleans must not bypass the review gate for new command
+          // contents.
+          proxy_command: buildProxyCommandConfig(),
+        };
+
+        switch (authMethod) {
+          case "password":
+            if (!currentConnection.password)
+              throw new Error("Password authentication requires a password");
+            sshPassword = currentConnection.password;
+            sshConfig.password = sshPassword;
+            sshConfig.private_key_path = null;
+            sshConfig.private_key_passphrase = null;
+            break;
+          case "key":
+            if (!currentConnection.privateKey)
+              throw new Error("Key authentication requires a key path");
+            privateKeyPassphrase = currentConnection.passphrase || null;
+            sshConfig.password = null;
+            sshConfig.private_key_path = currentConnection.privateKey;
+            sshConfig.private_key_passphrase = privateKeyPassphrase;
+            break;
+          case "totp":
+            if (!currentConnection.password || !currentConnection.totpSecret)
+              throw new Error("TOTP requires password and TOTP secret");
+            sshPassword = currentConnection.password;
+            totpSecret = currentConnection.totpSecret;
+            sshConfig.password = sshPassword;
+            sshConfig.totp_secret = totpSecret;
+            sshConfig.private_key_path = null;
+            sshConfig.private_key_passphrase = null;
+            break;
+          default:
+            throw new Error(`Unsupported authentication method: ${authMethod}`);
+        }
+
+        const sessionId = await invoke<string>("connect_ssh", {
+          config: sshConfig,
+        });
+        unlistenHostKeyPrompt?.();
+        unlistenHostKeyPrompt = null;
+        sshSessionId.current = sessionId;
+        dispatch({
+          type: "UPDATE_SESSION",
+          payload: { ...currentSession, backendSessionId: sessionId },
+        });
+        writeLine("\x1b[32mSSH connection established\x1b[0m");
+
+        const shellId = await invoke<string>("start_shell", { sessionId });
+        dispatch({
+          type: "UPDATE_SESSION",
+          payload: { ...currentSession, backendSessionId: sessionId, shellId },
+        });
+        writeLine("\x1b[32mShell started successfully\x1b[0m");
+        setStatusState("connected");
+
+        // Register session with the SSH scripts engine for event-driven scripts
+        invoke("ssh_scripts_register_session", {
+          sessionId,
+          connectionId: currentConnection.id ?? null,
+          host: currentSession.hostname ?? null,
+          username: currentConnection.username ?? null,
+        }).catch(() => {});
+
+        // Fire the "connected" lifecycle event
+        invoke("ssh_scripts_notify_event", {
+          event: {
+            sessionId,
+            connectionId: currentConnection.id,
+            host: currentSession.hostname,
+            username: currentConnection.username,
+            port: currentConnection.port || 22,
+            eventType: "connected",
+            timestamp: new Date().toISOString(),
+          },
+        }).catch(() => {});
+      } catch (err: unknown) {
+        // ── ProxyCommand import-confirmation gate ──
+        // The backend refuses an unconfirmed (imported/synced) ProxyCommand with a
+        // distinct error. This is NOT a normal failure: show the user the exact
+        // (redacted) command, and on approval confirm + persist + retry.
+        const rawErr =
+          typeof err === "string"
+            ? err
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        if (
+          rawErr.startsWith(PROXY_COMMAND_CONFIRMATION_REQUIRED) &&
+          hasProxyCommand
+        ) {
+          try {
+            unlistenHostKeyPrompt?.();
+            unlistenHostKeyPrompt = null;
+            const proxyConfig = buildProxyCommandConfig();
+            const host = currentSession.hostname;
+            const port = currentConnection.port || 22;
+            const username = currentConnection.username || "";
+            // Fetch the exact redacted command for review.
+            const expanded = await invoke<string>("expand_proxy_command", {
               config: proxyConfig,
               host,
               port,
               username,
             });
-            // ... and persist a durable flag on the stored connection so the
-            // backend's in-memory registry isn't required after a restart.
-            if (currentConnection) {
-              dispatch({
-                type: "UPDATE_CONNECTION",
-                payload: {
-                  ...currentConnection,
-                  sshConnectionConfigOverride: {
-                    ...(currentConnection.sshConnectionConfigOverride ?? {}),
-                    proxyCommandConfirmed: true,
-                  },
-                },
+            writeLine(
+              "\x1b[33mThis connection's ProxyCommand has not been confirmed (imported/synced).\x1b[0m",
+            );
+            const confirmed = await new Promise<boolean>((resolve) => {
+              proxyCommandResolveRef.current = resolve;
+              setProxyCommandPrompt({ command: expanded });
+            });
+            if (confirmed) {
+              // Record runtime confirmation (fingerprint-scoped) ...
+              await invoke<string>("confirm_proxy_command", {
+                config: proxyConfig,
+                host,
+                port,
+                username,
               });
+              writeLine(
+                "\x1b[32mProxyCommand confirmed — retrying connection...\x1b[0m",
+              );
+              isConnecting.current = false;
+              // Retry; the gate is now cleared (runtime fingerprint confirmation).
+              await initSshRef.current(true);
+              return;
             }
-            writeLine("\x1b[32mProxyCommand confirmed — retrying connection...\x1b[0m");
-            isConnecting.current = false;
-            // Retry; the gate is now cleared (runtime confirmation + persisted flag).
-            await initSshRef.current(true);
+            // Declined: abort gracefully, do not execute the command.
+            writeLine(
+              "\x1b[31mProxyCommand not confirmed — connection aborted.\x1b[0m",
+            );
+            setStatusState("error");
+            setError("ProxyCommand not confirmed — connection aborted");
             return;
+          } catch (gateErr) {
+            console.error("ProxyCommand confirmation flow failed:", gateErr);
+            // fall through to normal error handling below
+          } finally {
+            proxyCommandResolveRef.current = null;
+            setProxyCommandPrompt(null);
           }
-          // Declined: abort gracefully, do not execute the command.
-          writeLine("\x1b[31mProxyCommand not confirmed — connection aborted.\x1b[0m");
-          setStatusState("error");
-          setError("ProxyCommand not confirmed — connection aborted");
-          return;
-        } catch (gateErr) {
-          console.error("ProxyCommand confirmation flow failed:", gateErr);
-          // fall through to normal error handling below
-        } finally {
-          proxyCommandResolveRef.current = null;
-          setProxyCommandPrompt(null);
         }
+        const details = formatErrorDetails(err);
+        const classification = classifySshError(details.message);
+        console.error("SSH connection failed:", {
+          kind: classification.kind,
+          message: details.message,
+          name: details.name,
+          stack: details.stack,
+        });
+        setStatusState("error");
+        setError(classification.friendly);
+        writeLine(`\x1b[31m${classification.friendly}\x1b[0m`);
+        writeLine(`\x1b[90mFailure reason: ${classification.kind}\x1b[0m`);
+        writeLine(`\x1b[90mRaw error: ${details.message}\x1b[0m`);
+      } finally {
+        sshPassword = null;
+        privateKeyPassphrase = null;
+        totpSecret = null;
+        proxyCommandPassword = null;
+        isConnecting.current = false;
+        unlistenHostKeyPrompt?.();
+        sshTrustResolveRef.current = null;
       }
-      const details = formatErrorDetails(err);
-      const classification = classifySshError(details.message);
-      console.error("SSH connection failed:", { kind: classification.kind, message: details.message, name: details.name, stack: details.stack });
-      setStatusState("error");
-      setError(classification.friendly);
-      writeLine(`\x1b[31m${classification.friendly}\x1b[0m`);
-      writeLine(`\x1b[90mFailure reason: ${classification.kind}\x1b[0m`);
-      writeLine(`\x1b[90mRaw error: ${details.message}\x1b[0m`);
-    } finally {
-      sshPassword = null;
-      privateKeyPassphrase = null;
-      totpSecret = null;
-      proxyCommandPassword = null;
-      isConnecting.current = false;
-      unlistenHostKeyPrompt?.();
-      sshTrustResolveRef.current = null;
-    }
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- all used functions are listed; refs read at call time
-  [classifySshError, disconnectSsh, formatErrorDetails, isSsh, dispatch, restoreBuffer, setStatusState, writeLine]);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- all used functions are listed; refs read at call time
+    [
+      classifySshError,
+      disconnectSsh,
+      formatErrorDetails,
+      isSsh,
+      dispatch,
+      restoreBuffer,
+      setStatusState,
+      writeLine,
+    ],
+  );
 
   // Self-ref so the ProxyCommand confirm flow can retry the connection after
   // the user approves the imported command (avoids a useCallback self-cycle).
   const initSshRef = useRef(initSsh);
-  useEffect(() => { initSshRef.current = initSsh; }, [initSsh]);
+  useEffect(() => {
+    initSshRef.current = initSsh;
+  }, [initSsh]);
 
   /* ── Input handling ── */
 
-  const handleInput = useCallback(async (data: string) => {
-    if (!termRef.current || isDisposed.current) return;
-    if (isSsh) {
-      if (!sshSessionId.current || !isSshReady.current || isConnecting.current) return;
-      if (macroRecorder.isRecording) macroRecorder.recordInput(data);
-      try { await invoke("send_ssh_input", { sessionId: sshSessionId.current, data }); } catch (err) {
-        console.error("Failed to send SSH input:", err);
+  const handleInput = useCallback(
+    async (data: string) => {
+      if (!termRef.current || isDisposed.current) return;
+      if (isSsh) {
+        if (
+          !sshSessionId.current ||
+          !isSshReady.current ||
+          isConnecting.current
+        )
+          return;
+        if (macroRecorder.isRecording) macroRecorder.recordInput(data);
+        try {
+          await invoke("send_ssh_input", {
+            sessionId: sshSessionId.current,
+            data,
+          });
+        } catch (err) {
+          console.error("Failed to send SSH input:", err);
+        }
+        return;
       }
-      return;
-    }
-    safeWrite(data);
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- macroRecorder accessed via ref pattern, safeWrite is memoized
-  }, [isSsh, safeWrite]);
+      safeWrite(data);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- macroRecorder accessed via ref pattern, safeWrite is memoized
+    },
+    [isSsh, safeWrite],
+  );
 
   /* ── Run script ── */
 
-  const runScript = useCallback(async (script: ManagedScript) => {
-    if (!isSsh || !sshSessionId.current || !isSshReady.current || isConnecting.current) return;
-    try {
-      const lines = script.script.split("\n").filter((line) => !line.startsWith("#!"));
-      const command = lines.join("\n");
-      const isSingleLine = lines.length === 1;
+  const runScript = useCallback(
+    async (script: ManagedScript) => {
+      if (
+        !isSsh ||
+        !sshSessionId.current ||
+        !isSshReady.current ||
+        isConnecting.current
+      )
+        return;
+      try {
+        const lines = script.script
+          .split("\n")
+          .filter((line) => !line.startsWith("#!"));
+        const command = lines.join("\n");
+        const isSingleLine = lines.length === 1;
 
-      if (isSingleLine) {
-        // Single-line: pipe directly into the shell
-        await invoke("send_ssh_input", { sessionId: sshSessionId.current, data: command + "\n" });
-      } else {
-        // Multi-line: upload as temp file on the remote server, execute, capture output, clean up
-        const interpreter = script.language === "powershell" ? "powershell"
-          : script.language === "sh" ? "sh"
-          : "bash";
-
-        try {
-          const result = await invoke<{ stdout: string; stderr: string; exitCode: number }>("execute_script", {
+        if (isSingleLine) {
+          // Single-line: pipe directly into the shell
+          await invoke("send_ssh_input", {
             sessionId: sshSessionId.current,
-            script: command,
-            interpreter,
+            data: command + "\n",
           });
-          const term = termRef.current;
-          if (term) {
-            term.write(`\r\n\x1b[90m── Script: ${script.name} ──\x1b[0m\r\n`);
-            if (result.stdout) {
-              for (const line of result.stdout.split("\n")) {
-                term.write(line + "\r\n");
+        } else {
+          // Multi-line: upload as temp file on the remote server, execute, capture output, clean up
+          const interpreter =
+            script.language === "powershell"
+              ? "powershell"
+              : script.language === "sh"
+                ? "sh"
+                : "bash";
+
+          try {
+            const result = await invoke<{
+              stdout: string;
+              stderr: string;
+              exitCode: number;
+            }>("execute_script", {
+              sessionId: sshSessionId.current,
+              script: command,
+              interpreter,
+            });
+            const term = termRef.current;
+            if (term) {
+              term.write(`\r\n\x1b[90m── Script: ${script.name} ──\x1b[0m\r\n`);
+              if (result.stdout) {
+                for (const line of result.stdout.split("\n")) {
+                  term.write(line + "\r\n");
+                }
               }
+              if (result.stderr) {
+                term.write(`\x1b[31m${result.stderr}\x1b[0m\r\n`);
+              }
+              const codeColor = result.exitCode === 0 ? "32" : "31";
+              term.write(
+                `\x1b[90m── Exit: \x1b[${codeColor}m${result.exitCode}\x1b[90m ──\x1b[0m\r\n`,
+              );
             }
-            if (result.stderr) {
-              term.write(`\x1b[31m${result.stderr}\x1b[0m\r\n`);
-            }
-            const codeColor = result.exitCode === 0 ? "32" : "31";
-            term.write(`\x1b[90m── Exit: \x1b[${codeColor}m${result.exitCode}\x1b[90m ──\x1b[0m\r\n`);
+          } catch (execErr) {
+            // Fall back to shell piping if execute_script fails
+            console.warn(
+              "execute_script failed, falling back to shell piping:",
+              execErr,
+            );
+            await invoke("send_ssh_input", {
+              sessionId: sshSessionId.current,
+              data: command + "\n",
+            });
           }
-        } catch (execErr) {
-          // Fall back to shell piping if execute_script fails
-          console.warn("execute_script failed, falling back to shell piping:", execErr);
-          await invoke("send_ssh_input", { sessionId: sshSessionId.current, data: command + "\n" });
         }
+        closeScriptSelector();
+      } catch (err) {
+        console.error("Failed to run script:", err);
       }
-      closeScriptSelector();
-    } catch (err) {
-      console.error("Failed to run script:", err);
-    }
-  }, [isSsh, closeScriptSelector]);
+    },
+    [isSsh, closeScriptSelector],
+  );
 
   /* ──────────────────────────────────────────────────────────────
    * Terminal creation & lifecycle effect
@@ -983,12 +1277,22 @@ export function useWebTerminal(
 
     isDisposed.current = false;
 
-    const fontFamily = sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.family
-      ? sshTerminalConfig.font.family
-      : '"Cascadia Code", "Fira Code", Menlo, Monaco, "Ubuntu Mono", "Courier New", monospace';
-    const fontSize = sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.size ? sshTerminalConfig.font.size : 13;
-    const lineHeight = sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.lineHeight ? sshTerminalConfig.font.lineHeight : 1.25;
-    const letterSpacing = sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.letterSpacing ? sshTerminalConfig.font.letterSpacing : 0;
+    const fontFamily =
+      sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.family
+        ? sshTerminalConfig.font.family
+        : '"Cascadia Code", "Fira Code", Menlo, Monaco, "Ubuntu Mono", "Courier New", monospace';
+    const fontSize =
+      sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.size
+        ? sshTerminalConfig.font.size
+        : 13;
+    const lineHeight =
+      sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.lineHeight
+        ? sshTerminalConfig.font.lineHeight
+        : 1.25;
+    const letterSpacing =
+      sshTerminalConfig?.useCustomFont && sshTerminalConfig?.font?.letterSpacing
+        ? sshTerminalConfig.font.letterSpacing
+        : 0;
     const scrollbackLines = sshTerminalConfig?.scrollbackLines ?? 10000;
     const wordSeparator = sshTerminalConfig?.wordSeparators ?? " \t";
     const dimensionOptions = sshTerminalConfig?.useCustomDimensions
@@ -1009,7 +1313,7 @@ export function useWebTerminal(
       altClickMovesCursor: false,
       macOptionIsMeta: true,
       disableStdin: false,
-      wordSeparator: wordSeparator || ' ()[]{}\'":;,.<>~!@#$%^&*|+=`',
+      wordSeparator: wordSeparator || " ()[]{}'\":;,.<>~!@#$%^&*|+=`",
       scrollOnUserInput: sshTerminalConfig?.scrollOnKeystroke ?? true,
       ...dimensionOptions,
       allowProposedApi: true,
@@ -1032,11 +1336,22 @@ export function useWebTerminal(
       if (overuseProtection?.enabled) {
         bellCount++;
         if (bellResetTimer) clearTimeout(bellResetTimer);
-        bellResetTimer = setTimeout(() => { bellCount = 0; }, (overuseProtection.timeWindowSeconds ?? 2) * 1000);
+        bellResetTimer = setTimeout(
+          () => {
+            bellCount = 0;
+          },
+          (overuseProtection.timeWindowSeconds ?? 2) * 1000,
+        );
         if (bellCount > (overuseProtection.maxBells ?? 5)) {
           if (!bellSilenced) {
             bellSilenced = true;
-            bellSilenceTimer = setTimeout(() => { bellSilenced = false; bellCount = 0; }, (overuseProtection.silenceDurationSeconds ?? 5) * 1000);
+            bellSilenceTimer = setTimeout(
+              () => {
+                bellSilenced = false;
+                bellCount = 0;
+              },
+              (overuseProtection.silenceDurationSeconds ?? 5) * 1000,
+            );
           }
           return;
         }
@@ -1045,21 +1360,33 @@ export function useWebTerminal(
       if (bellSilenced) return;
 
       switch (bellStyle) {
-        case "none": break;
+        case "none":
+          break;
         case "system":
           try {
-            const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+            const audioCtx = new (
+              window.AudioContext || (window as any).webkitAudioContext
+            )();
             const osc = audioCtx.createOscillator();
             const gain = audioCtx.createGain();
-            osc.connect(gain); gain.connect(audioCtx.destination);
-            osc.frequency.value = 800; osc.type = "sine"; gain.gain.value = 0.1;
-            osc.start(); osc.stop(audioCtx.currentTime + 0.1);
-          } catch { /* audio not available */ }
+            osc.connect(gain);
+            gain.connect(audioCtx.destination);
+            osc.frequency.value = 800;
+            osc.type = "sine";
+            gain.gain.value = 0.1;
+            osc.start();
+            osc.stop(audioCtx.currentTime + 0.1);
+          } catch {
+            /* audio not available */
+          }
           break;
         case "visual":
           if (containerRef.current) {
             containerRef.current.style.backgroundColor = "#ff0";
-            setTimeout(() => { if (containerRef.current) containerRef.current.style.backgroundColor = ""; }, 100);
+            setTimeout(() => {
+              if (containerRef.current)
+                containerRef.current.style.backgroundColor = "";
+            }, 100);
           }
           break;
         case "flash-window":
@@ -1067,13 +1394,21 @@ export function useWebTerminal(
           break;
         case "pc-speaker":
           try {
-            const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+            const audioCtx = new (
+              window.AudioContext || (window as any).webkitAudioContext
+            )();
             const osc = audioCtx.createOscillator();
             const gain = audioCtx.createGain();
-            osc.connect(gain); gain.connect(audioCtx.destination);
-            osc.frequency.value = 1000; osc.type = "square"; gain.gain.value = 0.05;
-            osc.start(); osc.stop(audioCtx.currentTime + 0.05);
-          } catch { /* fallback */ }
+            osc.connect(gain);
+            gain.connect(audioCtx.destination);
+            osc.frequency.value = 1000;
+            osc.type = "square";
+            gain.gain.value = 0.05;
+            osc.start();
+            osc.stop(audioCtx.currentTime + 0.05);
+          } catch {
+            /* fallback */
+          }
           break;
       }
 
@@ -1088,7 +1423,9 @@ export function useWebTerminal(
       try {
         term.open(container);
         if (container.isConnected && !isDisposed.current) term.focus();
-      } catch (err) { console.warn("Failed to open terminal:", err); }
+      } catch (err) {
+        console.warn("Failed to open terminal:", err);
+      }
     });
 
     termRef.current = term;
@@ -1104,23 +1441,35 @@ export function useWebTerminal(
       const renderService = core?.renderService ?? core?._renderService;
       if (!renderService?.dimensions) return false;
       const dims = renderService.dimensions;
-      return typeof dims.css?.cell?.width === "number" && dims.css?.cell?.width > 0;
+      return (
+        typeof dims.css?.cell?.width === "number" && dims.css?.cell?.width > 0
+      );
     };
 
     const doFit = () => {
       if (isDisposed.current || !fitRef.current || !termRef.current) return;
-      if (!container.isConnected || !termRef.current.element?.isConnected) return;
+      if (!container.isConnected || !termRef.current.element?.isConnected)
+        return;
       if (!canFit()) {
-        if (initRetryCount < maxInitRetries) { initRetryCount++; setTimeout(doFit, 50); }
+        if (initRetryCount < maxInitRetries) {
+          initRetryCount++;
+          setTimeout(doFit, 50);
+        }
         return;
       }
       try {
         fitRef.current.fit();
         onResize?.(termRef.current.cols, termRef.current.rows);
         if (isSsh && sshSessionId.current) {
-          invoke("resize_ssh_shell", { sessionId: sshSessionId.current, cols: termRef.current.cols, rows: termRef.current.rows }).catch(() => undefined);
+          invoke("resize_ssh_shell", {
+            sessionId: sshSessionId.current,
+            cols: termRef.current.cols,
+            rows: termRef.current.rows,
+          }).catch(() => undefined);
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     };
 
     const scheduleFit = () => {
@@ -1131,7 +1480,10 @@ export function useWebTerminal(
 
     const resizeTimer = setTimeout(scheduleFit, 50);
     window.addEventListener("resize", scheduleFit);
-    const resizeObserver = typeof ResizeObserver !== "undefined" ? new ResizeObserver(scheduleFit) : null;
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(scheduleFit)
+        : null;
     resizeObserver?.observe(container);
 
     const dataDisposable = term.onData(handleInput);
@@ -1142,41 +1494,66 @@ export function useWebTerminal(
     const BATCH_INTERVAL_MS = 8;
 
     const flushOutputBuffer = () => {
-      if (outputBuffer.length === 0 || isDisposed.current || !termRef.current) { flushScheduled = false; return; }
+      if (outputBuffer.length === 0 || isDisposed.current || !termRef.current) {
+        flushScheduled = false;
+        return;
+      }
       const data = outputBuffer.join("");
       outputBuffer = [];
       flushScheduled = false;
       safeWrite(data);
     };
 
-    const scheduleFlush = () => { if (!flushScheduled) { flushScheduled = true; setTimeout(flushOutputBuffer, BATCH_INTERVAL_MS); } };
+    const scheduleFlush = () => {
+      if (!flushScheduled) {
+        flushScheduled = true;
+        setTimeout(flushOutputBuffer, BATCH_INTERVAL_MS);
+      }
+    };
 
     const attachListeners = async () => {
       if (!isSsh) return;
       try {
-        const unlistenOutput = await listen<SshOutputEvent>("ssh-output", (event) => {
-          if (event.payload.session_id !== sshSessionId.current) return;
-          outputBuffer.push(event.payload.data);
-          scheduleFlush();
-          // Blink window when output arrives and window is not focused
-          if (sshTerminalConfig?.blinkWindowOnActivity && document.visibilityState === 'hidden') {
-            invoke("flash_window").catch(() => {});
-          }
-        });
-        if (!cancelled) outputUnlistenRef.current = unlistenOutput; else unlistenOutput();
+        const unlistenOutput = await listen<SshOutputEvent>(
+          "ssh-output",
+          (event) => {
+            if (event.payload.session_id !== sshSessionId.current) return;
+            outputBuffer.push(event.payload.data);
+            scheduleFlush();
+            // Blink window when output arrives and window is not focused
+            if (
+              sshTerminalConfig?.blinkWindowOnActivity &&
+              document.visibilityState === "hidden"
+            ) {
+              invoke("flash_window").catch(() => {});
+            }
+          },
+        );
+        if (!cancelled) outputUnlistenRef.current = unlistenOutput;
+        else unlistenOutput();
 
-        const unlistenError = await listen<SshErrorEvent>("ssh-error", (event) => {
-          if (event.payload.session_id !== sshSessionId.current) return;
-          safeWriteln(`\r\n\x1b[31mSSH error: ${event.payload.message}\x1b[0m`);
-        });
-        if (!cancelled) errorUnlistenRef.current = unlistenError; else unlistenError();
+        const unlistenError = await listen<SshErrorEvent>(
+          "ssh-error",
+          (event) => {
+            if (event.payload.session_id !== sshSessionId.current) return;
+            safeWriteln(
+              `\r\n\x1b[31mSSH error: ${event.payload.message}\x1b[0m`,
+            );
+          },
+        );
+        if (!cancelled) errorUnlistenRef.current = unlistenError;
+        else unlistenError();
 
-        const unlistenClosed = await listen<SshClosedEvent>("ssh-shell-closed", (event) => {
-          if (event.payload.session_id !== sshSessionId.current) return;
-          setStatusState("error");
-          setError("Shell closed");
-        });
-        if (!cancelled) closeUnlistenRef.current = unlistenClosed; else unlistenClosed();
+        const unlistenClosed = await listen<SshClosedEvent>(
+          "ssh-shell-closed",
+          (event) => {
+            if (event.payload.session_id !== sshSessionId.current) return;
+            setStatusState("error");
+            setError("Shell closed");
+          },
+        );
+        if (!cancelled) closeUnlistenRef.current = unlistenClosed;
+        else unlistenClosed();
       } catch (error) {
         console.error("Failed to attach SSH listeners:", error);
       }
@@ -1188,7 +1565,9 @@ export function useWebTerminal(
       initSsh();
     } else {
       const s = sessionRef.current;
-      safeWriteln(`\x1b[32mTerminal ready for ${s.protocol.toUpperCase()} session\x1b[0m`);
+      safeWriteln(
+        `\x1b[32mTerminal ready for ${s.protocol.toUpperCase()} session\x1b[0m`,
+      );
       safeWriteln(`\x1b[36mConnected to: ${s.hostname}\x1b[0m`);
       setStatusState("connected");
     }
@@ -1204,22 +1583,45 @@ export function useWebTerminal(
       window.removeEventListener("resize", scheduleFit);
       resizeObserver?.disconnect();
       dataDisposable.dispose();
-      outputUnlistenRef.current?.(); errorUnlistenRef.current?.(); closeUnlistenRef.current?.();
-      outputUnlistenRef.current = null; errorUnlistenRef.current = null; closeUnlistenRef.current = null;
-      requestAnimationFrame(() => { try { term.dispose(); } catch { /* ignore */ } });
+      outputUnlistenRef.current?.();
+      errorUnlistenRef.current?.();
+      closeUnlistenRef.current?.();
+      outputUnlistenRef.current = null;
+      errorUnlistenRef.current = null;
+      closeUnlistenRef.current = null;
+      requestAnimationFrame(() => {
+        try {
+          term.dispose();
+        } catch {
+          /* ignore */
+        }
+      });
       termRef.current = null;
       fitRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- re-init terminal when session changes; callbacks are memoized
-  }, [getTerminalTheme, handleInput, initSsh, isSsh, onResize, session.id, safeWrite, safeWriteln, setStatusState]);
+  }, [
+    getTerminalTheme,
+    handleInput,
+    initSsh,
+    isSsh,
+    onResize,
+    session.id,
+    safeWrite,
+    safeWriteln,
+    setStatusState,
+  ]);
 
   /* ── Apply theme on settings change ── */
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const handleSettingsUpdate = () => { applyTerminalTheme(); };
+    const handleSettingsUpdate = () => {
+      applyTerminalTheme();
+    };
     window.addEventListener("settings-updated", handleSettingsUpdate);
-    return () => window.removeEventListener("settings-updated", handleSettingsUpdate);
+    return () =>
+      window.removeEventListener("settings-updated", handleSettingsUpdate);
   }, [applyTerminalTheme]);
 
   /* ── Simple actions ── */
@@ -1230,7 +1632,11 @@ export function useWebTerminal(
     const core = (termRef.current as any)?._core;
     const renderService = core?.renderService ?? core?._renderService;
     if (!renderService?.dimensions) return;
-    try { fitRef.current.fit(); } catch { /* ignore */ }
+    try {
+      fitRef.current.fit();
+    } catch {
+      /* ignore */
+    }
   }, []);
 
   const toggleFullscreen = useCallback(() => {
@@ -1244,7 +1650,14 @@ export function useWebTerminal(
     disconnectSsh();
     const currentSession = sessionRef.current;
     if (currentSession.backendSessionId || currentSession.shellId) {
-      dispatch({ type: "UPDATE_SESSION", payload: { ...currentSession, backendSessionId: undefined, shellId: undefined } });
+      dispatch({
+        type: "UPDATE_SESSION",
+        payload: {
+          ...currentSession,
+          backendSessionId: undefined,
+          shellId: undefined,
+        },
+      });
     }
     await initSsh(true);
     setTimeout(() => safeFit(), 80);
@@ -1252,13 +1665,18 @@ export function useWebTerminal(
 
   const clearTerminal = useCallback(() => {
     if (!termRef.current || !canRender()) return;
-    try { termRef.current.clear(); } catch { /* ignore */ }
+    try {
+      termRef.current.clear();
+    } catch {
+      /* ignore */
+    }
   }, [canRender]);
 
   const copySelection = useCallback(() => {
     const selection = termRef.current?.getSelection();
     if (!selection) return;
-    navigator.clipboard.writeText(selection)
+    navigator.clipboard
+      .writeText(selection)
       .then(() => toast.success("Copied to clipboard", 2000))
       .catch(() => toast.error("Failed to copy to clipboard", 2000));
   }, [toast]);
@@ -1274,7 +1692,12 @@ export function useWebTerminal(
 
   const sendCancel = useCallback(async () => {
     if (!isSsh || !sshSessionId.current || !isSshReady.current) return;
-    try { await invoke("send_ssh_input", { sessionId: sshSessionId.current, data: "\x03" }); } catch (err) {
+    try {
+      await invoke("send_ssh_input", {
+        sessionId: sshSessionId.current,
+        data: "\x03",
+      });
+    } catch (err) {
       console.error("Failed to send Ctrl+C:", err);
     }
   }, [isSsh]);
@@ -1287,7 +1710,12 @@ export function useWebTerminal(
     const cols = fit ? (fit.proposeDimensions()?.cols ?? 80) : 80;
     const rows = fit ? (fit.proposeDimensions()?.rows ?? 24) : 24;
     try {
-      await terminalRecorder.startRecording(sshSessionId.current, settings.recording?.recordInput ?? false, cols, rows);
+      await terminalRecorder.startRecording(
+        sshSessionId.current,
+        settings.recording?.recordInput ?? false,
+        cols,
+        rows,
+      );
     } catch (err) {
       console.error("Failed to start recording:", err);
     }
@@ -1295,44 +1723,70 @@ export function useWebTerminal(
 
   const handleStopRecording = useCallback(async () => {
     if (!sshSessionId.current) return;
-    const recording = await terminalRecorder.stopRecording(sshSessionId.current);
+    const recording = await terminalRecorder.stopRecording(
+      sshSessionId.current,
+    );
     if (recording) {
       const name = `${session.hostname} - ${new Date().toLocaleString()}`;
-      const saved: SavedRecording = { id: crypto.randomUUID(), name, recording, savedAt: new Date().toISOString(), connectionId: session.connectionId };
+      const saved: SavedRecording = {
+        id: crypto.randomUUID(),
+        name,
+        recording,
+        savedAt: new Date().toISOString(),
+        connectionId: session.connectionId,
+      };
       await macroService.saveRecording(saved);
     }
   }, [terminalRecorder, session.hostname, session.connectionId]);
 
   /* ── Macro handlers ── */
 
-  const handleStartMacroRecording = useCallback(() => { macroRecorder.startRecording(); }, [macroRecorder]);
+  const handleStartMacroRecording = useCallback(() => {
+    macroRecorder.startRecording();
+  }, [macroRecorder]);
 
   const handleStopMacroRecording = useCallback(async () => {
     const steps = macroRecorder.stopRecording();
     if (steps.length > 0) {
-      const macro: TerminalMacro = { id: crypto.randomUUID(), name: `Macro - ${new Date().toLocaleString()}`, steps, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+      const macro: TerminalMacro = {
+        id: crypto.randomUUID(),
+        name: `Macro - ${new Date().toLocaleString()}`,
+        steps,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
       await macroService.saveMacro(macro);
       setSavedMacros(await macroService.loadMacros());
     }
   }, [macroRecorder]);
 
-  const handleReplayMacro = useCallback(async (macro: TerminalMacro) => {
-    if (!sshSessionId.current || replayingMacro) return;
-    setShowMacroList(false);
-    setReplayingMacro(true);
-    const controller = new AbortController();
-    replayAbortRef.current = controller;
-    try {
-      await macroService.replayMacro(sshSessionId.current, macro, undefined, controller.signal);
-    } catch (err) {
-      console.error("Macro replay failed:", err);
-    } finally {
-      setReplayingMacro(false);
-      replayAbortRef.current = null;
-    }
-  }, [replayingMacro]);
+  const handleReplayMacro = useCallback(
+    async (macro: TerminalMacro) => {
+      if (!sshSessionId.current || replayingMacro) return;
+      setShowMacroList(false);
+      setReplayingMacro(true);
+      const controller = new AbortController();
+      replayAbortRef.current = controller;
+      try {
+        await macroService.replayMacro(
+          sshSessionId.current,
+          macro,
+          undefined,
+          controller.signal,
+        );
+      } catch (err) {
+        console.error("Macro replay failed:", err);
+      } finally {
+        setReplayingMacro(false);
+        replayAbortRef.current = null;
+      }
+    },
+    [replayingMacro],
+  );
 
-  const handleStopReplay = useCallback(() => { replayAbortRef.current?.abort(); }, []);
+  const handleStopReplay = useCallback(() => {
+    replayAbortRef.current?.abort();
+  }, []);
 
   useEffect(() => {
     if (showMacroList) macroService.loadMacros().then(setSavedMacros);
@@ -1342,18 +1796,29 @@ export function useWebTerminal(
 
   const totpConfigs = connection?.totpConfigs ?? [];
 
-  const handleUpdateTotpConfigs = useCallback((configs: TOTPConfig[]) => {
-    if (connection) dispatch({ type: "UPDATE_CONNECTION", payload: { ...connection, totpConfigs: configs } });
-  }, [connection, dispatch]);
+  const handleUpdateTotpConfigs = useCallback(
+    (configs: TOTPConfig[]) => {
+      if (connection)
+        dispatch({
+          type: "UPDATE_CONNECTION",
+          payload: { ...connection, totpConfigs: configs },
+        });
+    },
+    [connection, dispatch],
+  );
 
   /* ── Computed ── */
 
   const statusToneClass = useMemo(() => {
     switch (status) {
-      case "connected": return "app-badge--success";
-      case "connecting": return "app-badge--warning";
-      case "error": return "app-badge--error";
-      default: return "app-badge--neutral";
+      case "connected":
+        return "app-badge--success";
+      case "connecting":
+        return "app-badge--warning";
+      case "error":
+        return "app-badge--error";
+      default:
+        return "app-badge--neutral";
     }
   }, [status]);
 

--- a/src/types/ssh/sshSettings.ts
+++ b/src/types/ssh/sshSettings.ts
@@ -1,39 +1,23 @@
 // SSH Terminal Simulation Configuration Types
 export const BellStyles = [
-  'none',
-  'system',
-  'visual',
-  'flash-window',
-  'pc-speaker',
+  "none",
+  "system",
+  "visual",
+  "flash-window",
+  "pc-speaker",
 ] as const;
 export type BellStyle = (typeof BellStyles)[number];
 
-export const TaskbarFlashModes = [
-  'disabled',
-  'flashing',
-  'steady',
-] as const;
+export const TaskbarFlashModes = ["disabled", "flashing", "steady"] as const;
 export type TaskbarFlashMode = (typeof TaskbarFlashModes)[number];
 
-export const LocalEchoModes = [
-  'auto',
-  'on',
-  'off',
-] as const;
+export const LocalEchoModes = ["auto", "on", "off"] as const;
 export type LocalEchoMode = (typeof LocalEchoModes)[number];
 
-export const LineEditingModes = [
-  'auto',
-  'on',
-  'off',
-] as const;
+export const LineEditingModes = ["auto", "on", "off"] as const;
 export type LineEditingMode = (typeof LineEditingModes)[number];
 
-export const IPProtocols = [
-  'auto',
-  'ipv4',
-  'ipv6',
-] as const;
+export const IPProtocols = ["auto", "ipv4", "ipv6"] as const;
 export type IPProtocol = (typeof IPProtocols)[number];
 
 // ===================================
@@ -43,15 +27,15 @@ export type IPProtocol = (typeof IPProtocols)[number];
 /** Compression algorithms supported by the SSH transport layer (RFC 4253). */
 export const SshCompressionAlgorithms = [
   /** No compression — raw data transfer */
-  'none',
+  "none",
   /** Standard zlib compression (RFC 1950) — compresses from session start */
-  'zlib',
+  "zlib",
   /** Delayed zlib — compression activates only after user authentication.
    *  More secure than plain `zlib` (mitigates pre-auth exploits). */
-  'zlib_openssh',
+  "zlib_openssh",
   /** Automatically negotiate the best available algorithm.
    *  Preference order: zlib@openssh.com > zlib > none */
-  'auto',
+  "auto",
 ] as const;
 export type SshCompressionAlgorithm = (typeof SshCompressionAlgorithms)[number];
 
@@ -80,11 +64,35 @@ export const defaultAdaptiveCompression: SshAdaptiveCompression = {
   minPayloadBytes: 256,
   ratioThreshold: 0.9,
   incompressibleExtensions: [
-    'gz', 'bz2', 'xz', 'zst', 'lz4', 'lzma', 'zip', '7z', 'rar',
-    'tar.gz', 'tar.bz2', 'tar.xz', 'tgz',
-    'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif',
-    'mp3', 'mp4', 'mkv', 'avi', 'flac', 'ogg', 'webm',
-    'pdf', 'docx', 'xlsx',
+    "gz",
+    "bz2",
+    "xz",
+    "zst",
+    "lz4",
+    "lzma",
+    "zip",
+    "7z",
+    "rar",
+    "tar.gz",
+    "tar.bz2",
+    "tar.xz",
+    "tgz",
+    "jpg",
+    "jpeg",
+    "png",
+    "gif",
+    "webp",
+    "avif",
+    "mp3",
+    "mp4",
+    "mkv",
+    "avi",
+    "flac",
+    "ogg",
+    "webm",
+    "pdf",
+    "docx",
+    "xlsx",
   ],
 };
 
@@ -111,7 +119,7 @@ export interface SshCompressionConfig {
 
 export const defaultCompressionConfig: SshCompressionConfig = {
   enabled: false,
-  algorithm: 'auto',
+  algorithm: "auto",
   level: 6,
   clientToServer: undefined,
   serverToClient: undefined,
@@ -144,92 +152,87 @@ export interface SshCompressionInfo {
   negotiatedScAlgorithm: string;
 }
 
-export const SSHVersions = [
-  'auto',
-  '1',
-  '2',
-  '3',
-] as const;
+export const SSHVersions = ["auto", "1", "2", "3"] as const;
 export type SSHVersion = (typeof SSHVersions)[number];
 
 export const CharacterSets = [
-  'UTF-8',
-  'ISO-8859-1',
-  'ISO-8859-2',
-  'ISO-8859-3',
-  'ISO-8859-4',
-  'ISO-8859-5',
-  'ISO-8859-6',
-  'ISO-8859-7',
-  'ISO-8859-8',
-  'ISO-8859-9',
-  'ISO-8859-10',
-  'ISO-8859-11',
-  'ISO-8859-13',
-  'ISO-8859-14',
-  'ISO-8859-15',
-  'ISO-8859-16',
-  'Windows-1250',
-  'Windows-1251',
-  'Windows-1252',
-  'Windows-1253',
-  'Windows-1254',
-  'Windows-1255',
-  'Windows-1256',
-  'Windows-1257',
-  'Windows-1258',
-  'KOI8-R',
-  'KOI8-U',
-  'GB2312',
-  'GBK',
-  'GB18030',
-  'Big5',
-  'Big5-HKSCS',
-  'EUC-JP',
-  'Shift_JIS',
-  'ISO-2022-JP',
-  'EUC-KR',
-  'ISO-2022-KR',
-  'EUC-TW',
-  'TIS-620',
-  'VISCII',
-  'IBM437',
-  'IBM850',
-  'IBM852',
-  'IBM855',
-  'IBM857',
-  'IBM860',
-  'IBM861',
-  'IBM862',
-  'IBM863',
-  'IBM864',
-  'IBM865',
-  'IBM866',
-  'IBM869',
-  'CP1006',
-  'MacRoman',
-  'MacCentralEuropean',
-  'MacIceland',
-  'MacCroatian',
-  'MacTurkish',
-  'MacGreek',
-  'MacCyrillic',
-  'MacUkrainian',
-  'MacHebrew',
-  'MacArabic',
-  'MacThai',
-  'MacJapanese',
-  'MacChineseSimp',
-  'MacChineseTrad',
-  'MacKorean',
+  "UTF-8",
+  "ISO-8859-1",
+  "ISO-8859-2",
+  "ISO-8859-3",
+  "ISO-8859-4",
+  "ISO-8859-5",
+  "ISO-8859-6",
+  "ISO-8859-7",
+  "ISO-8859-8",
+  "ISO-8859-9",
+  "ISO-8859-10",
+  "ISO-8859-11",
+  "ISO-8859-13",
+  "ISO-8859-14",
+  "ISO-8859-15",
+  "ISO-8859-16",
+  "Windows-1250",
+  "Windows-1251",
+  "Windows-1252",
+  "Windows-1253",
+  "Windows-1254",
+  "Windows-1255",
+  "Windows-1256",
+  "Windows-1257",
+  "Windows-1258",
+  "KOI8-R",
+  "KOI8-U",
+  "GB2312",
+  "GBK",
+  "GB18030",
+  "Big5",
+  "Big5-HKSCS",
+  "EUC-JP",
+  "Shift_JIS",
+  "ISO-2022-JP",
+  "EUC-KR",
+  "ISO-2022-KR",
+  "EUC-TW",
+  "TIS-620",
+  "VISCII",
+  "IBM437",
+  "IBM850",
+  "IBM852",
+  "IBM855",
+  "IBM857",
+  "IBM860",
+  "IBM861",
+  "IBM862",
+  "IBM863",
+  "IBM864",
+  "IBM865",
+  "IBM866",
+  "IBM869",
+  "CP1006",
+  "MacRoman",
+  "MacCentralEuropean",
+  "MacIceland",
+  "MacCroatian",
+  "MacTurkish",
+  "MacGreek",
+  "MacCyrillic",
+  "MacUkrainian",
+  "MacHebrew",
+  "MacArabic",
+  "MacThai",
+  "MacJapanese",
+  "MacChineseSimp",
+  "MacChineseTrad",
+  "MacKorean",
 ] as const;
 export type CharacterSet = (typeof CharacterSets)[number] | string;
 
 export interface TerminalFontConfig {
   family: string;
   size: number;
-  weight: 'normal' | 'bold' | 'lighter' | 'bolder' | number;
-  style: 'normal' | 'italic' | 'oblique';
+  weight: "normal" | "bold" | "lighter" | "bolder" | number;
+  style: "normal" | "italic" | "oblique";
   lineHeight: number;
   letterSpacing: number;
 }
@@ -280,7 +283,7 @@ export interface SSHTerminalConfig {
 
   // Character set
   characterSet: CharacterSet;
-  unicodeAmbiguousWidth: 'narrow' | 'wide';
+  unicodeAmbiguousWidth: "narrow" | "wide";
 
   // Font configuration
   useCustomFont: boolean;
@@ -332,59 +335,60 @@ export interface SSHTerminalConfig {
 // ===================================
 
 export const TerminalBackgroundTypes = [
-  'none',
-  'solid',
-  'gradient',
-  'image',
-  'animated',
+  "none",
+  "solid",
+  "gradient",
+  "image",
+  "animated",
 ] as const;
 export type TerminalBackgroundType = (typeof TerminalBackgroundTypes)[number];
 
 export const GradientDirections = [
-  'to-bottom',
-  'to-right',
-  'to-bottom-right',
-  'to-bottom-left',
-  'radial',
-  'conic',
+  "to-bottom",
+  "to-right",
+  "to-bottom-right",
+  "to-bottom-left",
+  "radial",
+  "conic",
 ] as const;
 export type GradientDirection = (typeof GradientDirections)[number];
 
 export const AnimatedBackgroundEffects = [
-  'matrix-rain',
-  'starfield',
-  'particles',
-  'scanlines',
-  'noise',
-  'aurora',
-  'rain',
-  'fireflies',
+  "matrix-rain",
+  "starfield",
+  "particles",
+  "scanlines",
+  "noise",
+  "aurora",
+  "rain",
+  "fireflies",
 ] as const;
-export type AnimatedBackgroundEffect = (typeof AnimatedBackgroundEffects)[number];
+export type AnimatedBackgroundEffect =
+  (typeof AnimatedBackgroundEffects)[number];
 
 export const OverlayBlendModes = [
-  'normal',
-  'multiply',
-  'screen',
-  'overlay',
-  'darken',
-  'lighten',
-  'color-dodge',
-  'color-burn',
-  'soft-light',
-  'hard-light',
+  "normal",
+  "multiply",
+  "screen",
+  "overlay",
+  "darken",
+  "lighten",
+  "color-dodge",
+  "color-burn",
+  "soft-light",
+  "hard-light",
 ] as const;
 export type OverlayBlendMode = (typeof OverlayBlendModes)[number];
 
 export const FadingEdges = [
-  'none',
-  'top',
-  'bottom',
-  'left',
-  'right',
-  'all',
-  'top-bottom',
-  'left-right',
+  "none",
+  "top",
+  "bottom",
+  "left",
+  "right",
+  "all",
+  "top-bottom",
+  "left-right",
 ] as const;
 export type FadingEdge = (typeof FadingEdges)[number];
 
@@ -396,7 +400,14 @@ export interface GradientStop {
 export interface TerminalOverlay {
   id: string;
   enabled: boolean;
-  type: 'color' | 'gradient' | 'vignette' | 'scanlines' | 'noise' | 'crt' | 'grid';
+  type:
+    | "color"
+    | "gradient"
+    | "vignette"
+    | "scanlines"
+    | "noise"
+    | "crt"
+    | "grid";
   opacity: number; // 0-1
   blendMode: OverlayBlendMode;
   color?: string;
@@ -430,7 +441,7 @@ export interface TerminalBackgroundConfig {
   imagePath?: string;
   imageOpacity?: number; // 0-1
   imageBlur?: number; // px
-  imageSize?: 'cover' | 'contain' | 'fill' | 'tile';
+  imageSize?: "cover" | "contain" | "fill" | "tile";
   imagePosition?: string; // CSS background-position
 
   // Animated effect
@@ -451,31 +462,31 @@ export interface TerminalBackgroundConfig {
 
 export const defaultTerminalFading: TerminalFadingConfig = {
   enabled: false,
-  edge: 'none',
+  edge: "none",
   size: 40,
 };
 
 export const defaultTerminalBackground: TerminalBackgroundConfig = {
   enabled: false,
-  type: 'none',
+  type: "none",
   opacity: 1,
-  solidColor: '#0b1120',
+  solidColor: "#0b1120",
   gradientStops: [
-    { color: '#0b1120', position: 0 },
-    { color: '#1a1a2e', position: 100 },
+    { color: "#0b1120", position: 0 },
+    { color: "#1a1a2e", position: 100 },
   ],
-  gradientDirection: 'to-bottom',
+  gradientDirection: "to-bottom",
   imageOpacity: 0.15,
   imageBlur: 0,
-  imageSize: 'cover',
-  imagePosition: 'center center',
-  animatedEffect: 'matrix-rain',
+  imageSize: "cover",
+  imagePosition: "center center",
+  animatedEffect: "matrix-rain",
   animationSpeed: 1,
   animationDensity: 1,
-  animationColor: '#00ff41',
+  animationColor: "#00ff41",
   fading: { ...defaultTerminalFading },
   overlays: [],
-}
+};
 
 export const defaultSSHTerminalConfig: SSHTerminalConfig = {
   // Line handling
@@ -484,18 +495,18 @@ export const defaultSSHTerminalConfig: SSHTerminalConfig = {
   autoWrap: true,
 
   // Line discipline
-  localEcho: 'auto',
-  localLineEditing: 'auto',
+  localEcho: "auto",
+  localLineEditing: "auto",
 
   // Bell settings
-  bellStyle: 'system',
+  bellStyle: "system",
   bellOveruseProtection: {
     enabled: true,
     maxBells: 5,
     timeWindowSeconds: 2,
     silenceDurationSeconds: 5,
   },
-  taskbarFlash: 'disabled',
+  taskbarFlash: "disabled",
   blinkWindowOnActivity: false,
 
   // Keypad mode
@@ -508,16 +519,16 @@ export const defaultSSHTerminalConfig: SSHTerminalConfig = {
   rows: 24,
 
   // Character set
-  characterSet: 'UTF-8',
-  unicodeAmbiguousWidth: 'narrow',
+  characterSet: "UTF-8",
+  unicodeAmbiguousWidth: "narrow",
 
   // Font configuration
   useCustomFont: false,
   font: {
     family: 'Consolas, Monaco, "Courier New", monospace',
     size: 14,
-    weight: 'normal',
-    style: 'normal',
+    weight: "normal",
+    style: "normal",
     lineHeight: 1.2,
     letterSpacing: 0,
   },
@@ -532,52 +543,52 @@ export const defaultSSHTerminalConfig: SSHTerminalConfig = {
     tcpNoDelay: true, // Disable Nagle's algorithm for lower latency
     tcpKeepAlive: true,
     soKeepAlive: true,
-    ipProtocol: 'auto',
+    ipProtocol: "auto",
     keepAliveInterval: 30, // Faster keepalive detection (was 60)
     keepAliveProbes: 2, // Fewer probes before disconnect (was 3)
     connectionTimeout: 15, // Faster timeout for unresponsive hosts (was 30)
   },
 
   // SSH protocol settings
-  sshVersion: 'auto',
+  sshVersion: "auto",
   enableCompression: false,
   compressionLevel: 6,
   compressionConfig: { ...defaultCompressionConfig },
 
   // Additional SSH options (ordered by performance - fastest first)
   preferredCiphers: [
-    'aes128-gcm@openssh.com', // Fastest with AES-NI hardware
-    'aes256-gcm@openssh.com',
-    'chacha20-poly1305@openssh.com', // Fast on systems without AES-NI
-    'aes128-ctr', // Good balance of speed and security
-    'aes256-ctr',
-    'aes192-ctr',
+    "aes128-gcm@openssh.com", // Fastest with AES-NI hardware
+    "aes256-gcm@openssh.com",
+    "chacha20-poly1305@openssh.com", // Fast on systems without AES-NI
+    "aes128-ctr", // Good balance of speed and security
+    "aes256-ctr",
+    "aes192-ctr",
   ],
   preferredMACs: [
-    'umac-128-etm@openssh.com', // Fastest MAC
-    'umac-64-etm@openssh.com',
-    'hmac-sha2-256-etm@openssh.com',
-    'hmac-sha2-512-etm@openssh.com',
-    'hmac-sha2-256',
+    "umac-128-etm@openssh.com", // Fastest MAC
+    "umac-64-etm@openssh.com",
+    "hmac-sha2-256-etm@openssh.com",
+    "hmac-sha2-512-etm@openssh.com",
+    "hmac-sha2-256",
   ],
   preferredKeyExchanges: [
-    'curve25519-sha256', // Fastest modern key exchange
-    'curve25519-sha256@libssh.org',
-    'ecdh-sha2-nistp256', // Faster than larger curves
-    'ecdh-sha2-nistp384',
-    'ecdh-sha2-nistp521',
-    'diffie-hellman-group14-sha256', // Fastest DH group
-    'diffie-hellman-group16-sha512',
-    'diffie-hellman-group18-sha512',
+    "curve25519-sha256", // Fastest modern key exchange
+    "curve25519-sha256@libssh.org",
+    "ecdh-sha2-nistp256", // Faster than larger curves
+    "ecdh-sha2-nistp384",
+    "ecdh-sha2-nistp521",
+    "diffie-hellman-group14-sha256", // Fastest DH group
+    "diffie-hellman-group16-sha512",
+    "diffie-hellman-group18-sha512",
   ],
   preferredHostKeyAlgorithms: [
-    'ssh-ed25519',
-    'ecdsa-sha2-nistp521',
-    'ecdsa-sha2-nistp384',
-    'ecdsa-sha2-nistp256',
-    'rsa-sha2-512',
-    'rsa-sha2-256',
-    'ssh-rsa',
+    "ssh-ed25519",
+    "ecdsa-sha2-nistp521",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp256",
+    "rsa-sha2-512",
+    "rsa-sha2-256",
+    "ssh-rsa",
   ],
 
   // Scrollback
@@ -588,10 +599,10 @@ export const defaultSSHTerminalConfig: SSHTerminalConfig = {
   // Selection behavior
   copyOnSelect: false,
   pasteOnRightClick: true,
-  wordSeparators: ' !"#$%&\'()*+,-./:;<=>?@[\\]^`{|}~',
+  wordSeparators: " !\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~",
 
   // Misc terminal behavior
-  answerbackString: '',
+  answerbackString: "",
   localPrinting: false,
   remoteControlledPrinting: false,
 
@@ -622,7 +633,7 @@ export interface JumpHostConfig {
 
 /** Proxy hop used inside a mixed chain. */
 export interface ProxyConfig {
-  proxyType: 'http' | 'https' | 'socks4' | 'socks5';
+  proxyType: "http" | "https" | "socks4" | "socks5";
   host: string;
   port: number;
   username?: string;
@@ -631,8 +642,8 @@ export interface ProxyConfig {
 
 /** A single hop in a mixed chain. */
 export type ChainHop =
-  | { type: 'ssh_jump' } & JumpHostConfig
-  | { type: 'proxy' } & ProxyConfig;
+  | ({ type: "ssh_jump" } & JumpHostConfig)
+  | ({ type: "proxy" } & ProxyConfig);
 
 /** Configuration for a mixed chain of SSH jumps + proxy hops. */
 export interface MixedChainConfig {
@@ -715,11 +726,9 @@ export interface SSHConnectionConfig {
   proxyCommandProxyType?: string;
   proxyCommandTimeout?: number;
   /**
-   * Trust marker mirroring the Rust `ProxyCommandConfig.command_confirmed`.
-   * A ProxyCommand is only EXECUTED once the user has explicitly confirmed it.
-   * Imported/synced configs leave this `false`/undefined so the backend gate
-   * (`PROXY_COMMAND_CONFIRMATION_REQUIRED`) fires; the confirm flow persists
-   * `true` here after the user reviews the redacted command.
+   * Deprecated persisted trust marker. Kept for backward-compatible settings
+   * parsing only; ProxyCommand execution must be authorized by the backend's
+   * fingerprint-scoped runtime confirmation registry instead of this boolean.
    */
   proxyCommandConfirmed?: boolean;
 
@@ -745,10 +754,24 @@ export interface SSHConnectionConfig {
   bannerTimeout: number; // seconds to wait for banner
 }
 
-export const SSHAuthMethods = ['password', 'publickey', 'keyboard-interactive', 'gssapi-with-mic', 'hostbased', 'none'] as const;
+export const SSHAuthMethods = [
+  "password",
+  "publickey",
+  "keyboard-interactive",
+  "gssapi-with-mic",
+  "hostbased",
+  "none",
+] as const;
 export type SSHAuthMethod = (typeof SSHAuthMethods)[number];
 
-export const ProxyCommandTemplates = ['nc', 'ncat', 'socat', 'connect', 'corkscrew', 'ssh_stdio'] as const;
+export const ProxyCommandTemplates = [
+  "nc",
+  "ncat",
+  "socat",
+  "connect",
+  "corkscrew",
+  "ssh_stdio",
+] as const;
 export type ProxyCommandTemplate = (typeof ProxyCommandTemplates)[number];
 
 export const defaultSSHConnectionConfig: SSHConnectionConfig = {
@@ -759,13 +782,13 @@ export const defaultSSHConnectionConfig: SSHConnectionConfig = {
   knownHostsPath: undefined,
 
   // Authentication preferences
-  preferredAuthMethods: ['publickey', 'keyboard-interactive', 'password'],
+  preferredAuthMethods: ["publickey", "keyboard-interactive", "password"],
   tryPublicKeyFirst: true,
   tryAgentFirst: true,
   agentForwarding: false,
 
   // SSH protocol options
-  sshVersion: 'auto',
+  sshVersion: "auto",
   enableCompression: false,
   compressionLevel: 6,
   compressionConfig: { ...defaultCompressionConfig },
@@ -780,7 +803,7 @@ export const defaultSSHConnectionConfig: SSHConnectionConfig = {
   tcpNoDelay: true,
   tcpKeepAlive: true,
   keepAliveProbes: 3,
-  ipProtocol: 'auto',
+  ipProtocol: "auto",
 
   // Port forwarding defaults
   enableX11Forwarding: false,
@@ -807,7 +830,7 @@ export const defaultSSHConnectionConfig: SSHConnectionConfig = {
 
   // Session settings
   requestPty: true,
-  ptyType: 'xterm-256color',
+  ptyType: "xterm-256color",
   environment: undefined,
 
   // SFTP/SCP settings
@@ -830,7 +853,7 @@ export const defaultSSHConnectionConfig: SSHConnectionConfig = {
  */
 export function mergeSSHConnectionConfig(
   globalConfig: SSHConnectionConfig,
-  override?: Partial<SSHConnectionConfig>
+  override?: Partial<SSHConnectionConfig>,
 ): SSHConnectionConfig {
   if (!override) return globalConfig;
 
@@ -838,11 +861,16 @@ export function mergeSSHConnectionConfig(
     ...globalConfig,
     ...override,
     // Merge arrays by taking override if provided
-    preferredAuthMethods: override.preferredAuthMethods ?? globalConfig.preferredAuthMethods,
-    preferredCiphers: override.preferredCiphers ?? globalConfig.preferredCiphers,
+    preferredAuthMethods:
+      override.preferredAuthMethods ?? globalConfig.preferredAuthMethods,
+    preferredCiphers:
+      override.preferredCiphers ?? globalConfig.preferredCiphers,
     preferredMACs: override.preferredMACs ?? globalConfig.preferredMACs,
-    preferredKeyExchanges: override.preferredKeyExchanges ?? globalConfig.preferredKeyExchanges,
-    preferredHostKeyAlgorithms: override.preferredHostKeyAlgorithms ?? globalConfig.preferredHostKeyAlgorithms,
+    preferredKeyExchanges:
+      override.preferredKeyExchanges ?? globalConfig.preferredKeyExchanges,
+    preferredHostKeyAlgorithms:
+      override.preferredHostKeyAlgorithms ??
+      globalConfig.preferredHostKeyAlgorithms,
     revokedHostKeys: override.revokedHostKeys ?? globalConfig.revokedHostKeys,
     // Deep merge compression config
     compressionConfig: {
@@ -868,7 +896,7 @@ export function mergeSSHConnectionConfig(
  */
 export function mergeSSHTerminalConfig(
   globalConfig: SSHTerminalConfig,
-  override?: Partial<SSHTerminalConfig>
+  override?: Partial<SSHTerminalConfig>,
 ): SSHTerminalConfig {
   if (!override) return globalConfig;
 
@@ -903,7 +931,8 @@ export function mergeSSHTerminalConfig(
         ...globalConfig.background.fading,
         ...(override.background?.fading || {}),
       },
-      overlays: override.background?.overlays ?? globalConfig.background.overlays,
+      overlays:
+        override.background?.overlays ?? globalConfig.background.overlays,
     },
   };
 }

--- a/tests/ssh/ProxyCommandConfirmFlow.test.tsx
+++ b/tests/ssh/ProxyCommandConfirmFlow.test.tsx
@@ -56,13 +56,19 @@ const mockTerminal = {
 };
 
 vi.mock("@xterm/xterm", () => ({
-  Terminal: vi.fn(function () { return mockTerminal; }),
+  Terminal: vi.fn(function () {
+    return mockTerminal;
+  }),
 }));
 vi.mock("@xterm/addon-fit", () => ({
-  FitAddon: vi.fn(function () { return { fit: vi.fn() }; }),
+  FitAddon: vi.fn(function () {
+    return { fit: vi.fn() };
+  }),
 }));
 vi.mock("@xterm/addon-web-links", () => ({
-  WebLinksAddon: vi.fn(function () { return {}; }),
+  WebLinksAddon: vi.fn(function () {
+    return {};
+  }),
 }));
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -135,34 +141,45 @@ describe("ProxyCommand import-confirmation gate (frontend)", () => {
     renderWithProviders(mockSession);
 
     // Dialog appears showing the exact redacted command.
-    const dialogCmd = await screen.findByTestId("proxy-command-confirm-command");
+    const dialogCmd = await screen.findByTestId(
+      "proxy-command-confirm-command",
+    );
     expect(dialogCmd).toHaveTextContent(REDACTED_CMD);
     expect(mockInvoke).toHaveBeenCalledWith(
       "expand_proxy_command",
-      expect.objectContaining({ host: "192.168.1.100", port: 22, username: "testuser" }),
+      expect.objectContaining({
+        host: "192.168.1.100",
+        port: 22,
+        username: "testuser",
+      }),
     );
 
-    // Accept → confirm_proxy_command called, flag persisted, connection retried.
+    // Accept → confirm_proxy_command called, connection retried without persisting a reusable flag.
     fireEvent.click(screen.getByTestId("proxy-command-confirm-accept"));
 
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith(
         "confirm_proxy_command",
-        expect.objectContaining({ host: "192.168.1.100", port: 22, username: "testuser" }),
-      );
-    });
-
-    // Durable flag persisted onto the stored connection.
-    await waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "UPDATE_CONNECTION",
-          payload: expect.objectContaining({
-            sshConnectionConfigOverride: expect.objectContaining({ proxyCommandConfirmed: true }),
-          }),
+          host: "192.168.1.100",
+          port: 22,
+          username: "testuser",
         }),
       );
     });
+
+    // Confirmation is runtime/fingerprint-scoped and is not persisted as a
+    // reusable boolean that could bless later command contents.
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "UPDATE_CONNECTION",
+        payload: expect.objectContaining({
+          sshConnectionConfigOverride: expect.objectContaining({
+            proxyCommandConfirmed: true,
+          }),
+        }),
+      }),
+    );
 
     // Retry happened (connect_ssh called a second time) and succeeded.
     await waitFor(() => {
@@ -202,12 +219,17 @@ describe("ProxyCommand import-confirmation gate (frontend)", () => {
     });
 
     // Never confirmed, never retried, never persisted.
-    expect(mockInvoke).not.toHaveBeenCalledWith("confirm_proxy_command", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "confirm_proxy_command",
+      expect.anything(),
+    );
     expect(connectAttempts).toBe(1);
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          sshConnectionConfigOverride: expect.objectContaining({ proxyCommandConfirmed: true }),
+          sshConnectionConfigOverride: expect.objectContaining({
+            proxyCommandConfirmed: true,
+          }),
         }),
       }),
     );


### PR DESCRIPTION
### Motivation

- Prevent persisted or imported `proxyCommandConfirmed` booleans from bypassing the runtime, fingerprint-scoped ProxyCommand confirmation gate and thus avoid accidental execution of unreviewed commands.

### Description

- Frontend: always send `command_confirmed: false` to the backend and stop persisting a durable `proxyCommandConfirmed` flag after runtime confirmation, so only a runtime fingerprint confirmation can allow execution; primary changes in `src/hooks/ssh/useWebTerminal.ts`.
- Backend: ignore `ProxyCommandConfig.command_confirmed` when deciding to spawn and require that the exact expanded command fingerprint be confirmed at runtime; primary change in `src-tauri/crates/sorng-ssh/src/ssh/proxy_command.rs`.
- Import hygiene: strip any incoming `sshConnectionConfigOverride.proxyCommandConfirmed` from native JSON imports to prevent untrusted files from carrying a bypass bit; added `dropImportedProxyCommandConfirmation` in `src/components/ImportExport/utils.ts`.
- Types & tests: mark the persisted boolean as deprecated in `src/types/ssh/sshSettings.ts` and update frontend & Rust tests to assert confirmation is fingerprint-scoped and not persisted; updated tests in `tests/ssh/ProxyCommandConfirmFlow.test.tsx` and `src-tauri/crates/sorng-ssh/src/ssh/proxy_command.rs`.

### Testing

- Ran formatting: `npm run format -- src/hooks/ssh/useWebTerminal.ts src/components/ImportExport/utils.ts src/types/ssh/sshSettings.ts tests/ssh/ProxyCommandConfirmFlow.test.tsx` (completed).
- JavaScript unit tests: `npm test -- tests/ssh/ProxyCommandConfirmFlow.test.tsx` (1 file, 2 tests) passed.
- Rust unit tests: `cargo test --manifest-path src-tauri/Cargo.toml -p sorng-ssh proxy_command --target x86_64-unknown-linux-gnu` (proxy_command tests) passed (all tests OK).
- Lint: `npm run lint -- src/hooks/ssh/useWebTerminal.ts src/components/ImportExport/utils.ts src/types/ssh/sshSettings.ts tests/ssh/ProxyCommandConfirmFlow.test.tsx` completed with existing warnings only and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb721f5688325863fa00cfa92125d)