### PR TITLE
fix(tls-trust): require WebPKI before TOFU pinning

### DIFF
--- a/src-tauri/crates/sorng-tls-trust/src/lib.rs
+++ b/src-tauri/crates/sorng-tls-trust/src/lib.rs
@@ -18,20 +18,22 @@
 //!
 //! 1. Fingerprints the leaf certificate (SHA-256 hex — same format the trust
 //!    store records) and parses subject/issuer/validity/SAN for the record.
-//! 2. Runs standard webpki chain validation against the native root store
-//!    (records `chain_valid` for diagnostics — TOFU pins *identity*, it does
-//!    **not** disable signature/chain checking).
+//! 2. Runs standard webpki chain validation against the native root store.
+//!    Unknown certificates are only pinned on first use when this validation
+//!    succeeds; the explicit `AlwaysTrust` override remains the escape hatch
+//!    for legacy self-signed endpoints.
 //! 3. Consults the persistent Trust Center store (via the blocking
 //!    [`sorng_storage::trust_store::SyncTrustStore`] façade) and applies a
 //!    **pure decision function** [`decide_tls_trust`]:
-//!    - `Tofu` (default): unknown → fingerprint + persist + accept; known &
-//!      matching → accept; **changed → reject** (MITM).
+//!    - `Tofu` (default): valid unknown → fingerprint + persist + accept;
+//!      invalid unknown → reject; known & matching → accept; **changed →
+//!      reject** (MITM).
 //!    - `AlwaysTrust`: accept without storing — the explicit replacement for
 //!      today's blind skip (the legacy skip flags map to this override).
 //!    - `Strict`: reject unknown; accept only a pre-approved match.
 //!    - `AlwaysAsk`: no prompt channel for these non-interactive backends, so
-//!      it degrades to TOFU-persist-on-unknown / reject-on-change (same as
-//!      SFTP's `Ask`).
+//!      it degrades to TOFU-persist-on-valid-unknown / reject-on-invalid-or-change
+//!      (same as SFTP's `Ask`).
 //!
 //! `verify_tls12_signature` / `verify_tls13_signature` /
 //! `supported_verify_schemes` delegate to rustls' default
@@ -122,11 +124,12 @@ impl StoreVerdict {
 /// * `Unknown`  → policy-dependent:
 ///   - `AlwaysTrust`        → accept, do not persist.
 ///   - `Strict`             → reject (manual pinning required).
-///   - `Tofu` / `AlwaysAsk` / others → accept and persist (TOFU).
+///   - `Tofu` / `AlwaysAsk` / others → accept and persist (TOFU), but only
+///     after normal WebPKI chain/hostname validation succeeds.
 pub fn decide_tls_trust(
     verdict: StoreVerdict,
     policy: &TrustPolicy,
-    _chain_valid: bool,
+    chain_valid: bool,
 ) -> TlsTrustAction {
     // AlwaysTrust short-circuits everything: it is the explicit replacement for
     // the old blind `danger_accept_invalid_certs(true)`. It accepts any
@@ -154,8 +157,19 @@ pub fn decide_tls_trust(
                     .to_string(),
             ),
             // Tofu (default), AlwaysAsk (degrades to TOFU — non-interactive),
-            // and all other policies trust-on-first-use: persist + accept.
-            _ => TlsTrustAction::AcceptAndPersist,
+            // and all other policies trust-on-first-use only after the normal
+            // CA/hostname checks have succeeded. This preserves default reqwest
+            // security for public APIs and prevents pinning a first-use MITM
+            // certificate; use the explicit AlwaysTrust override for legacy
+            // self-signed endpoints.
+            _ if chain_valid => TlsTrustAction::AcceptAndPersist,
+            _ => TlsTrustAction::Reject(
+                "the server's TLS certificate could not be validated by the \
+                 system trust store, so it was not pinned on first use. If this \
+                 is a trusted legacy self-signed endpoint, enable the explicit \
+                 TLS skip/AlwaysTrust override for this connection."
+                    .to_string(),
+            ),
         },
     }
 }
