### PR TITLE
Strip behavior automation from JSON imports

### DIFF
--- a/src/components/ImportExport/utils.ts
+++ b/src/components/ImportExport/utils.ts
@@ -1841,8 +1841,10 @@ export const importFromJSON = async (
       const protocol = (conn.protocol?.toLowerCase() ||
         "rdp") as Connection["protocol"];
 
+      const { behaviorAutomation: _behaviorAutomation, ...safeConn } = conn;
+
       return {
-        ...conn,
+        ...safeConn,
         protocol,
         id: conn.id || generateId(),
         name: conn.name || "Imported Connection",
@@ -1874,8 +1876,10 @@ export const importFromJSON = async (
         const protocol = (conn.protocol?.toLowerCase() ||
           "rdp") as Connection["protocol"];
 
+        const { behaviorAutomation: _behaviorAutomation, ...safeConn } = conn;
+
         return {
-          ...conn,
+          ...safeConn,
           protocol,
           id: conn.id || generateId(),
           name: conn.name || "Imported Connection",

--- a/tests/importExport/ImportVendors.test.ts
+++ b/tests/importExport/ImportVendors.test.ts
@@ -1116,6 +1116,70 @@ describe('importFromJSON', () => {
     expect(conns[0].id).toBeTruthy();
   });
 
+  it('drops behavior automation from direct-array JSON imports', async () => {
+    const conns = await importFromJSON(
+      JSON.stringify([
+        {
+          name: 'Automated Host',
+          protocol: 'ssh',
+          hostname: 'auto.example.com',
+          behaviorAutomation: {
+            version: 1,
+            rules: [
+              {
+                id: 'hidden-rule',
+                name: 'Hidden Rule',
+                enabled: true,
+                events: ['session.started'],
+                actions: [
+                  { type: 'runCustomScript', scriptId: 'script-1' },
+                ],
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(conns).toHaveLength(1);
+    expect(conns[0].behaviorAutomation).toBeUndefined();
+  });
+
+  it('drops behavior automation from native database package JSON imports', async () => {
+    const conns = await importFromJSON(
+      JSON.stringify({
+        databases: [
+          {
+            connections: [
+              {
+                name: 'Packaged Automated Host',
+                protocol: 'ssh',
+                hostname: 'package.example.com',
+                behaviorAutomation: {
+                  version: 1,
+                  rules: [
+                    {
+                      id: 'hidden-package-rule',
+                      name: 'Hidden Package Rule',
+                      enabled: true,
+                      events: ['session.started'],
+                      actions: [
+                        { type: 'runCustomScript', scriptId: 'script-1' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(conns).toHaveLength(1);
+    expect(conns[0].behaviorAutomation).toBeUndefined();
+  });
+
   it('throws for unsupported JSON object shapes', async () => {
     await expect(importFromJSON(JSON.stringify({ invalid: true }))).rejects.toThrow(
       'Invalid JSON format: expected array or object with connections array',


### PR DESCRIPTION
### Motivation

- Prevent hidden per-connection automation rules from being preserved during JSON import and later executed via lifecycle hooks, which can run saved scripts without a trust prompt.

### Description

- Remove `behaviorAutomation` from imported connection objects by destructuring it out before spreading imported fields in the generic array JSON import path in `src/components/ImportExport/utils.ts`.
- Apply the same `behaviorAutomation` stripping to the native multi-database package JSON import path in `src/components/ImportExport/utils.ts`.
- Add regression tests in `tests/importExport/ImportVendors.test.ts` that assert `behaviorAutomation` is dropped for both direct-array JSON imports and native package imports.

### Testing

- Ran the import vendor unit tests with `npm test -- tests/importExport/ImportVendors.test.ts`, and the test file passed (Test Files 1 passed, Tests 101 passed). 
- Ran linter with `npx eslint src/components/ImportExport/utils.ts tests/importExport/ImportVendors.test.ts` and no blocking errors were reported. 
- Performed a check for obvious diff issues with `git diff --check` and no problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57be675b508325a158eb6a79be5a14)