### PR TITLE
fix(mail): terminate ssh options for mail clients

### DIFF
--- a/src-tauri/crates/sorng-amavis/src/client.rs
+++ b/src-tauri/crates/sorng-amavis/src/client.rs
@@ -58,8 +58,10 @@ impl AmavisClient {
             ssh_args.push("BatchMode=yes".to_string());
         }
 
-        let target = format!("{}@{}", ssh_user, self.config.host);
-        ssh_args.push(target);
+        ssh_args.push("-l".to_string());
+        ssh_args.push(ssh_user.to_string());
+        ssh_args.push("--".to_string());
+        ssh_args.push(self.config.host.clone());
         ssh_args.push(command.to_string());
 
         let use_sshpass = self.config.password.is_some() && self.config.private_key.is_none();

--- a/src-tauri/crates/sorng-cyrus-sasl/src/client.rs
+++ b/src-tauri/crates/sorng-cyrus-sasl/src/client.rs
@@ -74,8 +74,10 @@ impl CyrusSaslClient {
             ssh_args.push("BatchMode=yes".to_string());
         }
 
-        let target = format!("{}@{}", ssh_user, self.config.host);
-        ssh_args.push(target);
+        ssh_args.push("-l".to_string());
+        ssh_args.push(ssh_user.to_string());
+        ssh_args.push("--".to_string());
+        ssh_args.push(self.config.host.clone());
         ssh_args.push(command.to_string());
 
         let use_sshpass = self.config.ssh_password.is_some() && self.config.ssh_key.is_none();

--- a/src-tauri/crates/sorng-dovecot/src/client.rs
+++ b/src-tauri/crates/sorng-dovecot/src/client.rs
@@ -75,8 +75,10 @@ impl DovecotClient {
             ssh_args.push("BatchMode=yes".to_string());
         }
 
-        let target = format!("{}@{}", ssh_user, self.config.host);
-        ssh_args.push(target);
+        ssh_args.push("-l".to_string());
+        ssh_args.push(ssh_user.to_string());
+        ssh_args.push("--".to_string());
+        ssh_args.push(self.config.host.clone());
         ssh_args.push(command.to_string());
 
         let use_sshpass = self.config.ssh_password.is_some() && self.config.ssh_key.is_none();

--- a/src-tauri/crates/sorng-postfix/src/client.rs
+++ b/src-tauri/crates/sorng-postfix/src/client.rs
@@ -67,8 +67,10 @@ impl PostfixClient {
             ssh_args.push("BatchMode=yes".to_string());
         }
 
-        let target = format!("{}@{}", ssh_user, self.config.host);
-        ssh_args.push(target);
+        ssh_args.push("-l".to_string());
+        ssh_args.push(ssh_user.to_string());
+        ssh_args.push("--".to_string());
+        ssh_args.push(self.config.host.clone());
         ssh_args.push(command.to_string());
 
         let use_sshpass = self.config.ssh_password.is_some() && self.config.ssh_key.is_none();


### PR DESCRIPTION
### Motivation

- The Mail sub-tabs expose SSH-backed clients that previously constructed positional `user@host` destinations, allowing an attacker-controlled username beginning with `-` to be parsed as an OpenSSH option (e.g. `-oProxyCommand=...`) and cause local command execution. 

### Description

- Replace the positional destination `format!("{}@{}", ssh_user, host)` with explicit SSH arguments `-l <user> -- <host>` to terminate option parsing in the Postfix, Dovecot, Amavis, and Cyrus SASL clients. 
- Changes applied to `src-tauri/crates/sorng-postfix/src/client.rs`, `src-tauri/crates/sorng-dovecot/src/client.rs`, `src-tauri/crates/sorng-amavis/src/client.rs`, and `src-tauri/crates/sorng-cyrus-sasl/src/client.rs`. 
- This ensures attacker-controlled data is passed after the OpenSSH `--` terminator so it cannot be interpreted as ssh options. 

### Testing

- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --package sorng-postfix --package sorng-dovecot --package sorng-amavis --package sorng-cyrus-sasl` and it completed successfully. 
- Ran `cargo check --manifest-path src-tauri/Cargo.toml -p sorng-postfix -p sorng-dovecot -p sorng-amavis -p sorng-cyrus-sasl` and the packages type-checked successfully. 
- Ran `git diff --check` and no whitespace or diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5420c7ef78832581a663c81cde1d0f)