### PR TITLE
fix(encryption): remove plaintext settings after migration

### DIFF
--- a/src-tauri/crates/sorng-encryption/src/artifacts/settings.rs
+++ b/src-tauri/crates/sorng-encryption/src/artifacts/settings.rs
@@ -15,8 +15,6 @@
 //! ```text
 //!   settings.json       v0 plaintext (legacy; read for migration only)
 //!   settings.enc        v2 envelope (current)
-//!   settings.json.v0.bak post-migration rollback copy (kept for one
-//!                       release as a safety net; manual delete after)
 //! ```
 
 use rand::rngs::OsRng;
@@ -32,9 +30,6 @@ use crate::state::EncryptionState;
 
 /// Filename for the encrypted settings blob inside the app-data dir.
 pub const SETTINGS_ENC_FILENAME: &str = "settings.enc";
-
-/// Filename for the post-migration plaintext backup.
-pub const SETTINGS_BACKUP_FILENAME: &str = "settings.json.v0.bak";
 
 /// Errors raised by the settings artifact codec.
 #[derive(Debug, thiserror::Error)]

--- a/src-tauri/crates/sorng-encryption/src/commands.rs
+++ b/src-tauri/crates/sorng-encryption/src/commands.rs
@@ -10,8 +10,7 @@
 //!   `settings.enc` when the state is unlocked; reads dispatch by
 //!   `looks_like_envelope`.
 //! - **`encryption_migrate_settings`** — read `settings.json` v0,
-//!   re-encrypt as v2, atomic-swap, archive the original to
-//!   `settings.json.v0.bak`.
+//!   re-encrypt as v2, then remove the plaintext `settings.json`.
 //!
 //! The file-IO portions of the unlock / setup flows accept a
 //! `tauri::AppHandle` so they can resolve `app_data_dir`; pure tests
