### PR TITLE
fix(web-browser): pin trusted proxy certificates

### DIFF
--- a/src-tauri/crates/sorng-protocols/src/http.rs
+++ b/src-tauri/crates/sorng-protocols/src/http.rs
@@ -138,6 +138,89 @@ impl ServerCertVerifier for NoCertificateVerification {
     }
 }
 
+#[derive(Debug)]
+pub struct PinnedCertificateVerification {
+    fingerprint: String,
+}
+
+impl PinnedCertificateVerification {
+    pub fn new(fingerprint: String) -> Self {
+        Self {
+            fingerprint: normalize_cert_fingerprint(&fingerprint),
+        }
+    }
+}
+
+impl ServerCertVerifier for PinnedCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let mut hasher = Sha256::new();
+        hasher.update(end_entity.as_ref());
+        let presented = hex::encode(hasher.finalize());
+        if presented.eq_ignore_ascii_case(&self.fingerprint) {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(format!(
+                "TLS certificate fingerprint mismatch: expected {}, got {}",
+                self.fingerprint, presented
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+pub fn normalize_cert_fingerprint(fingerprint: &str) -> String {
+    fingerprint
+        .trim()
+        .strip_prefix("SHA256:")
+        .unwrap_or_else(|| fingerprint.trim())
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+pub fn build_pinned_tls_config(fingerprint: String) -> Result<rustls::ClientConfig, String> {
+    rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(PinnedCertificateVerification::new(fingerprint)))
+        .with_no_client_auth()
+        .pipe(Ok)
+}
+
 pub fn native_root_store() -> Result<rustls::RootCertStore, String> {
     let mut roots = rustls::RootCertStore::empty();
     let cert_result = rustls_native_certs::load_native_certs();
@@ -388,6 +471,11 @@ pub struct BasicAuthProxyConfig {
     /// Whether to verify SSL certificates
     #[serde(default = "default_verify_ssl")]
     pub verify_ssl: bool,
+    /// Optional SHA-256 certificate fingerprint accepted by the frontend trust prompt.
+    /// When present, the proxy pins outbound TLS to this exact leaf certificate
+    /// instead of disabling certificate verification for the whole session.
+    #[serde(default)]
+    pub accepted_cert_fingerprint: Option<String>,
     /// Minimum TLS version for outbound requests ("1.0", "1.1", "1.2", "1.3").
     /// Defaults to "1.2".  SSL 3.0 is NOT supported by the TLS backend.
     #[serde(default = "default_min_tls_version")]
@@ -476,6 +564,8 @@ pub struct ProxySessionEntry {
     pub min_tls_version: String,
     /// Whether SSL certificate verification is enabled.
     pub verify_ssl: bool,
+    /// Optional SHA-256 leaf certificate fingerprint pinned for this session.
+    pub accepted_cert_fingerprint: Option<String>,
     pub request_count: Arc<AtomicU64>,
     pub error_count: Arc<AtomicU64>,
     pub last_error: Arc<std::sync::Mutex<Option<String>>>,
@@ -820,10 +910,7 @@ pub async fn axum_proxy_handler(
                 .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
                 .collect();
             if matches!(
-                crate::themed_auth::intercept_basic_auth_challenge(
-                    status_u16,
-                    &www_auth_values,
-                ),
+                crate::themed_auth::intercept_basic_auth_challenge(status_u16, &www_auth_values,),
                 crate::themed_auth::ChallengeDecision::Challenge,
             ) {
                 let nonce = crate::themed_auth::fresh_nonce();
@@ -833,11 +920,7 @@ pub async fn axum_proxy_handler(
                 if let Ok(mut n) = state.pending_nonce.write() {
                     *n = Some(nonce.clone());
                 }
-                let existing_user = state
-                    .username
-                    .read()
-                    .map(|g| g.clone())
-                    .unwrap_or_default();
+                let existing_user = state.username.read().map(|g| g.clone()).unwrap_or_default();
                 // `path_and_query` is the path the user was trying
                 // to reach on the proxy; the POST handler will
                 // 303-redirect back to it after the credentials
@@ -853,11 +936,7 @@ pub async fn axum_proxy_handler(
                 // P7: pull live theme tokens out of the RwLock so the
                 // served form matches whatever theme the user has
                 // active right now.
-                let theme = state
-                    .theme
-                    .read()
-                    .map(|g| g.clone())
-                    .unwrap_or_default();
+                let theme = state.theme.read().map(|g| g.clone()).unwrap_or_default();
                 return crate::themed_auth::themed_challenge_response(
                     &full_url,
                     &path_and_query,
@@ -912,13 +991,9 @@ pub async fn axum_proxy_handler(
                     // downstream is response-shaping that we skip
                     // by returning early.)
                     if let Ok(mut recordings) = active_web_recordings().lock() {
-                        if let Some(rec_state) =
-                            recordings.get_mut(&state.session_id)
-                        {
-                            let timestamp_ms =
-                                rec_state.start_time.elapsed().as_millis() as u64;
-                            let mut response_headers: HashMap<String, String> =
-                                HashMap::new();
+                        if let Some(rec_state) = recordings.get_mut(&state.session_id) {
+                            let timestamp_ms = rec_state.start_time.elapsed().as_millis() as u64;
+                            let mut response_headers: HashMap<String, String> = HashMap::new();
                             if rec_state.record_headers {
                                 for (k, v) in resp_hdrs.iter() {
                                     if let Ok(s) = v.to_str() {
@@ -950,16 +1025,9 @@ pub async fn axum_proxy_handler(
                         }
                     }
                     // P7: snapshot theme tokens for this render.
-                    let theme = state
-                        .theme
-                        .read()
-                        .map(|g| g.clone())
-                        .unwrap_or_default();
+                    let theme = state.theme.read().map(|g| g.clone()).unwrap_or_default();
                     return crate::themed_status::themed_status_response(
-                        status_u16,
-                        &full_url,
-                        &raw_bytes,
-                        &theme,
+                        status_u16, &full_url, &raw_bytes, &theme,
                     );
                 }
                 // Non-HTML 4xx/5xx — pass through as-is so JSON/XML
@@ -1040,8 +1108,7 @@ pub async fn axum_proxy_handler(
                 // when not armed. The injected HTML carries ONLY a per-page
                 // nonce + non-secret selectors — never the credential.
                 let autologin_script =
-                    crate::themed_autologin::build_autologin_injection(&state)
-                        .unwrap_or_default();
+                    crate::themed_autologin::build_autologin_injection(&state).unwrap_or_default();
                 // e5 hardened client asset defines
                 // `window.__sorng_autologin.fetchCredsAndRun`, which the e3
                 // bootstrap checks for and defers to. It MUST appear BEFORE the
@@ -1057,8 +1124,8 @@ pub async fn axum_proxy_handler(
                     format!("{}{}{}", nav_script, autologin_asset, autologin_script);
                 let body_str = String::from_utf8_lossy(&final_body);
                 if body_str.contains("</body>") {
-                    let injected = body_str
-                        .replacen("</body>", &format!("{}</body>", injected_scripts), 1);
+                    let injected =
+                        body_str.replacen("</body>", &format!("{}</body>", injected_scripts), 1);
                     final_body = injected.into_bytes();
                 } else {
                     final_body.extend_from_slice(injected_scripts.as_bytes());
@@ -1159,11 +1226,7 @@ pub async fn axum_proxy_handler(
             }
 
             // P7: snapshot theme tokens for this render.
-            let theme = state
-                .theme
-                .read()
-                .map(|g| g.clone())
-                .unwrap_or_default();
+            let theme = state.theme.read().map(|g| g.clone()).unwrap_or_default();
             crate::themed_errors::themed_error_response(kind, &full_url, &err_msg, &theme)
         }
     }
@@ -1231,9 +1294,7 @@ pub async fn themed_auth_post_handler(
     // Defensive: refuse a `return_to` that isn't a same-origin path.
     // Anything starting with a scheme or `//` could be an open
     // redirect; force it to start with a single `/`.
-    let safe_return = if form.return_to.starts_with('/')
-        && !form.return_to.starts_with("//")
-    {
+    let safe_return = if form.return_to.starts_with('/') && !form.return_to.starts_with("//") {
         form.return_to.clone()
     } else {
         "/".to_string()
@@ -1389,7 +1450,10 @@ pub struct ParsedTlsCertificateDetails {
 }
 
 #[cfg(feature = "tls-cert-details")]
-fn extract_dn_attr(name: &x509_parser::x509::X509Name<'_>, oid: &x509_parser::oid_registry::Oid) -> Option<String> {
+fn extract_dn_attr(
+    name: &x509_parser::x509::X509Name<'_>,
+    oid: &x509_parser::oid_registry::Oid,
+) -> Option<String> {
     name.iter()
         .flat_map(|rdn| rdn.iter())
         .find(|attr| attr.attr_type() == oid)
@@ -1398,7 +1462,9 @@ fn extract_dn_attr(name: &x509_parser::x509::X509Name<'_>, oid: &x509_parser::oi
 }
 
 #[cfg(feature = "tls-cert-details")]
-fn resolve_key_algorithm_and_size(cert: &x509_parser::certificate::X509Certificate<'_>) -> (Option<String>, Option<u32>) {
+fn resolve_key_algorithm_and_size(
+    cert: &x509_parser::certificate::X509Certificate<'_>,
+) -> (Option<String>, Option<u32>) {
     let spki = cert.public_key();
     let algo_oid = spki.algorithm.algorithm.to_id_string();
 
@@ -1422,9 +1488,9 @@ fn resolve_key_algorithm_and_size(cert: &x509_parser::certificate::X509Certifica
                 params.as_oid().ok().map(|curve_oid| {
                     let curve_str = curve_oid.to_id_string();
                     match curve_str.as_str() {
-                        "1.2.840.10045.3.1.7" => ("ECDSA (P-256)".to_string(), 256u32),  // secp256r1 / prime256v1
-                        "1.3.132.0.34" => ("ECDSA (P-384)".to_string(), 384u32),          // secp384r1
-                        "1.3.132.0.35" => ("ECDSA (P-521)".to_string(), 521u32),          // secp521r1
+                        "1.2.840.10045.3.1.7" => ("ECDSA (P-256)".to_string(), 256u32), // secp256r1 / prime256v1
+                        "1.3.132.0.34" => ("ECDSA (P-384)".to_string(), 384u32),        // secp384r1
+                        "1.3.132.0.35" => ("ECDSA (P-521)".to_string(), 521u32),        // secp521r1
                         _ => (format!("ECDSA ({})", curve_str), 0u32),
                     }
                 })
@@ -1534,7 +1600,10 @@ pub fn parse_tls_certificate_details(der: &[u8], fingerprint: &str) -> ParsedTls
 }
 
 #[cfg(not(feature = "tls-cert-details"))]
-pub fn parse_tls_certificate_details(_der: &[u8], fingerprint: &str) -> ParsedTlsCertificateDetails {
+pub fn parse_tls_certificate_details(
+    _der: &[u8],
+    fingerprint: &str,
+) -> ParsedTlsCertificateDetails {
     ParsedTlsCertificateDetails {
         diagnostic_detail: Some(format!("Fingerprint: SHA256:{fingerprint}")),
         ..ParsedTlsCertificateDetails::default()
@@ -1555,4 +1624,3 @@ pub use sorng_core::diagnostics::{self as diagnostics, DiagnosticReport, Diagnos
 pub use crate::themed_autologin::{autologin_cred_handler, AUTOLOGIN_PATH};
 
 // ─── Web Session Recording Commands ──────────────────────────────
-

--- a/src-tauri/crates/sorng-protocols/src/http_cmds.rs
+++ b/src-tauri/crates/sorng-protocols/src/http_cmds.rs
@@ -75,6 +75,36 @@ pub async fn http_post(
     service.fetch(config).await
 }
 
+
+fn proxy_client_builder(
+    verify_ssl: bool,
+    accepted_cert_fingerprint: Option<&str>,
+    min_tls: &str,
+) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .pool_idle_timeout(std::time::Duration::from_secs(20))
+        .pool_max_idle_per_host(4)
+        .tcp_keepalive(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .min_tls_version(resolve_min_tls_version(min_tls))
+        .cookie_store(true);
+
+    if let Some(fingerprint) = accepted_cert_fingerprint
+        .map(normalize_cert_fingerprint)
+        .filter(|fp| !fp.is_empty())
+    {
+        builder = builder.use_preconfigured_tls(build_pinned_tls_config(fingerprint)?);
+    } else {
+        builder = builder.danger_accept_invalid_certs(!verify_ssl);
+    }
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to create proxy HTTP client: {}", e))
+}
+
 /// Start a basic auth proxy mediator.
 ///
 /// Spawns a local TCP server on `127.0.0.1:0` (OS auto-assigns a free port)
@@ -90,6 +120,7 @@ pub async fn start_basic_auth_proxy(
     let session_id = uuid::Uuid::new_v4().to_string();
     let target_url = config.target_url.clone();
     let verify_ssl = config.verify_ssl;
+    let accepted_cert_fingerprint = config.accepted_cert_fingerprint.clone();
     let min_tls = config.min_tls_version.clone();
     let connection_id = config.connection_id.clone();
 
@@ -128,18 +159,11 @@ pub async fn start_basic_auth_proxy(
 
     // Build an async reqwest client for this session with connection keep-alive
     // and reasonable timeouts to avoid stale-connection errors.
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(120))
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .pool_idle_timeout(std::time::Duration::from_secs(20))
-        .pool_max_idle_per_host(4)
-        .tcp_keepalive(std::time::Duration::from_secs(30))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .danger_accept_invalid_certs(!verify_ssl)
-        .min_tls_version(resolve_min_tls_version(&min_tls))
-        .cookie_store(true)
-        .build()
-        .map_err(|e| format!("Failed to create proxy HTTP client: {}", e))?;
+    let client = proxy_client_builder(
+        verify_ssl,
+        accepted_cert_fingerprint.as_deref(),
+        &min_tls,
+    )?;
 
     // Bind to a random free port.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -420,7 +444,7 @@ pub async fn restart_proxy_session(
     sessions: tauri::State<'_, ProxySessionManagerState>,
 ) -> Result<ProxyMediatorResponse, String> {
     // Extract the config from the existing (dead) session entry.
-    let (target_url, username, password, target_origin, connection_id, verify_ssl, min_tls) = {
+    let (target_url, username, password, target_origin, connection_id, verify_ssl, accepted_cert_fingerprint, min_tls) = {
         let mgr = sessions.lock().map_err(|e| format!("Lock error: {}", e))?;
         let entry = mgr
             .sessions
@@ -433,6 +457,7 @@ pub async fn restart_proxy_session(
             entry.target_origin.clone(),
             entry.connection_id.clone(),
             entry.verify_ssl,
+            entry.accepted_cert_fingerprint.clone(),
             entry.min_tls_version.clone(),
         )
     };
@@ -448,18 +473,11 @@ pub async fn restart_proxy_session(
     }
 
     // Build a fresh reqwest client.
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(120))
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .pool_idle_timeout(std::time::Duration::from_secs(20))
-        .pool_max_idle_per_host(4)
-        .tcp_keepalive(std::time::Duration::from_secs(30))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .danger_accept_invalid_certs(!verify_ssl)
-        .min_tls_version(resolve_min_tls_version(&min_tls))
-        .cookie_store(true)
-        .build()
-        .map_err(|e| format!("Failed to create proxy HTTP client: {}", e))?;
+    let client = proxy_client_builder(
+        verify_ssl,
+        accepted_cert_fingerprint.as_deref(),
+        &min_tls,
+    )?;
 
     // Bind to a new random free port.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/src/hooks/protocol/useWebBrowser.ts
+++ b/src/hooks/protocol/useWebBrowser.ts
@@ -110,24 +110,12 @@ export function useWebBrowser(session: ConnectionSession) {
   const loadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const navGenRef = useRef(0);
   /**
-   * P6c: set to `true` once `fetchAndVerifyCert` has resolved trust
-   * for this tab — either because the cert was already in the trust
-   * store, the user accepted the themed TrustWarningDialog, or the
-   * trust policy auto-trusted (always-trust / tofu). When true, the
-   * proxy reqwest client is built with `verify_ssl: false` so it
-   * doesn't re-reject the cert and undo the user's accept.
-   *
-   * Pre-P6c: the trust accept landed in localStorage but `verify_ssl`
-   * was still derived solely from `connection.httpVerifySsl` (default
-   * `true`). The proxy then failed TLS handshake and showed the P2
-   * "Secure connection failed" themed page — from the user's POV the
-   * trust prompt accomplished nothing.
-   *
-   * Scope: per-tab (i.e. per useWebBrowser instance). The proxy is
-   * started once at first navigation and bound to the connection's
-   * target URL, so a single trust decision covers the entire session.
+   * Set once `fetchAndVerifyCert` has resolved trust for this tab.
+   * The proxy receives this SHA-256 leaf certificate fingerprint and pins
+   * outbound TLS to that exact certificate instead of disabling TLS
+   * verification for the whole session.
    */
-  const tlsTrustAcceptedRef = useRef(false);
+  const acceptedCertFingerprintRef = useRef<string | null>(null);
   const LOAD_TIMEOUT_MS = 30_000;
 
   const sslVerifyDisabled =
@@ -207,13 +195,6 @@ export function useWebBrowser(session: ConnectionSession) {
       settings.trustPolicy,
       connection?.tlsTrustPolicy ?? settings.tlsTrustPolicy ?? "always-ask",
     );
-    if (policy === "always-trust") {
-      // P6c: explicit "always-trust" — propagate to the proxy so it
-      // doesn't TLS-reject what the user said to trust.
-      tlsTrustAcceptedRef.current = true;
-      return true;
-    }
-
     // Capture the navigation generation BEFORE the async gap so we can
     // detect whether a newer navigation has superseded us after the
     // await completes (e.g. React StrictMode double-mount race).
@@ -292,6 +273,10 @@ export function useWebBrowser(session: ConnectionSession) {
         })),
       };
       setCertIdentity(identity);
+      if (policy === "always-trust") {
+        acceptedCertFingerprintRef.current = identity.fingerprint;
+        return true;
+      }
       const connId = connection?.id;
       const result = verifyIdentity(
         session.hostname,
@@ -301,15 +286,15 @@ export function useWebBrowser(session: ConnectionSession) {
         connId,
       );
       if (result.status === "trusted") {
-        // P6c: the cert was previously accepted (this session or a
-        // prior one). Tell the proxy not to second-guess us.
-        tlsTrustAcceptedRef.current = true;
+        // The cert was previously accepted (this session or a prior one).
+        // Pin the proxy to the same fingerprint.
+        acceptedCertFingerprintRef.current = identity.fingerprint;
         return true;
       }
       if (result.status === "first-use" && policy === "tofu") {
         trustIdentity(session.hostname, port, "https", identity, false, connId);
-        // P6c: TOFU auto-trusted on first contact — same as above.
-        tlsTrustAcceptedRef.current = true;
+        // TOFU auto-trusted on first contact — pin the proxy to this cert.
+        acceptedCertFingerprintRef.current = identity.fingerprint;
         return true;
       }
       if (
@@ -355,13 +340,10 @@ export function useWebBrowser(session: ConnectionSession) {
         connection?.id,
       );
     }
-    // P6c: persist the user's accept so the next `navigateToUrl`
-    // call passes `verify_ssl: false` to the proxy. Pre-P6c this was
-    // the missing wire — the dialog accept landed in localStorage but
-    // the proxy's reqwest client kept TLS verification on and
-    // rejected the cert, ending with a themed "Secure connection
-    // failed" page in the iframe and no recovery path.
-    tlsTrustAcceptedRef.current = true;
+    // Persist the user's accepted fingerprint so the next `navigateToUrl`
+    // can pass a cert pin to the proxy. The proxy must not disable TLS
+    // validation for arbitrary certificates after this trust decision.
+    acceptedCertFingerprintRef.current = certIdentity?.fingerprint ?? null;
     setTrustPrompt(null);
     trustResolveRef.current?.(true);
     trustResolveRef.current = null;
@@ -492,21 +474,19 @@ export function useWebBrowser(session: ConnectionSession) {
                 username: resolvedCreds?.username ?? "",
                 password: resolvedCreds?.password ?? "",
                 local_port: 0,
-                // P6c: the trust decision made by `fetchAndVerifyCert`
-                // (auto-trusted via policy, accepted via dialog, or
-                // looked up from a prior accept) wins. If the user
-                // trusted this cert we MUST disable verification in
-                // the proxy's reqwest client — otherwise it'd
-                // reject the cert again and serve a "Secure
-                // connection failed" themed page that the user
-                // can't recover from. The `httpVerifySsl` setting
-                // is still honoured as the gating policy: if the
-                // user explicitly turned verification off on the
-                // connection record (rare), we respect that too.
+                // Keep normal verification unless the connection record
+                // explicitly disables it. When the frontend trust flow accepted
+                // a self-signed/untrusted cert, send the accepted SHA-256 leaf
+                // fingerprint so the backend pins to that cert instead of
+                // accepting arbitrary certificates for the session.
                 verify_ssl:
-                  !tlsTrustAcceptedRef.current &&
                   ((connection as unknown as Record<string, unknown>)
                     ?.httpVerifySsl ?? true) !== false,
+                accepted_cert_fingerprint:
+                  ((connection as unknown as Record<string, unknown>)
+                    ?.httpVerifySsl ?? true) !== false
+                    ? acceptedCertFingerprintRef.current
+                    : null,
                 connection_id: connection?.id ?? "",
                 // t20: arm proxy-side web auto-login for this session
                 // when the connection opted in. Default off. The


### PR DESCRIPTION
### Motivation

- Replace the previous per-tab "disable verification" approach which turned the proxy into a blanket acceptor after a frontend trust decision, and instead pin the accepted SHA-256 leaf certificate so the proxy only trusts the specific certificate the user approved.

### Description

- Replace the boolean `tlsTrustAcceptedRef` with `acceptedCertFingerprintRef` in `useWebBrowser.ts` and set it on `always-trust`, previously-trusted, TOFU, and explicit Trust dialog accept paths so the frontend records the accepted leaf fingerprint.
- Add `accepted_cert_fingerprint` to the IPC proxy config in `useWebBrowser.ts` so `start_basic_auth_proxy` receives the fingerprint instead of a signal to disable verification.
- Extend `BasicAuthProxyConfig` and `ProxySessionEntry` with `accepted_cert_fingerprint` and persist it across restart paths in `src-tauri/crates/sorng-protocols/src/http.rs`/`http_cmds.rs`.
- Add a `proxy_client_builder` helper and wire pinned verification: when an `accepted_cert_fingerprint` is present the proxy uses a rustls `ServerCertVerifier` that accepts only the exact presented SHA-256 fingerprint, otherwise `danger_accept_invalid_certs(!verify_ssl)` is used (so `verify_ssl: false` remains an explicit escape hatch).
- Implement `PinnedCertificateVerification`, `normalize_cert_fingerprint`, and `build_pinned_tls_config` so pinned verification performs a fingerprint match while still performing signature checks; centralize client creation so pinned vs dangerous TLS selection is consistent.

### Testing

- `npx tsc --noEmit` ran and succeeded.
- `npm run format -- -- src/hooks/protocol/useWebBrowser.ts` ran and confirmed formatting rules passed.
- `cargo fmt -p sorng-protocols` and `git diff --check` were run and passed.
- `cargo check -p sorng-protocols --target x86_64-unknown-linux-gnu` was attempted but blocked by a missing system dependency (`dbus-1` / development packages) in the environment and therefore did not complete.
- `cargo check -p sorng-protocols` (native/default target) was attempted but the full build was blocked by host/toolchain system limitations in the container (missing MSVC/OpenSSL/build tools) and therefore did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbaa9424c832583abf1c18747d801)