### PR TITLE
fix(encryption): prevent plaintext downgrade

### DIFF
--- a/src-tauri/crates/sorng-storage/src/backup.rs
+++ b/src-tauri/crates/sorng-storage/src/backup.rs
@@ -612,13 +612,16 @@ impl BackupService {
         // legacy SORNG1 paths. The migrator that converted SORNG1
         // files to v2 lived briefly between commits 57cf5505 and Z;
         // it's been removed now that the dev tree is fully migrated.
-        let used_v2 = self.encryption_state.is_some()
-            && self
-                .encryption_state
-                .as_ref()
-                .unwrap()
-                .is_unlocked()
-                .await;
+        let used_v2 = match self.encryption_state.as_ref() {
+            Some(state) if state.is_unlocked().await => true,
+            Some(_) => {
+                return Err(
+                    "Backup encryption state is locked; unlock before creating backups"
+                        .to_string(),
+                );
+            }
+            None => false,
+        };
         let encrypted_data = if used_v2 {
             self.encrypt_backup_v2(&final_data).await?
         } else {
@@ -2683,10 +2686,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn locked_state_falls_back_to_legacy_or_plaintext() {
-        // EncryptionState installed but never unlocked → v2 path is
-        // skipped without erroring; fall through to legacy / plaintext
-        // exactly like a no-encryption build.
+    async fn locked_state_refuses_plaintext_downgrade() {
+        // EncryptionState installed but never unlocked → refuse to write
+        // rather than silently downgrading secrets to plaintext.
         let tmp = fresh_temp_dir("v2_locked");
         let state = BackupService::new(tmp.to_string_lossy().to_string());
         let mut svc = state.lock().await;
@@ -2696,16 +2698,20 @@ mod tests {
         svc.set_encryption_state(locked);
 
         let data = serde_json::json!({ "connections": [] });
-        let _ = svc.perform_backup("manual", &data).await.unwrap();
-        let entry = std::fs::read_dir(&tmp).unwrap().find_map(|e| {
-            let e = e.ok()?;
-            let name = e.file_name().to_string_lossy().into_owned();
-            (name.starts_with("backup_") && !name.contains(".meta.")).then_some(e.path())
-        }).unwrap();
-        let bytes = std::fs::read(&entry).unwrap();
-        // No password configured and locked state → plaintext on disk.
-        assert_ne!(&bytes[..6.min(bytes.len())], sorng_encryption::envelope::MAGIC);
-        assert_ne!(&bytes[..6.min(bytes.len())], b"SORNG1");
+        let err = svc.perform_backup("manual", &data).await.unwrap_err();
+        assert!(
+            err.contains("encryption state is locked"),
+            "expected locked-state downgrade refusal, got: {err}"
+        );
+        let backup_files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                let name = e.file_name().to_string_lossy().into_owned();
+                (name.starts_with("backup_") && !name.contains(".meta.")).then_some(e.path())
+            })
+            .collect();
+        assert!(backup_files.is_empty(), "locked state must not write plaintext backups");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/crates/sorng-storage/src/storage.rs
+++ b/src-tauri/crates/sorng-storage/src/storage.rs
@@ -76,9 +76,9 @@ pub struct SecureStorage {
     store_path: String,
     /// Master encryption-at-rest handle. When `Some` and unlocked,
     /// writes go through the v2 envelope codec
-    /// (`sorng-v1::connections` sub-key); when `None` or locked,
-    /// writes land as plain JSON. Installed via
-    /// `set_encryption_state` after `app.manage(EncryptionState)`.
+    /// (`sorng-v1::connections` sub-key). A missing state is reserved
+    /// for tests and writes plain JSON; an installed-but-locked state
+    /// refuses writes rather than silently downgrading secrets.
     encryption_state:
         Option<Arc<sorng_encryption::EncryptionState>>,
 }
@@ -237,16 +237,20 @@ impl SecureStorage {
         // arg is retained on the Tauri-facing API for backward-compat
         // with the previous serde shape but no longer influences
         // anything; the master key is the single source of truth.
-        let used_v2 = self.encryption_state.is_some()
-            && self
-                .encryption_state
-                .as_ref()
-                .unwrap()
-                .is_unlocked()
-                .await;
+        let state = self.encryption_state.as_ref();
+        let used_v2 = match state {
+            Some(state) if state.is_unlocked().await => true,
+            Some(_) => {
+                return Err(
+                    "Connections database encryption state is locked; unlock before saving"
+                        .to_string(),
+                );
+            }
+            None => false,
+        };
 
         if used_v2 {
-            let state = self.encryption_state.as_ref().unwrap();
+            let state = state.unwrap();
             let value: serde_json::Value =
                 serde_json::from_str(&json).map_err(|e| e.to_string())?;
             let mode = sorng_encryption::envelope::MasterKeyStorage::Vault;
@@ -498,6 +502,25 @@ mod connections_dispatch_tests {
         svc.set_encryption_state(locked);
         let err = svc.load_data().await.unwrap_err();
         assert!(err.contains("encrypted") || err.contains("unlock"));
+    }
+
+    #[tokio::test]
+    async fn locked_state_refuses_plaintext_downgrade() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("data.json").to_string_lossy().to_string();
+        let mut svc = build_storage(path.clone());
+        let locked = Arc::new(EncryptionState::new());
+        svc.set_encryption_state(locked);
+
+        let err = svc.save_data(sample_data(), false).await.unwrap_err();
+        assert!(
+            err.contains("encryption state is locked"),
+            "expected locked-state downgrade refusal, got: {err}"
+        );
+        assert!(
+            !Path::new(&path).exists(),
+            "locked state must not write plaintext storage"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/state_registry.rs
+++ b/src-tauri/src/state_registry.rs
@@ -308,6 +308,51 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
 
     let app_dir = app.path().app_data_dir()?;
 
+    // Encryption-at-rest subsystem (Phase 0): managed state holds the
+    // in-memory master DEK. See crates/sorng-encryption/src/state.rs.
+    //
+    // Boot-time silent vault unlock — when the OS vault is available
+    // we call `ensure_dek` rather than `read_dek` so a fresh install
+    // auto-initialises a vault-mode master DEK on first boot. P4
+    // requires every database write to go through an unlocked state
+    // (eager-encrypt, explicit-downgrade-refusal policy); without
+    // auto-init the database picker would be empty on fresh installs
+    // until the user manually visited Settings → Security.
+    //
+    // Password / hybrid modes still require explicit user input via
+    // the Settings → Security panel — `ensure_dek` only fires for the
+    // vault path here, so the user-driven setup flow is unchanged.
+    let enc_state = sorng_encryption::EncryptionState::new();
+    if sorng_vault::keychain::is_available() {
+        if let Ok(bytes) = tauri::async_runtime::block_on(sorng_vault::keychain::ensure_dek()) {
+            if let Some(dek) = sorng_encryption::MasterDek::from_bytes(&bytes) {
+                tauri::async_runtime::block_on(enc_state.install(dek));
+                println!("Encryption-at-rest: vault DEK ensured + installed at boot.");
+            }
+        }
+    }
+    // Snapshot the (cheaply cloneable Arc-backed) handle BEFORE
+    // `app.manage` consumes it — the logger drainer task owns its
+    // own clone so it survives independent of Tauri state lookups.
+    let enc_state_for_logger = enc_state.clone();
+    app.manage(enc_state);
+
+    // Install the encrypted log adapter once the encryption state
+    // exists. Gated on `debug_assertions` to preserve the prior
+    // tauri_plugin_log behaviour (no global logger in release until
+    // the rollout flips the gate). The state may be locked here —
+    // the sink buffers lines until unlock, so no records are lost.
+    if cfg!(debug_assertions) {
+        let logs_dir = app_dir.join("logs");
+        if let Err(e) = sorng_encryption::log_adapter::EncryptedLogAdapter::install(
+            std::sync::Arc::new(enc_state_for_logger),
+            logs_dir,
+            log::LevelFilter::Info,
+        ) {
+            eprintln!("Failed to install encrypted log adapter: {}", e);
+        }
+    }
+
     let updater_service = UpdaterService::new(env!("CARGO_PKG_VERSION"), &app_dir);
     app.manage(updater_service);
 
@@ -319,9 +364,9 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
     let secure_storage = SecureStorage::new(storage_path.to_string_lossy().to_string());
     // Phase 8 — inject the master-key handle so subsequent saves use
     // the v2 connections envelope (`sorng-v1::connections`) when
-    // unlocked. Falls through silently when no encryption state is
-    // installed (the pre-encryption boot path remains valid for
-    // tests).
+    // unlocked. The encryption state is managed above before this
+    // service is created, so production writes cannot silently miss
+    // the handle and downgrade to plaintext.
     if let Some(enc_handle) = app.try_state::<sorng_encryption::EncryptionState>() {
         let enc_arc = std::sync::Arc::new(enc_handle.inner().clone());
         let svc = secure_storage.clone();
@@ -387,55 +432,6 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
 
     access::register(app);
 
-    // Encryption-at-rest subsystem (Phase 0): managed state holds the
-    // in-memory master DEK. See crates/sorng-encryption/src/state.rs.
-    //
-    // Boot-time silent vault unlock — when the OS vault is available
-    // we call `ensure_dek` rather than `read_dek` so a fresh install
-    // auto-initialises a vault-mode master DEK on first boot. P4
-    // requires every database write to go through an unlocked state
-    // (eager-encrypt, explicit-downgrade-refusal policy); without
-    // auto-init the database picker would be empty on fresh installs
-    // until the user manually visited Settings → Security.
-    //
-    // Password / hybrid modes still require explicit user input via
-    // the Settings → Security panel — `ensure_dek` only fires for the
-    // vault path here, so the user-driven setup flow is unchanged.
-    let enc_state = sorng_encryption::EncryptionState::new();
-    if sorng_vault::keychain::is_available() {
-        if let Ok(bytes) = tauri::async_runtime::block_on(
-            sorng_vault::keychain::ensure_dek(),
-        ) {
-            if let Some(dek) = sorng_encryption::MasterDek::from_bytes(&bytes) {
-                tauri::async_runtime::block_on(enc_state.install(dek));
-                println!(
-                    "Encryption-at-rest: vault DEK ensured + installed at boot."
-                );
-            }
-        }
-    }
-    // Snapshot the (cheaply cloneable Arc-backed) handle BEFORE
-    // `app.manage` consumes it — the logger drainer task owns its
-    // own clone so it survives independent of Tauri state lookups.
-    let enc_state_for_logger = enc_state.clone();
-    app.manage(enc_state);
-
-    // Install the encrypted log adapter once the encryption state
-    // exists. Gated on `debug_assertions` to preserve the prior
-    // tauri_plugin_log behaviour (no global logger in release until
-    // the rollout flips the gate). The state may be locked here —
-    // the sink buffers lines until unlock, so no records are lost.
-    if cfg!(debug_assertions) {
-        let logs_dir = app_dir.join("logs");
-        if let Err(e) = sorng_encryption::log_adapter::EncryptedLogAdapter::install(
-            std::sync::Arc::new(enc_state_for_logger),
-            logs_dir,
-            log::LevelFilter::Info,
-        ) {
-            eprintln!("Failed to install encrypted log adapter: {}", e);
-        }
-    }
-
     #[cfg(any(feature = "ops", feature = "collab", feature = "platform"))]
     platform::register(app);
     #[cfg(any(feature = "collab", feature = "platform"))]
@@ -483,15 +479,13 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
     // readable here for vault-mode installs. Password / hybrid mode
     // installs surface "locked" and simply skip the priming step; the
     // capabilities load anyway as soon as the user unlocks.
-    if let Some(enc_state_handle) =
-        app.app_handle().try_state::<sorng_encryption::EncryptionState>()
+    if let Some(enc_state_handle) = app
+        .app_handle()
+        .try_state::<sorng_encryption::EncryptionState>()
     {
         if let Ok(dir) = app.app_handle().path().app_data_dir() {
             if let Ok(Some(value)) = tauri::async_runtime::block_on(
-                crate::app_settings_commands::read_app_settings_inner(
-                    &dir,
-                    &enc_state_handle,
-                ),
+                crate::app_settings_commands::read_app_settings_inner(&dir, &enc_state_handle),
             ) {
                 if let Some(list) = value
                     .get("restApi")

--- a/src-tauri/src/state_registry/security_data.rs
+++ b/src-tauri/src/state_registry/security_data.rs
@@ -106,9 +106,9 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>, app_dir: &std::path::Pa
     let backup_service = backup::BackupService::new(backup_path.to_string_lossy().to_string());
     // Phase 3a — inject the encryption state so the backup pipeline
     // writes v2 envelopes whenever the master key is unlocked.
-    // `EncryptionState` was installed by the main bootstrap before
-    // this function runs; falling through silently is fine for the
-    // unit-test boot path that pre-dates encryption-at-rest.
+    // `EncryptionState` is installed by the main bootstrap before
+    // this function runs; production backups therefore cannot miss
+    // the handle and silently downgrade to plaintext.
     if let Some(enc_handle) = app.try_state::<sorng_encryption::EncryptionState>() {
         let enc_arc = std::sync::Arc::new(enc_handle.inner().clone());
         let svc = backup_service.clone();


### PR DESCRIPTION
### Motivation
- Prevent silent plaintext downgrade when an `EncryptionState` is installed but locked so configured-encrypted storage/backups cannot be written as plaintext.

### Description
- Initialize and `app.manage` the global `EncryptionState` earlier in `src-tauri/src/state_registry.rs` so services can attach the managed handle during registration.
- Change `SecureStorage::save_data` in `src-tauri/crates/sorng-storage/src/storage.rs` to refuse writes when an installed `EncryptionState` is present but locked (return an error) instead of falling back to plaintext.
- Change `BackupService::perform_backup` in `src-tauri/crates/sorng-storage/src/backup.rs` to refuse backup creation when an installed `EncryptionState` is present but locked instead of writing plaintext/compressed bytes.
- Add regression tests that assert writes fail and no plaintext files are produced when the state is installed but locked (`locked_state_refuses_plaintext_downgrade` in both storage and backup test modules).

### Testing
- Ran `cargo test -p sorng-storage locked_state_refuses_plaintext_downgrade --manifest-path src-tauri/Cargo.toml`, which attempted to build but was blocked by the system dependency `glib-2.0` missing for `glib-sys` (build error), so the new tests could not be executed to completion.
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check`, which reported pre-existing formatting diffs outside this patch and therefore was not fully clean; the patch itself was formatted with `cargo fmt` during development.
- Verified repository static checks: `git diff --check` and commit creation succeeded and the branch contains the change set as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc85ded2083258a97b00ce01ef4a9)