### PR TITLE
fix(clamav): fail closed on unknown SSH host keys

### DIFF
--- a/src-tauri/crates/sorng-clamav/src/client.rs
+++ b/src-tauri/crates/sorng-clamav/src/client.rs
@@ -9,6 +9,8 @@ use log::debug;
 use reqwest::Client as HttpClient;
 use std::time::Duration;
 
+const SSH_STRICT_HOST_KEY_CHECKING: &str = "StrictHostKeyChecking=yes";
+
 /// ClamAV management client – connects via SSH to manage ClamAV remotely.
 pub struct ClamavClient {
     pub config: ClamavConnectionConfig,
@@ -90,7 +92,7 @@ impl ClamavClient {
 
         let mut ssh_args = vec![
             "-o".to_string(),
-            "StrictHostKeyChecking=accept-new".to_string(),
+            SSH_STRICT_HOST_KEY_CHECKING.to_string(),
             "-o".to_string(),
             format!("ConnectTimeout={}", timeout),
             "-p".to_string(),
@@ -210,4 +212,15 @@ impl ClamavClient {
 
 pub fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SSH_STRICT_HOST_KEY_CHECKING;
+
+    #[test]
+    fn ssh_host_key_checking_fails_closed_for_unknown_hosts() {
+        assert_eq!(SSH_STRICT_HOST_KEY_CHECKING, "StrictHostKeyChecking=yes");
+        assert!(!SSH_STRICT_HOST_KEY_CHECKING.ends_with("accept-new"));
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent ClamAV SSH client from silently trusting unknown host keys to avoid first‑connect MITM disclosure of SSH credentials. 

### Description
- Replace the previous `StrictHostKeyChecking=accept-new` behaviour with a constant `SSH_STRICT_HOST_KEY_CHECKING = "StrictHostKeyChecking=yes"` and use it when building SSH arguments in `src-tauri/crates/sorng-clamav/src/client.rs`.
- Keep existing credential handling and command execution paths unchanged so functionality is preserved while tightening host‑key verification.
- Add a focused unit test that asserts the host‑key option is set to the fail‑closed value and does not end with `accept-new` to prevent regressions.

### Testing
- Ran `cargo fmt -p sorng-clamav --check` which succeeded.
- Ran `cargo test -p sorng-clamav ssh_host_key_checking_fails_closed_for_unknown_hosts` which passed (1 test, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a542305d5388325aecb14835ca632bd)