### PR TITLE
Normalize scheme-prefixed hostnames for HTTPS cert trust and proxy targets

### DIFF
--- a/src/hooks/protocol/useWebBrowser.ts
+++ b/src/hooks/protocol/useWebBrowser.ts
@@ -45,6 +45,10 @@ export function useWebBrowser(session: ConnectionSession) {
   const connection = state.connections.find(
     (c) => c.id === session.connectionId,
   );
+  const normalizedHostname = useMemo(
+    () => stripSchemePrefix(session.hostname),
+    [session.hostname],
+  );
 
   // ── Derived auth ────────────────────────────────────────────
   const resolvedCreds = useMemo<{
@@ -81,9 +85,8 @@ export function useWebBrowser(session: ConnectionSession) {
     // editor also sanitises at input time (GeneralSection.tsx) so
     // new connections never reach this point un-cleaned — this
     // belt is for existing data + .mremoteng/.royal imports.
-    const cleanHost = stripSchemePrefix(session.hostname);
-    return `${protocol}://${cleanHost}${portSuffix}/`;
-  }, [connection, session.protocol, session.hostname]);
+    return `${protocol}://${normalizedHostname}${portSuffix}/`;
+  }, [connection, session.protocol, normalizedHostname]);
 
   // ── State ───────────────────────────────────────────────────
   const [currentUrl, setCurrentUrl] = useState(buildTargetUrl);
@@ -250,7 +253,7 @@ export function useWebBrowser(session: ConnectionSession) {
           valid_from: string;
           valid_to: string;
         }> | null;
-      }>("get_tls_certificate_info", { host: session.hostname, port });
+      }>("get_tls_certificate_info", { host: normalizedHostname, port });
 
       // If a newer navigation started while we were awaiting the cert,
       // this call is stale — bail out so we don't overwrite the ref
