### PR TITLE
Fix live API capability disable state registration

### DIFF
--- a/src-tauri/crates/sorng-commands-core/src/lib.rs
+++ b/src-tauri/crates/sorng-commands-core/src/lib.rs
@@ -30,7 +30,7 @@ mod encryption_rotation_commands;
 #[path = "../../../src/api_capability.rs"]
 mod api_capability;
 #[path = "../../../src/api_capability_commands.rs"]
-mod api_capability_commands;
+pub mod api_capability_commands;
 #[path = "../../../src/aws_commands.rs"]
 mod aws_commands;
 #[path = "../../../src/backup_commands.rs"]

--- a/src-tauri/src/api_capability_commands.rs
+++ b/src-tauri/src/api_capability_commands.rs
@@ -6,10 +6,11 @@
 //!
 //! `set_api_disabled_capabilities` reaches the running API server via
 //! a [`DisabledCapsSetter`] function-trait-object the main app crate
-//! registers in Tauri state at startup. That indirection avoids a
-//! circular dep between `sorng-commands-core` and the main app crate
-//! (the latter already depends on the former, so the former can't
-//! import `crate::api::ApiService` directly).
+//! registers in Tauri state at startup. This file is compiled as part
+//! of `sorng-commands-core`, so the main app must register that exact
+//! exported type in Tauri state. Tauri state is keyed by concrete type,
+//! and registering a same-named type from another crate would not be
+//! visible to this command.
 
 use crate::api_capability::{CapabilityGroup, CapabilityMeta, ALL_CAPABILITIES};
 use serde::Serialize;
@@ -77,18 +78,20 @@ pub fn get_api_capabilities() -> Vec<ApiCapabilityDto> {
 /// Mandatory capabilities passed in the list are silently filtered
 /// out by the underlying `ApiService::set_disabled_capabilities`.
 ///
-/// Returns `Ok(())` even if no `DisabledCapsSetter` has been
-/// registered — that happens in the unlikely event the API server
-/// failed to start, in which case the disabled-list is moot anyway.
+/// Returns an error if no `DisabledCapsSetter` has been registered so
+/// the frontend cannot silently believe a live access-control update
+/// succeeded when the running API gate was not actually changed.
 #[tauri::command]
 pub fn set_api_disabled_capabilities(
     app: tauri::AppHandle,
     disabled: Vec<String>,
 ) -> Result<(), String> {
     use tauri::Manager;
-    if let Some(setter) = app.try_state::<DisabledCapsSetter>() {
-        (setter.0)(disabled);
-    }
+    let setter = app.try_state::<DisabledCapsSetter>().ok_or_else(|| {
+        "REST API capability updater is unavailable; live capability changes were not applied"
+            .to_string()
+    })?;
+    (setter.0)(disabled);
     Ok(())
 }
 

--- a/src-tauri/src/state_registry.rs
+++ b/src-tauri/src/state_registry.rs
@@ -512,7 +512,7 @@ pub(crate) fn register(app: &mut tauri::App<tauri::Wry>) -> tauri::Result<()> {
     // see api_capability_commands.rs.
     {
         let svc_for_setter = api_service.clone();
-        let setter = crate::api_capability_commands::DisabledCapsSetter(Arc::new(
+        let setter = sorng_commands_core::api_capability_commands::DisabledCapsSetter(Arc::new(
             move |ids: Vec<String>| {
                 svc_for_setter.set_disabled_capabilities(ids);
             },


### PR DESCRIPTION
### Motivation
- A runtime mismatch caused the `set_api_disabled_capabilities` Tauri command to look up a different `DisabledCapsSetter` type than the one the main app registered, making live capability disables silently no-op. 
- The change ensures the frontend-driven disabled-capability list is applied to the running `ApiService` immediately and that failures to apply are reported instead of returning silent success.

### Description
- Export the commands-core module by changing the include in `crates/sorng-commands-core/src/lib.rs` to `pub mod api_capability_commands` so the exact command-side type is accessible to the app. 
- Register the setter in app state as `sorng_commands_core::api_capability_commands::DisabledCapsSetter` in `src-tauri/src/state_registry.rs` so the Tauri-keyed concrete type matches the command lookup. 
- Harden the command `set_api_disabled_capabilities` in `src-tauri/src/api_capability_commands.rs` to return an error when the updater state is unavailable instead of silently returning `Ok(())`. 
- Add clarifying documentation in the command module explaining that Tauri state is keyed by concrete Rust type and the exported core type must be used.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Attempted the targeted unit test `cargo test -p sorng-commands-core api_capability_commands::tests::mandatory_entries_round_trip -- --nocapture`, which could not complete due to the container missing the system `glib-2.0` pkg-config dependency and therefore failed to build. 
- Re-ran the same test with `--no-default-features`, which likewise failed for the same missing system dependency, so the repository tests could not be executed to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fde2e40c083259c83333a18bf5451)