### PR TITLE
fix(encryption): preserve password-mode lock on boot

### DIFF
--- a/src-tauri/src/state_registry.rs
+++ b/src-tauri/src/state_registry.rs
@@ -391,18 +391,17 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
     // in-memory master DEK. See crates/sorng-encryption/src/state.rs.
     //
     // Boot-time silent vault unlock — when the OS vault is available
-    // we call `ensure_dek` rather than `read_dek` so a fresh install
-    // auto-initialises a vault-mode master DEK on first boot. P4
-    // requires every database write to go through an unlocked state
-    // (eager-encrypt, explicit-downgrade-refusal policy); without
-    // auto-init the database picker would be empty on fresh installs
-    // until the user manually visited Settings → Security.
+    // and no password wrapper is configured, `ensure_dek` lets a fresh
+    // vault-only install auto-initialise a master DEK on first boot.
     //
-    // Password / hybrid modes still require explicit user input via
-    // the Settings → Security panel — `ensure_dek` only fires for the
-    // vault path here, so the user-driven setup flow is unchanged.
+    // If `dek.enc` exists, password or hybrid mode is configured. In
+    // those modes boot must remain locked until the user supplies their
+    // password; calling `ensure_dek` here would create a different vault
+    // DEK on password-only installs and incorrectly mark the process as
+    // unlocked before `encryption_unlock` can unwrap the real DEK.
     let enc_state = sorng_encryption::EncryptionState::new();
-    if sorng_vault::keychain::is_available() {
+    let password_wrap_present = app_dir.join("dek.enc").exists();
+    if !password_wrap_present && sorng_vault::keychain::is_available() {
         if let Ok(bytes) = tauri::async_runtime::block_on(
             sorng_vault::keychain::ensure_dek(),
         ) {


### PR DESCRIPTION
### Motivation
- Boot previously called `sorng_vault::keychain::ensure_dek()` unconditionally when an OS vault was available, which created and installed a fresh vault DEK even for password-only installs and silently unlocked the process.
- That behavior can bypass or downgrade password-mode protection and cause password-wrapped artifacts to become undecryptable or be re-encrypted under an unintended vault key.

### Description
- Add a check for the password-wrap sentinel file (`dek.enc`) and only run `keychain::ensure_dek()` when `dek.enc` is absent, preserving a locked state for password and hybrid modes at startup.
- Implement the check by testing `app_dir.join("dek.enc").exists()` and gating the existing `ensure_dek()` call in `src-tauri/src/state_registry.rs` accordingly.
- Add inline comments explaining why boot must remain locked when `dek.enc` is present to avoid creating/installing a new vault DEK prematurely.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors for the modified file and passed.
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml` to apply repository formatting; the command completed locally.
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check` which flagged unrelated pre-existing formatting diffs in other files and therefore reported non-zero exit status.
- Ran `cargo check --manifest-path src-tauri/Cargo.toml --lib` which failed in this environment due to a missing system package (`glib-2.0` required by `glib-sys`) and not because of the introduced change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbef336c88325abccece02c9962f3)