@@ -284,17 +298,13 @@ fn extract_leaf_details(der: &[u8]) -> LeafCertDetails {
 
     match x509_parser::parse_x509_certificate(der) {
         Ok((_rem, cert)) => {
-            let san = cert
-                .subject_alternative_name()
-                .ok()
-                .flatten()
-                .map(|ext| {
-                    ext.value
-                        .general_names
-                        .iter()
-                        .map(|name| format!("{name}"))
-                        .collect::<Vec<_>>()
-                });
+            let san = cert.subject_alternative_name().ok().flatten().map(|ext| {
+                ext.value
+                    .general_names
+                    .iter()
+                    .map(|name| format!("{name}"))
+                    .collect::<Vec<_>>()
+            });
             LeafCertDetails {
                 fingerprint,
                 subject: Some(cert.subject().to_string()),
@@ -407,8 +417,9 @@ impl ServerCertVerifier for TofuVerifier {
         let details = extract_leaf_details(end_entity.as_ref());
         let identity = details.into_identity();
 
-        // 2. Standard webpki chain validation (records chain_valid; does NOT
-        //    gate identity pinning — TOFU should still pin a self-signed cert).
+        // 2. Standard webpki chain/hostname validation. Unknown certificates
+        //    are only pinned when this succeeds; otherwise a first-use MITM
+        //    could become trusted before any prior identity exists.
         let chain_valid = self
             .inner
             .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)

--- a/src-tauri/crates/sorng-tls-trust/src/tests.rs
+++ b/src-tauri/crates/sorng-tls-trust/src/tests.rs
@@ -50,20 +50,36 @@ fn changed_rejects_under_every_policy_except_always_trust() {
 }
 
 #[test]
-fn unknown_under_tofu_persists() {
+fn unknown_under_tofu_persists_when_chain_is_valid() {
     assert_eq!(
-        decide_tls_trust(StoreVerdict::Unknown, &TrustPolicy::Tofu, false),
+        decide_tls_trust(StoreVerdict::Unknown, &TrustPolicy::Tofu, true),
         TlsTrustAction::AcceptAndPersist
     );
 }
 
 #[test]
-fn unknown_under_always_ask_degrades_to_tofu_persist() {
+fn unknown_under_tofu_rejects_when_chain_is_invalid() {
+    assert!(matches!(
+        decide_tls_trust(StoreVerdict::Unknown, &TrustPolicy::Tofu, false),
+        TlsTrustAction::Reject(_)
+    ));
+}
+
+#[test]
+fn unknown_under_always_ask_degrades_to_tofu_persist_when_chain_is_valid() {
     // Non-interactive backends cannot prompt; AlwaysAsk degrades to TOFU.
     assert_eq!(
         decide_tls_trust(StoreVerdict::Unknown, &TrustPolicy::AlwaysAsk, true),
         TlsTrustAction::AcceptAndPersist
     );
+}
+
+#[test]
+fn unknown_under_always_ask_rejects_when_chain_is_invalid() {
+    assert!(matches!(
+        decide_tls_trust(StoreVerdict::Unknown, &TrustPolicy::AlwaysAsk, false),
+        TlsTrustAction::Reject(_)
+    ));
 }
 
 #[test]
@@ -208,7 +224,12 @@ fn run_decision(store: &StubStore, host_key: &str, fp: &str) -> TlsTrustAction {
     let action = decide_tls_trust(verdict, &policy, true);
     if action == TlsTrustAction::AcceptAndPersist {
         store
-            .trust(host_key.to_string(), TLS_RECORD_TYPE.to_string(), identity, false)
+            .trust(
+                host_key.to_string(),
+                TLS_RECORD_TYPE.to_string(),
+                identity,
+                false,
+            )
             .unwrap();
     }
     action
@@ -300,5 +321,8 @@ fn sync_facade_round_trips_through_disk() {
     let r3 = store
         .verify_identity_blocking("h:443", TLS_RECORD_TYPE, tls_identity("feedface"))
         .unwrap();
-    assert!(matches!(r3, TrustVerifyResult::Mismatch { .. }), "got {r3:?}");
+    assert!(
+        matches!(r3, TrustVerifyResult::Mismatch { .. }),
+        "got {r3:?}"
+    );
 }


### PR DESCRIPTION
### Motivation
- Close a security regression where the TOFU verifier could pin and accept a first-use certificate even when WebPKI chain/hostname validation failed, allowing a first-connection MITM to be persisted and capture credentials.

### Description
- Require the `chain_valid` result from the WebPKI delegate to be true before accepting-and-persisting an `Unknown` certificate under TOFU-style policies by changing `decide_tls_trust` to take and honor `chain_valid`.
- Preserve the explicit `AlwaysTrust` override as the documented escape hatch for legacy self-signed endpoints while keeping `Strict` behavior unchanged.
- Update verifier documentation/comments to reflect that unknown certs are only pinned after successful native root WebPKI validation and adjust the verifier flow to use the new decision behavior in `TofuVerifier` (`src-tauri/crates/sorng-tls-trust/src/lib.rs`).
- Add unit tests that cover valid vs invalid first-use certificates for `Tofu` and `AlwaysAsk` policies and small related test formatting fixes (`src-tauri/crates/sorng-tls-trust/src/tests.rs`).

### Testing
- Ran code formatting with `cargo fmt --manifest-path src-tauri/crates/sorng-tls-trust/Cargo.toml` and checked diffs with `git diff --check`, both succeeded.
- Added unit tests in `src-tauri/crates/sorng-tls-trust/src/tests.rs` to exercise the decision matrix for valid/invalid first-use certificates, but a full `cargo test` run could not complete in this environment.
- Attempted `cargo test -p sorng-tls-trust` and targeted test runs, which were blocked by toolchain/environment issues: the default Windows MSVC build failed due to missing `lib.exe` (`ring` build), and Linux-target builds failed due to missing system libraries (`dbus-1` and `glib-2.0`), so automated test execution was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb3d8efb88325b1a298c26a42f44e)