@@ -294,7 +297,7 @@ export function useWebBrowser(session: ConnectionSession) {
       setCertIdentity(identity);
       const connId = connection?.id;
       const result = verifyIdentity(
-        session.hostname,
+        normalizedHostname,
         port,
         "https",
         identity,
@@ -307,7 +310,14 @@ export function useWebBrowser(session: ConnectionSession) {
         return true;
       }
       if (result.status === "first-use" && policy === "tofu") {
-        trustIdentity(session.hostname, port, "https", identity, false, connId);
+        trustIdentity(
+          normalizedHostname,
+          port,
+          "https",
+          identity,
+          false,
+          connId,
+        );
         // P6c: TOFU auto-trusted on first contact — same as above.
         tlsTrustAcceptedRef.current = true;
         return true;
@@ -336,7 +346,7 @@ export function useWebBrowser(session: ConnectionSession) {
     }
   }, [
     session.protocol,
-    session.hostname,
+    normalizedHostname,
     connection,
     settings.httpsTrustPolicy,
     settings.trustPolicy,
@@ -347,7 +357,7 @@ export function useWebBrowser(session: ConnectionSession) {
     if (trustPrompt && certIdentity) {
       const port = connection?.port || 443;
       trustIdentity(
-        session.hostname,
+        normalizedHostname,
         port,
         "https",
         certIdentity,
@@ -365,7 +375,7 @@ export function useWebBrowser(session: ConnectionSession) {
     setTrustPrompt(null);
     trustResolveRef.current?.(true);
     trustResolveRef.current = null;
-  }, [trustPrompt, certIdentity, session.hostname, connection]);
+  }, [trustPrompt, certIdentity, normalizedHostname, connection]);
 
   const handleTrustReject = useCallback(() => {
     setTrustPrompt(null);

--- a/tests/protocol/webAutoLogin.test.ts
+++ b/tests/protocol/webAutoLogin.test.ts
@@ -10,9 +10,13 @@
  * This is a DIFFERENT level than the e3/e5 Rust unit tests (which check the
  * proxy/asset side): it pins the actual invoke payload the React hook sends.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { invoke } from '@tauri-apps/api/core';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  verifyIdentity,
+  resolveEffectiveTrustPolicy,
+} from "../../src/utils/auth/trustStore";
 
 // ── Mocks for the hook's context / side-effect dependencies ──
 const { mockDispatch, connections } = vi.hoisted(() => ({
@@ -20,85 +24,98 @@ const { mockDispatch, connections } = vi.hoisted(() => ({
   connections: [] as Record<string, unknown>[],
 }));
 
-vi.mock('../../src/contexts/useConnections', () => ({
-  useConnections: vi.fn(() => ({ state: { connections }, dispatch: mockDispatch })),
+vi.mock("../../src/contexts/useConnections", () => ({
+  useConnections: vi.fn(() => ({
+    state: { connections },
+    dispatch: mockDispatch,
+  })),
 }));
-vi.mock('../../src/contexts/SettingsContext', () => ({
-  useSettings: vi.fn(() => ({ settings: { theme: 'dark' }, updateSettings: vi.fn() })),
+vi.mock("../../src/contexts/SettingsContext", () => ({
+  useSettings: vi.fn(() => ({
+    settings: { theme: "dark" },
+    updateSettings: vi.fn(),
+  })),
 }));
-vi.mock('../../src/contexts/ToastContext', () => ({
+vi.mock("../../src/contexts/ToastContext", () => ({
   useToastContext: vi.fn(() => ({ toast: vi.fn() })),
 }));
-vi.mock('../../src/hooks/recording/useWebRecorder', () => ({
-  useWebRecorder: vi.fn(() => ({ startRecording: vi.fn(), stopRecording: vi.fn() })),
+vi.mock("../../src/hooks/recording/useWebRecorder", () => ({
+  useWebRecorder: vi.fn(() => ({
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  })),
 }));
-vi.mock('../../src/hooks/recording/useDisplayRecorder', () => ({
+vi.mock("../../src/hooks/recording/useDisplayRecorder", () => ({
   useDisplayRecorder: vi.fn(() => ({})),
 }));
-vi.mock('../../src/utils/recording/macroService', () => ({
+vi.mock("../../src/utils/recording/macroService", () => ({
   saveWebRecording: vi.fn(),
   trimWebRecordings: vi.fn(),
 }));
-vi.mock('../../src/utils/auth/trustStore', () => ({
+vi.mock("../../src/utils/auth/trustStore", () => ({
   verifyIdentity: vi.fn(),
   trustIdentity: vi.fn(),
   resolveEffectiveTrustPolicy: vi.fn(),
 }));
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
 }));
-vi.mock('@tauri-apps/plugin-dialog', () => ({
+vi.mock("@tauri-apps/plugin-dialog", () => ({
   save: vi.fn(),
 }));
 
-import { useWebBrowser } from '../../src/hooks/protocol/useWebBrowser';
-import type { ConnectionSession } from '../../src/types/connection/connection';
+import { useWebBrowser } from "../../src/hooks/protocol/useWebBrowser";
+import type { ConnectionSession } from "../../src/types/connection/connection";
 
 const mockInvoke = vi.mocked(invoke);
+const mockVerifyIdentity = vi.mocked(verifyIdentity);
+const mockResolveEffectiveTrustPolicy = vi.mocked(resolveEffectiveTrustPolicy);
 
 const session: ConnectionSession = {
-  id: 'sess-1',
-  connectionId: 'conn-1',
-  name: 'Device Panel',
-  status: 'connected',
+  id: "sess-1",
+  connectionId: "conn-1",
+  name: "Device Panel",
+  status: "connected",
   startTime: new Date(),
-  protocol: 'http',
-  hostname: 'device.local',
+  protocol: "http",
+  hostname: "device.local",
 };
 
 /** Pull the config object from the first `start_basic_auth_proxy` invoke. */
 function lastProxyConfig(): Record<string, unknown> | undefined {
-  const call = mockInvoke.mock.calls.find((c) => c[0] === 'start_basic_auth_proxy');
+  const call = mockInvoke.mock.calls.find(
+    (c) => c[0] === "start_basic_auth_proxy",
+  );
   if (!call) return undefined;
   return (call[1] as { config: Record<string, unknown> }).config;
 }
 
-describe('useWebBrowser — web auto-login invoke mapping (t20)', () => {
+describe("useWebBrowser — web auto-login invoke mapping (t20)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     connections.length = 0;
     mockInvoke.mockReset();
     mockInvoke.mockResolvedValue({
       local_port: 9000,
-      session_id: 'proxy-1',
-      proxy_url: 'http://127.0.0.1:9000',
+      session_id: "proxy-1",
+      proxy_url: "http://127.0.0.1:9000",
     });
   });
 
-  it('maps httpAutoLogin + camelCase selectors to the snake_case config when armed', async () => {
+  it("maps httpAutoLogin + camelCase selectors to the snake_case config when armed", async () => {
     connections.push({
-      id: 'conn-1',
-      name: 'Device Panel',
-      hostname: 'device.local',
-      protocol: 'http',
-      username: 'admin',
-      password: 'devpass',
+      id: "conn-1",
+      name: "Device Panel",
+      hostname: "device.local",
+      protocol: "http",
+      username: "admin",
+      password: "devpass",
       httpVerifySsl: true,
       httpAutoLogin: true,
       httpAutoLoginSelectors: {
-        usernameSelector: '#user',
-        passwordSelector: '#pass',
-        submitSelector: '#go',
+        usernameSelector: "#user",
+        passwordSelector: "#pass",
+        submitSelector: "#go",
       },
       isGroup: false,
       createdAt: new Date().toISOString(),
@@ -107,30 +124,30 @@ describe('useWebBrowser — web auto-login invoke mapping (t20)', () => {
 
     const { result } = renderHook(() => useWebBrowser(session));
     await act(async () => {
-      await result.current.navigateToUrl('http://device.local/login');
+      await result.current.navigateToUrl("http://device.local/login");
     });
 
     const config = lastProxyConfig();
     expect(config).toBeDefined();
     expect(config?.http_auto_login).toBe(true);
     expect(config?.http_auto_login_selectors).toEqual({
-      username_selector: '#user',
-      password_selector: '#pass',
-      submit_selector: '#go',
+      username_selector: "#user",
+      password_selector: "#pass",
+      submit_selector: "#go",
     });
     // The credential is NOT a new field — it rides the existing username/password.
-    expect(config?.username).toBe('admin');
-    expect(config?.password).toBe('devpass');
+    expect(config?.username).toBe("admin");
+    expect(config?.password).toBe("devpass");
   });
 
-  it('sends http_auto_login=false and omits selectors when not opted in', async () => {
+  it("sends http_auto_login=false and omits selectors when not opted in", async () => {
     connections.push({
-      id: 'conn-1',
-      name: 'Plain Site',
-      hostname: 'device.local',
-      protocol: 'http',
-      username: 'admin',
-      password: 'devpass',
+      id: "conn-1",
+      name: "Plain Site",
+      hostname: "device.local",
+      protocol: "http",
+      username: "admin",
+      password: "devpass",
       httpVerifySsl: true,
       // httpAutoLogin absent → off
       isGroup: false,
@@ -140,7 +157,7 @@ describe('useWebBrowser — web auto-login invoke mapping (t20)', () => {
 
     const { result } = renderHook(() => useWebBrowser(session));
     await act(async () => {
-      await result.current.navigateToUrl('http://device.local/login');
+      await result.current.navigateToUrl("http://device.local/login");
     });
 
     const config = lastProxyConfig();
@@ -150,14 +167,14 @@ describe('useWebBrowser — web auto-login invoke mapping (t20)', () => {
     expect(config?.http_auto_login_selectors).toBeUndefined();
   });
 
-  it('arms auto-login but omits selectors when the toggle is on with no overrides', async () => {
+  it("arms auto-login but omits selectors when the toggle is on with no overrides", async () => {
     connections.push({
-      id: 'conn-1',
-      name: 'Heuristic Site',
-      hostname: 'device.local',
-      protocol: 'http',
-      username: 'admin',
-      password: 'devpass',
+      id: "conn-1",
+      name: "Heuristic Site",
+      hostname: "device.local",
+      protocol: "http",
+      username: "admin",
+      password: "devpass",
       httpVerifySsl: true,
       httpAutoLogin: true,
       // no httpAutoLoginSelectors → backend heuristic, undefined selectors
@@ -168,11 +185,84 @@ describe('useWebBrowser — web auto-login invoke mapping (t20)', () => {
 
     const { result } = renderHook(() => useWebBrowser(session));
     await act(async () => {
-      await result.current.navigateToUrl('http://device.local/login');
+      await result.current.navigateToUrl("http://device.local/login");
     });
 
     const config = lastProxyConfig();
     expect(config?.http_auto_login).toBe(true);
     expect(config?.http_auto_login_selectors).toBeUndefined();
+  });
+
+  it("normalizes scheme-prefixed HTTPS hostnames before certificate trust checks", async () => {
+    connections.push({
+      id: "conn-1",
+      name: "Legacy HTTPS Admin",
+      hostname: "https://admin.example.test",
+      protocol: "https",
+      port: 443,
+      httpVerifySsl: true,
+      isGroup: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    const httpsSession: ConnectionSession = {
+      ...session,
+      protocol: "https",
+      hostname: "https://admin.example.test",
+    };
+    mockResolveEffectiveTrustPolicy.mockReturnValue("tofu");
+    mockVerifyIdentity.mockReturnValue({ status: "trusted" });
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === "get_tls_certificate_info") {
+        return {
+          fingerprint: "sha256:clean-host-cert",
+          subject: "CN=admin.example.test",
+          issuer: "CN=Test CA",
+          pem: null,
+          valid_from: null,
+          valid_to: null,
+          serial: null,
+          signature_algorithm: null,
+          san: [],
+          subject_cn: "admin.example.test",
+          subject_org: null,
+          subject_ou: null,
+          subject_country: null,
+          subject_state: null,
+          subject_locality: null,
+          subject_email: null,
+          issuer_cn: "Test CA",
+          issuer_org: null,
+          issuer_country: null,
+          key_algorithm: null,
+          key_size: null,
+          version: null,
+          chain: null,
+        };
+      }
+      return {
+        local_port: 9000,
+        session_id: "proxy-1",
+        proxy_url: "http://127.0.0.1:9000",
+      };
+    });
+
+    const { result } = renderHook(() => useWebBrowser(httpsSession));
+    await act(async () => {
+      await result.current.navigateToUrl("https://admin.example.test/");
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("get_tls_certificate_info", {
+      host: "admin.example.test",
+      port: 443,
+    });
+    expect(mockVerifyIdentity).toHaveBeenCalledWith(
+      "admin.example.test",
+      443,
+      "https",
+      expect.objectContaining({ fingerprint: "sha256:clean-host-cert" }),
+      "conn-1",
+    );
+    expect(lastProxyConfig()?.target_url).toBe("https://admin.example.test/");
   });
 });


### PR DESCRIPTION
### Motivation
- Existing sanitisation only stripped schemes when composing the proxy target URL which let the backend cert fetch and trust checks receive a scheme-prefixed host (e.g. `https://admin.example.test`), causing the Rust cert lookup to fail and the frontend to `return true` (fail open), bypassing TOFU/pinning/strict checks.
- Use a single, canonical cleaned hostname so the host the proxy connects to and the host used for certificate retrieval/trust decisions match exactly.

### Description
- Introduce a `normalizedHostname` via `useMemo(() => stripSchemePrefix(session.hostname))` and reuse it throughout the hook instead of raw `session.hostname` for URL construction and trust code paths.
- Update `buildTargetUrl` to reference `normalizedHostname` so proxy `target_url` remains the sanitized origin.
- Pass `normalizedHostname` to the `get_tls_certificate_info` invoke and use it for `verifyIdentity`/`trustIdentity` and when persisting a trust accept so certificate retrieval and trust-store keys align with the proxy target.
- Add a regression test in `tests/protocol/webAutoLogin.test.ts` that verifies a stored `https://...` hostname results in `get_tls_certificate_info` and `verifyIdentity` being called with the bare host while the proxy `target_url` remains the sanitized `https://.../`.

### Testing
- Ran unit tests: `npx vitest run tests/protocol/webAutoLogin.test.ts tests/utils/sanitizeHostname.test.ts --reporter=verbose`, and both test files passed (all tests passed).
- Type-check: `npx tsc --noEmit` completed cleanly with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb68fad408325bd4f25050ecaf560)