### PR TITLE
fix(mail): require known SSH host keys

### DIFF
--- a/src-tauri/crates/sorng-clamav/src/client.rs
+++ b/src-tauri/crates/sorng-clamav/src/client.rs
@@ -90,7 +90,7 @@ impl ClamavClient {
 
         let mut ssh_args = vec![
             "-o".to_string(),
-            "StrictHostKeyChecking=accept-new".to_string(),
+            "StrictHostKeyChecking=yes".to_string(),
             "-o".to_string(),
             format!("ConnectTimeout={}", timeout),
             "-p".to_string(),

--- a/src-tauri/crates/sorng-procmail/src/client.rs
+++ b/src-tauri/crates/sorng-procmail/src/client.rs
@@ -58,7 +58,7 @@ impl ProcmailClient {
 
         let mut ssh_args = vec![
             "-o".to_string(),
-            "StrictHostKeyChecking=accept-new".to_string(),
+            "StrictHostKeyChecking=yes".to_string(),
             "-o".to_string(),
             format!("ConnectTimeout={}", timeout),
             "-p".to_string(),


### PR DESCRIPTION
### Motivation
- Prevent first-use (TOFU) SSH host-key acceptance in the Procmail and ClamAV clients to avoid silent host-key acceptance that enables MITM capture of user-supplied SSH passwords.

### Description
- Replace `StrictHostKeyChecking=accept-new` with `StrictHostKeyChecking=yes` in the `exec_ssh` implementations for Procmail and ClamAV (`src-tauri/crates/sorng-procmail/src/client.rs` and `src-tauri/crates/sorng-clamav/src/client.rs`) so connections require known/trusted host keys before password authentication proceeds.

### Testing
- Ran `cargo test -p sorng-procmail -p sorng-clamav` and both crates built and their test suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5420d7d8ec8325aeedb033852acbdd)