@@ -119,7 +118,7 @@ impl From<&LockoutState> for LockoutSnapshot {
 pub struct MigrationReport {
     pub source_path: String,
     pub destination_path: String,
-    pub backup_path: String,
+    pub backup_path: Option<String>,
     pub bytes_in: usize,
     pub bytes_out: usize,
     pub master_key_storage: MasterKeyStorage,
@@ -456,9 +455,9 @@ pub async fn encryption_change_password(
 }
 
 /// Migrate `settings.json` (v0 plaintext) → `settings.enc` (v2
-/// envelope). Requires the state to be unlocked. On success archives
-/// the original at `settings.json.v0.bak` so the user has a one-step
-/// rollback for the rest of the release cycle.
+/// envelope). Requires the state to be unlocked. On success removes
+/// the original plaintext `settings.json` so secrets do not remain
+/// available outside the encrypted envelope.
 #[tauri::command]
 pub async fn encryption_migrate_settings(
     app: AppHandle,
@@ -470,8 +469,6 @@ pub async fn encryption_migrate_settings(
     let dir = ensure_app_data_dir(&app)?;
     let source = dir.join(SETTINGS_JSON_FILENAME);
     let destination = dir.join(artifact_settings::SETTINGS_ENC_FILENAME);
-    let backup = dir.join(artifact_settings::SETTINGS_BACKUP_FILENAME);
-
     let raw = std::fs::read(&source).map_err(|e| format!("read settings.json: {e}"))?;
     let bytes_in = raw.len();
 
@@ -505,9 +502,10 @@ pub async fn encryption_migrate_settings(
     let bytes_out = blob.len();
 
     atomic_write(&destination, &blob)?;
-    // Archive the original last — if the rename above fails we don't
-    // want a missing original.
-    std::fs::rename(&source, &backup).map_err(|e| format!("archive backup: {e}"))?;
+    // Remove the original only after the encrypted envelope has been
+    // durably written. Keeping a plaintext rollback copy would defeat
+    // the encryption-at-rest guarantee exposed in Settings.
+    std::fs::remove_file(&source).map_err(|e| format!("remove plaintext settings.json: {e}"))?;
 
     let _ = audit::record(
         &dir,
@@ -526,7 +524,7 @@ pub async fn encryption_migrate_settings(
     Ok(MigrationReport {
         source_path: source.to_string_lossy().into_owned(),
         destination_path: destination.to_string_lossy().into_owned(),
-        backup_path: backup.to_string_lossy().into_owned(),
+        backup_path: None,
         bytes_in,
         bytes_out,
         master_key_storage: mode,
@@ -914,7 +912,7 @@ mod tests {
         let r = MigrationReport {
             source_path: "a".into(),
             destination_path: "b".into(),
-            backup_path: "c".into(),
+            backup_path: None,
             bytes_in: 1,
             bytes_out: 2,
             master_key_storage: MasterKeyStorage::Vault,

--- a/src-tauri/src/app_settings_commands.rs
+++ b/src-tauri/src/app_settings_commands.rs
@@ -115,9 +115,8 @@ pub async fn read_app_settings(
 ///
 /// - When [`EncryptionState`] is unlocked, the merged blob lands in
 ///   `settings.enc` (v2 envelope). Any pre-existing plaintext file is
-///   left untouched as a one-release rollback safety net; the post-
-///   migration commit renames it to `.v0.bak`, so callers won't see a
-///   stale file in normal operation.
+///   removed after the encrypted write succeeds so secrets do not
+///   remain available outside the envelope.
 /// - When locked, the merge writes plaintext `settings.json` — this
 ///   keeps the boot flow that loads window geometry before unlock
 ///   working unchanged. Sensitive keys are still in the user's hands
@@ -287,8 +286,9 @@ pub async fn write_app_settings_inner(
         .await
         .map_err(|e| format!("encode settings.enc: {e}"))?;
         atomic_write(&enc_path, &blob)?;
-        if plain_path.exists() && plain_path != dir.join("settings.json.v0.bak") {
-            let _ = std::fs::remove_file(&plain_path);
+        if plain_path.exists() {
+            std::fs::remove_file(&plain_path)
+                .map_err(|e| format!("remove plaintext settings.json: {e}"))?;
         }
         Ok(())
     } else {

--- a/src/components/SettingsDialog/sections/security/EncryptionAtRestSection.tsx
+++ b/src/components/SettingsDialog/sections/security/EncryptionAtRestSection.tsx
@@ -661,11 +661,8 @@ const EncryptionAtRestSection: React.FC = () => {
               A legacy <code>settings.json</code> was found alongside
               the new format. Running the migration encrypts it as
               <code>settings.enc</code> using the current master key,
-              archives the original as
-              <code>settings.json.v0.bak</code>, and updates the boot
-              path to read from the encrypted file going forward. The
-              backup stays on disk for one release cycle as a
-              rollback safety net.
+              removes the original plaintext file, and updates the boot
+              path to read from the encrypted file going forward.
             </p>
 
             {migrateError && (
@@ -694,10 +691,8 @@ const EncryptionAtRestSection: React.FC = () => {
                   <span className="text-[var(--color-text)]">
                     {describeStorage(migrateReport.masterKeyStorage)}
                   </span>
-                  <span>Backup path</span>
-                  <span className="text-[var(--color-text)] font-mono truncate">
-                    {migrateReport.backupPath}
-                  </span>
+                  <span>Plaintext source</span>
+                  <span className="text-[var(--color-text)]">Removed after encryption</span>
                 </div>
               </div>
             )}

--- a/src/types/encryption/encryption.ts
+++ b/src/types/encryption/encryption.ts
@@ -63,7 +63,7 @@ export interface EncryptionStatus {
 export interface MigrationReport {
   sourcePath: string;
   destinationPath: string;
-  backupPath: string;
+  backupPath: string | null;
   bytesIn: number;
   bytesOut: number;
   masterKeyStorage: MasterKeyStorage;

--- a/tests/settings/useEncryption.test.ts
+++ b/tests/settings/useEncryption.test.ts
@@ -55,7 +55,7 @@ const setupStatus: EncryptionStatus = {
 const migrationReport: MigrationReport = {
   sourcePath: "/x/settings.json",
   destinationPath: "/x/settings.enc",
-  backupPath: "/x/settings.json.v0.bak",
+  backupPath: null,
   bytesIn: 1024,
   bytesOut: 1124,
   masterKeyStorage: "vault",


### PR DESCRIPTION
### Motivation
- Prevent an encryption-at-rest bypass where `encryption_migrate_settings` left a plaintext backup and the normal settings writer could recreate plaintext `settings.json`, exposing secrets after migration.
- Align the UI, DTOs, and tests with the invariant that once migration succeeds the plaintext source is removed.

### Description
- `encryption_migrate_settings` now deletes `settings.json` after successfully writing `settings.enc` instead of renaming it to a plaintext backup, and its `MigrationReport.backup_path` is now `Option<String>` (mapped to `backupPath: string | null` on the frontend).
- Removed the obsolete `settings.json.v0.bak` artifact constant and docs from the settings artifact module.
- `write_app_settings` / `write_app_settings_inner` now removes any plaintext `settings.json` after a successful encrypted write so plaintext cannot linger or be resurrected.
- Updated the Settings → Security UI to indicate the plaintext source is removed after migration and replaced the displayed `backupPath` with a fixed "Removed after encryption" message.
- Updated TypeScript DTO (`src/types/encryption/encryption.ts`) and the `useEncryption` test fixture (`tests/settings/useEncryption.test.ts`) to accept `backupPath: null` and adjusted the migration serialization test in Rust accordingly.

### Testing
- Ran the frontend unit tests: `npx vitest run tests/settings/useEncryption.test.ts`, which passed (31/31 tests in that file).
- Ran `cargo test --manifest-path src-tauri/Cargo.toml -p sorng-encryption migration_report_serializes_camel_case`, which could not complete in the container due to a missing system dependency (`glib-2.0` pkg-config) and so was blocked; the Rust unit asserting camelCase serialization was updated to reflect `backup_path: None`.
- Ran TypeScript typecheck `npx tsc --noEmit`, which failed due to a pre-existing, unrelated TypeScript error in `src/hooks/protocol/useWebBrowser.ts` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd85335408325b2673ee70e6af181)