### PR TITLE
Require HTTPS for WSMan authentication

### DIFF
--- a/src-tauri/crates/sorng-powershell/src/psrp_wsman.rs
+++ b/src-tauri/crates/sorng-powershell/src/psrp_wsman.rs
@@ -257,14 +257,10 @@ fn validate_auth_and_trust(config: &PsRemotingConfig) -> Result<SupportedAuth, P
         ));
     }
     match config.auth_method {
-        PsAuthMethod::Basic => {
-            if !config.uses_tls() {
-                return Err(protocol(
-                    "Basic authentication is rejected over HTTP; use HTTPS with Trust Center verification",
-                ));
-            }
-            Ok(SupportedAuth::Basic)
-        }
+        PsAuthMethod::Basic | PsAuthMethod::Ntlm if !config.uses_tls() => Err(protocol(
+            "WSMan authentication is rejected over HTTP; use HTTPS with Trust Center verification",
+        )),
+        PsAuthMethod::Basic => Ok(SupportedAuth::Basic),
         PsAuthMethod::Ntlm => Ok(SupportedAuth::Ntlm),
         PsAuthMethod::Negotiate | PsAuthMethod::Default => Err(protocol(
             "Negotiate is not claimed by the WSMan adapter; select NTLM explicitly",

--- a/src-tauri/crates/sorng-powershell/src/runspace_session/types.rs
+++ b/src-tauri/crates/sorng-powershell/src/runspace_session/types.rs
@@ -293,10 +293,11 @@ impl PowerShellWsmanSessionOptions {
             return Err(PowerShellSessionError::invalid("credential"));
         }
         match self.authentication {
-            PowerShellWsmanAuth::Basic if endpoint.scheme() != "https" => {
-                return Err(PowerShellSessionError::TransportSecurityRequired);
+            PowerShellWsmanAuth::Basic | PowerShellWsmanAuth::Ntlm => {
+                if endpoint.scheme() != "https" {
+                    return Err(PowerShellSessionError::TransportSecurityRequired);
+                }
             }
-            PowerShellWsmanAuth::Basic | PowerShellWsmanAuth::Ntlm => {}
             _ => return Err(PowerShellSessionError::AuthenticationUnsupported),
         }
         if self.tls_trust != PowerShellWsmanTrustPolicy::TrustCenter {

--- a/src-tauri/crates/sorng-powershell/tests/psrp_wsman.rs
+++ b/src-tauri/crates/sorng-powershell/tests/psrp_wsman.rs
@@ -688,12 +688,14 @@ fn canonical_endpoint_and_security_policy_fail_closed() {
         "http://server.example:5985/wsman"
     );
 
-    config.auth_method = PsAuthMethod::Basic;
-    let error = WsmanPsrpTransport::new(&config, test_limits())
-        .unwrap_err()
-        .to_string();
-    assert!(error.contains("Basic authentication is rejected over HTTP"));
-    assert!(!error.contains("do-not-log"));
+    for auth_method in [PsAuthMethod::Basic, PsAuthMethod::Ntlm] {
+        config.auth_method = auth_method;
+        let error = WsmanPsrpTransport::new(&config, test_limits())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("WSMan authentication is rejected over HTTP"));
+        assert!(!error.contains("do-not-log"));
+    }
 
     config.auth_method = PsAuthMethod::Ntlm;
     config.skip_ca_check = true;

--- a/src/components/connectionEditor/powerShellRemoting/AuthenticationSection.tsx
+++ b/src/components/connectionEditor/powerShellRemoting/AuthenticationSection.tsx
@@ -49,10 +49,8 @@ export function AuthenticationSection({
     value.transport === "ssh"
       ? (sshCapability?.status ?? "unsupported")
       : (selected?.status ?? "unsupported");
-  const basicOverHttp =
-    value.transport === "wsman" &&
-    value.wsman.scheme === "http" &&
-    value.wsman.authMethod === "basic";
+  const wsmanOverHttp =
+    value.transport === "wsman" && value.wsman.scheme === "http";
 
   return (
     <PowerShellEditorSection
@@ -92,8 +90,8 @@ export function AuthenticationSection({
           <FormField
             label="Authentication method"
             error={
-              basicOverHttp
-                ? "Basic authentication is blocked over HTTP. Select HTTPS first."
+              wsmanOverHttp
+                ? "WSMan authentication is blocked over HTTP. Select HTTPS first."
                 : undefined
             }
           >
@@ -226,10 +224,11 @@ export function AuthenticationSection({
         )}
       </div>
 
-      {basicOverHttp && (
+      {wsmanOverHttp && (
         <CapabilityNotice tone="error">
-          Basic authentication is blocked over HTTP because credentials would
-          not have transport confidentiality. Change the endpoint to HTTPS.
+          WSMan authentication is blocked over HTTP because NTLM and Basic
+          traffic require transport confidentiality. Change the endpoint to
+          HTTPS.
         </CapabilityNotice>
       )}
       {value.transport === "ssh" ? (

--- a/src/hooks/protocol/powerShellSessionRuntime.test.ts
+++ b/src/hooks/protocol/powerShellSessionRuntime.test.ts
@@ -117,7 +117,12 @@ describe("PowerShell live-session runtime", () => {
     settings.wsman.scheme = "http";
     settings.wsman.port = 5985;
     expect(() => buildPowerShellSessionOptions(connection(), settings)).toThrow(
-      /Basic authentication.*HTTPS/i,
+      /WSMan authentication.*HTTPS/i,
+    );
+
+    settings.wsman.authMethod = "ntlm";
+    expect(() => buildPowerShellSessionOptions(connection(), settings)).toThrow(
+      /WSMan authentication.*HTTPS/i,
     );
 
     settings.wsman.scheme = "https";

--- a/src/hooks/protocol/powerShellSessionRuntime.ts
+++ b/src/hooks/protocol/powerShellSessionRuntime.ts
@@ -251,9 +251,9 @@ export function buildPowerShellSessionOptions(
     }
     const endpoint = canonicalPowerShellEndpoint(settings, connection.hostname);
     const endpointScheme = new URL(endpoint).protocol.replace(/:$/, "");
-    if (settings.wsman.authMethod === "basic" && endpointScheme !== "https") {
+    if (endpointScheme !== "https") {
       throw new Error(
-        "Basic authentication is blocked unless the canonical WSMan endpoint uses HTTPS.",
+        "WSMan authentication is blocked unless the canonical endpoint uses HTTPS.",
       );
     }
     const username =

--- a/src/utils/powershell/normalizePowerShellRemoting.test.ts
+++ b/src/utils/powershell/normalizePowerShellRemoting.test.ts
@@ -83,7 +83,7 @@ describe("PowerShell Remoting settings schema", () => {
     expect(twice.warnings).toEqual([]);
   });
 
-  it("blocks Basic authentication over HTTP", () => {
+  it("blocks WSMan authentication over HTTP", () => {
     const settings = createDefaultPowerShellRemotingSettings();
     settings.wsman.scheme = "http";
     settings.wsman.port = 5985;

--- a/src/utils/powershell/normalizePowerShellRemoting.ts
+++ b/src/utils/powershell/normalizePowerShellRemoting.ts
@@ -604,16 +604,12 @@ export function validatePowerShellRemotingSettings(
       message: "The SSH port must be between 1 and 65535.",
     });
   }
-  if (
-    settings.transport === "wsman" &&
-    settings.wsman.authMethod === "basic" &&
-    settings.wsman.scheme === "http"
-  ) {
+  if (settings.transport === "wsman" && settings.wsman.scheme === "http") {
     add({
       path: "wsman.authMethod",
       code: "basicRequiresTls",
       severity: "error",
-      message: "Basic authentication is blocked over HTTP. Select HTTPS first.",
+      message: "WSMan authentication is blocked over HTTP. Select HTTPS first.",
     });
   }
   if (


### PR DESCRIPTION
### Motivation

- Address a security regression that allowed NTLM-based WSMan (PowerShell Remoting) sessions to be initiated over plain HTTP, exposing SOAP/PSRP payloads and NTLM challenge/response material to on-path attackers.
- Fail closed so that any WSMan live session requires transport confidentiality to avoid leaking remote shell traffic or credentials.

### Description

- Backend validation: require HTTPS for WSMan sessions by treating `Basic` and `Ntlm` as disallowed when the endpoint is non-HTTPS in `src-tauri/crates/sorng-powershell/src/runspace_session/types.rs` (session options validation) and `src-tauri/crates/sorng-powershell/src/psrp_wsman.rs` (`validate_auth_and_trust`).
- Frontend runtime: fail session construction for any canonical WSMan endpoint that is not `https` in `src/hooks/protocol/powerShellSessionRuntime.ts` so live-session creation is closed for non-TLS endpoints.
- Settings validation and UI: update settings validation and editor UI messaging to block WSMan over HTTP regardless of chosen auth method by changing `src/utils/powershell/normalizePowerShellRemoting.ts` and `src/components/connectionEditor/powerShellRemoting/AuthenticationSection.tsx`.
- Tests: extend/update unit tests to assert NTLM-over-HTTP is rejected in `src-tauri/crates/sorng-powershell/tests/psrp_wsman.rs` and update frontend tests in `src/hooks/protocol/powerShellSessionRuntime.test.ts` and `src/utils/powershell/normalizePowerShellRemoting.test.ts` to reflect the stricter policy.

### Testing

- Ran frontend unit tests with `npm run test -- src/hooks/protocol/powerShellSessionRuntime.test.ts src/utils/powershell/normalizePowerShellRemoting.test.ts`, and the two test files passed (all related assertions succeeded).
- Attempted `cargo test` for the backend `sorng-powershell` test `canonical_endpoint_and_security_policy_fail_closed`, but the run was blocked by a missing system dependency (`glib-2.0.pc`) required by `glib-sys`, so the Rust tests could not complete in this environment.
- Performed automated formatting with project tooling (`npm run format:write` and `cargo fmt`) and no formatting issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5810994c488325a5d8c37166caf8b1)