### PR TITLE
Enforce PowerShell SSH credential source to prevent secret leaks

### DIFF
--- a/src/hooks/protocol/powerShellSessionRuntime.test.ts
+++ b/src/hooks/protocol/powerShellSessionRuntime.test.ts
@@ -24,6 +24,7 @@ describe("PowerShell live-session runtime", () => {
   it("builds a strict pinned password payload without changing protocol identity", () => {
     const settings = createDefaultPowerShellRemotingSettings();
     settings.transport = "ssh";
+    settings.credential.source = "saved";
     settings.credential.username = "ps-admin";
     settings.ssh.authMethod = "password";
     settings.ssh.hostTrust = {
@@ -50,6 +51,7 @@ describe("PowerShell live-session runtime", () => {
   it("uses an explicit known_hosts file and fails closed for unavailable modes", () => {
     const settings = createDefaultPowerShellRemotingSettings();
     settings.transport = "ssh";
+    settings.credential.source = "saved";
     settings.ssh.authMethod = "privateKey";
     settings.ssh.privateKeyPath = "C:\\Keys\\id_ed25519";
     settings.ssh.hostTrust.mode = "strict";
@@ -78,6 +80,74 @@ describe("PowerShell live-session runtime", () => {
     expect(() =>
       buildPowerShellSshSessionOptions(connection(), settings),
     ).toThrow(/Trust-on-first-use is not available/i);
+  });
+
+  it("refuses to reuse connection passwords for prompt, vault, or explicit saved references", () => {
+    const settings = createDefaultPowerShellRemotingSettings();
+    settings.transport = "ssh";
+    settings.ssh.authMethod = "password";
+    settings.ssh.hostTrust = {
+      mode: "pinned",
+      fingerprint: "SHA256:abc123",
+    };
+
+    expect(() =>
+      buildPowerShellSshSessionOptions(connection(), settings),
+    ).toThrow(/must be prompted at connect time/i);
+
+    settings.credential.source = "vault";
+    settings.credential.vaultRef = { secretId: "vault/password" };
+    expect(() =>
+      buildPowerShellSshSessionOptions(connection(), settings),
+    ).toThrow(/selected vault reference/i);
+
+    settings.credential.source = "saved";
+    settings.credential.savedCredentialId = "ps-credential-record";
+    expect(() =>
+      buildPowerShellSshSessionOptions(connection(), settings),
+    ).toThrow(/selected saved credential/i);
+  });
+
+  it("refuses to ignore private-key credential references or leak prompt passphrases", () => {
+    const settings = createDefaultPowerShellRemotingSettings();
+    settings.transport = "ssh";
+    settings.ssh.authMethod = "privateKey";
+    settings.ssh.privateKeyPath = "C:\\Keys\\id_ed25519";
+    settings.ssh.hostTrust = {
+      mode: "pinned",
+      fingerprint: "SHA256:abc123",
+    };
+
+    expect(() =>
+      buildPowerShellSshSessionOptions(
+        { ...connection(), passphrase: "key-passphrase" },
+        settings,
+      ),
+    ).toThrow(/private-key passphrase must be prompted/i);
+
+    settings.ssh.privateKeyPath = null;
+    expect(() =>
+      buildPowerShellSshSessionOptions(
+        {
+          ...connection(),
+          privateKey: "C:\\Users\\operator\\.ssh\\id_ed25519",
+        },
+        settings,
+      ),
+    ).toThrow(/private key must be prompted/i);
+
+    settings.ssh.privateKeyPath = "C:\\Keys\\id_ed25519";
+    settings.credential.source = "saved";
+    settings.ssh.privateKeyCredentialRef = "key-record";
+    expect(() =>
+      buildPowerShellSshSessionOptions(
+        {
+          ...connection(),
+          privateKey: "C:\\Users\\operator\\.ssh\\id_ed25519",
+        },
+        settings,
+      ),
+    ).toThrow(/private-key credential reference/i);
   });
 
   it("deduplicates replay and rejects invalid sequence numbers", () => {

--- a/src/hooks/protocol/powerShellSessionRuntime.ts
+++ b/src/hooks/protocol/powerShellSessionRuntime.ts
@@ -145,6 +145,27 @@ export type PowerShellSshSessionOptions = {
 const secondsToMs = (value: number, fallback: number): number =>
   Math.max(1_000, Math.min(300_000, Math.round((value || fallback) * 1_000)));
 
+function assertConnectionSecretSource(
+  settings: PowerShellRemotingSettings,
+  secretDescription: string,
+): void {
+  if (settings.credential.source === "prompt") {
+    throw new Error(
+      `${secretDescription} must be prompted at connect time; refusing to reuse a saved connection secret.`,
+    );
+  }
+  if (settings.credential.source === "vault") {
+    throw new Error(
+      `${secretDescription} must be resolved from the selected vault reference; refusing to reuse a saved connection secret.`,
+    );
+  }
+  if (settings.credential.savedCredentialId) {
+    throw new Error(
+      `${secretDescription} must be resolved from the selected saved credential; refusing to reuse the connection-level secret.`,
+    );
+  }
+}
+
 /** Build the strict, secret-bearing invoke payload without retaining it. */
 export function buildPowerShellSshSessionOptions(
   connection: Connection,
@@ -162,6 +183,7 @@ export function buildPowerShellSshSessionOptions(
 
   let auth: PowerShellSshSessionOptions["auth"];
   if (settings.ssh.authMethod === "password") {
+    assertConnectionSecretSource(settings, "The PowerShell SSH password");
     if (!connection.password) {
       throw new Error(
         "A saved or prompted password is required for PowerShell SSH authentication.",
@@ -169,14 +191,30 @@ export function buildPowerShellSshSessionOptions(
     }
     auth = { type: "password", password: connection.password };
   } else if (settings.ssh.authMethod === "privateKey") {
-    const path = settings.ssh.privateKeyPath?.trim() || connection.privateKey;
+    if (settings.ssh.privateKeyCredentialRef) {
+      throw new Error(
+        "The PowerShell SSH private-key credential reference must be resolved at connect time; refusing to reuse the connection-level private key.",
+      );
+    }
+    let path = settings.ssh.privateKeyPath?.trim();
+    if (!path && connection.privateKey) {
+      assertConnectionSecretSource(settings, "The PowerShell SSH private key");
+      path = connection.privateKey;
+    }
     if (!path) {
       throw new Error("A private-key path is required for PowerShell SSH.");
+    }
+    const passphrase = connection.passphrase || null;
+    if (passphrase) {
+      assertConnectionSecretSource(
+        settings,
+        "The PowerShell SSH private-key passphrase",
+      );
     }
     auth = {
       type: "private_key",
       path,
-      passphrase: connection.passphrase || null,
+      passphrase,
     };
   } else {
     throw new Error(


### PR DESCRIPTION
### Motivation
- The live PowerShell SSH session builder was using connection-level `password`, `privateKey`, and `passphrase` regardless of the selected PowerShell credential source, which could leak saved secrets when `credential.source` is `prompt`/`vault` or when a credential/vault reference was selected.
- The UI documents that secret values are resolved at connect time and that saved/vault/prompt choices must be respected; the runtime must fail closed when those choices would be bypassed.

### Description
- Add an `assertConnectionSecretSource` helper that rejects reuse of connection-level secrets when `settings.credential.source` is `prompt` or `vault` or when an explicit saved credential record is selected. (`src/hooks/protocol/powerShellSessionRuntime.ts`)
- Enforce the helper for SSH password auth so the runtime throws instead of sending `connection.password` when the credential source requires resolution at connect time. (`buildPowerShellSshSessionOptions`)
- Harden private-key handling by rejecting `privateKeyCredentialRef` being ignored, refusing to reuse `connection.privateKey` unless the selected source allows it, and refusing to reuse `connection.passphrase` when the credential source requires on-connect resolution. (`buildPowerShellSshSessionOptions`)
- Add regression tests covering password prompt/vault/saved-reference refusal and private-key reference/passphrase leakage prevention, and adjust existing tests to exercise the saved-source success path. (`src/hooks/protocol/powerShellSessionRuntime.test.ts`)

### Testing
- Ran formatting on the changed files with `npm run format:write -- src/hooks/protocol/powerShellSessionRuntime.ts src/hooks/protocol/powerShellSessionRuntime.test.ts` which completed successfully. 
- Ran the unit tests with `npm test -- src/hooks/protocol/powerShellSessionRuntime.test.ts` and all tests passed (`Test Files 1 passed; Tests 5 passed`).
- Ran `npm run lint -- src/hooks/protocol/powerShellSessionRuntime.ts src/hooks/protocol/powerShellSessionRuntime.test.ts` which exited successfully with repository-wide warnings only (no new errors introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5802f22f048325814ea08219868f62)